### PR TITLE
 WIP: Support global scale change for SpringBoneCollider

### DIFF
--- a/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs
+++ b/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs
@@ -286,6 +286,9 @@ namespace VRM
             {
                 foreach (var group in ColliderGroups)
                 {
+                    var globalScale = Mathf.Max(Mathf.Max(group.transform.lossyScale.x,
+                                                          group.transform.lossyScale.y),
+                                                transform.lossyScale.z);                
                     if (group != null)
                     {
                         foreach (var collider in group.Colliders)
@@ -293,7 +296,7 @@ namespace VRM
                             m_colliderList.Add(new SphereCollider
                             {
                                 Position = group.transform.TransformPoint(collider.Offset),
-                                Radius = collider.Radius,
+                                Radius = collider.Radius * globalScale,
                             });
                         }
                     }

--- a/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBoneColliderGroup.cs
+++ b/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBoneColliderGroup.cs
@@ -35,9 +35,12 @@ namespace VRM
                 1.0f / transform.lossyScale.y,
                 1.0f / transform.lossyScale.z
                 ));
+            var globalScale = Mathf.Max(Mathf.Max(transform.lossyScale.x,
+                                                  transform.lossyScale.y),
+                                        transform.lossyScale.z);                
             foreach (var y in Colliders)
             {
-                Gizmos.DrawWireSphere(y.Offset, y.Radius);
+                Gizmos.DrawWireSphere(y.Offset, y.Radius * globalScale);
             }
         }
     }


### PR DESCRIPTION
すみません，issue立てたほうがよかったかもしれませんが，pull requestしてしまいます．

モデルのスケールを小さくしたときに，SpringBone用のColliderのサイズ（radius）が変わらず，
挙動がヘンになる問題の修正です．

ヘンになるとは例えば，顔あたりのColliderが大きいままで髪の毛がめくれ上がったようになる，などです．（詳細はhttp://mu-777.hatenablog.com/entry/2019/01/04/045618）

とりあえず，グローバルなスケールの最大値に合うようにSpringBone用のColliderのradiusを変更するような修正をプルリクさせていただきます．

VRMまだちゃんとはわかっていないので，もし「スケール１以外はサポートしない」「グローバルなスケールの最小値のほうがよい」などあれば，適当にrejectしてください．

よろしくお願いします．