### PR TITLE
Setup AppVeyor CI environment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,10 @@ environment:
   unity_serial:
     secure: cqmfJplindf90Uy/n53b58LNn5LVSxicPEXuFFBnnns=
   matrix:
-  - unity_version: 5.6.5f1
+  - unity_version: 5.6.7f1
     export_unitypackage: true
-  - unity_version: 2017.4.20f1
-  - unity_version: 2018.2.20f1
+  - unity_version: 2017.4.23f1
+  - unity_version: 2018.3.8f1
 
 init:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,54 @@
+image: Visual Studio 2017
+
+max_jobs: 1
+
+environment:
+  unity_username: dyob@lunaport.net
+  unity_password:
+    secure: bfiZ9ZLA6U2ue+6tpKwQ4ivRaePwVk/+RM7PoO7K6bQ=
+  unity_serial:
+    secure: cqmfJplindf90Uy/n53b58LNn5LVSxicPEXuFFBnnns=
+  matrix:
+  - unity_version: 5.6.5f1
+    export_unitypackage: true
+  - unity_version: 2017.4.20f1
+  - unity_version: 2018.2.20f1
+
+init:
+  - ps: |
+      Install-Module -Name UnitySetup -RequiredVersion 5.0.105
+      $unity_credential = New-Object Management.Automation.PSCredential ($env:unity_username, ($env:unity_password | ConvertTo-SecureString -AsPlainText -Force))
+
+install:
+  - ps: |
+      git submodule update --init --recursive
+      Install-UnitySetupInstance -Installers (Find-UnitySetupInstaller -Version $env:unity_version -Components 'Windows')
+      $unity = Start-UnityEditor -BatchMode -Latest -PassThru -Quit -Wait -LogFile License.log -Credential $unity_credential -Serial ($env:unity_serial | ConvertTo-SecureString -AsPlainText -Force)
+      type License.log
+      if ($unity.ExitCode) {
+        exit 1
+      }
+
+build_script:
+  - ps: |
+      if (!$env:export_unitypackage) {
+        echo Nothing to build
+        return
+      }
+      echo TODO: Export unitypackage
+
+test_script:
+  - ps: |
+      $unity = Start-UnityEditor -BatchMode -Latest -PassThru -Wait -LogFile Test.log -RunEditorTests
+      type Test.log
+      if ($unity.ExitCode) {
+        exit 1
+      }
+
+on_finish:
+  - ps: |
+      $unity = Start-UnityEditor -BatchMode -Latest -PassThru -Quit -Wait -LogFile ReturnLicense.Log -Credential $unity_credential -ReturnLicense
+      type ReturnLicense.Log
+      if ($unity.ExitCode) {
+        exit 1
+      }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,8 @@ test_script:
   - ps: |
       $unity = Start-UnityEditor -BatchMode -Latest -PassThru -Wait -LogFile Test.log -RunEditorTests
       type Test.log
+      $webclient = New-Object "System.Net.WebClient"
+      $webclient.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (dir TestResults-*.xml).FullName)
       if ($unity.ExitCode) {
         exit 1
       }


### PR DESCRIPTION
AppVeyorのCI設定になります。現在CIを選定、構築されている途中の状態だと思いますので、こちらの設定を参考にしていただけると幸いです。 CI画面はこちらになります →https://ci.appveyor.com/project/saturday06/univrm/builds/22436743
 もしこちらのPRのものを使っていただける場合、下記を注意お願いします。

- Unityのライセンスがこのような使い方をOKとしているか私は知らないので、そのあたりの確認をお願いします。
- 設定ファイルには私のアカウント情報が記述されていますので、appveyorの環境変数設定などで便宜置き換えてください。
- unitypackageファイルのエクスポート、デプロイは未実装です。
- ビルドタイムアウトが原因でライセンスの返却がうまく動かない可能性があるため、ビルド失敗の際に発生するwebhookを拾って手動で対応するなどの手順を作っておくと安心です。

fixes https://github.com/dwango/UniVRM/issues/108
