### PR TITLE
WIP: Add texture transform extensions

### DIFF
--- a/Assets/VRM/UniGLTF/Editor/Tests/MaterialTests.cs
+++ b/Assets/VRM/UniGLTF/Editor/Tests/MaterialTests.cs
@@ -6,6 +6,37 @@ namespace UniGLTF
 {
     public class MaterialTests
     {
+
+        [Test]
+        public void TextureTransformTest()
+        {
+            var tex0 = new Texture2D(128, 128)
+            {
+                wrapMode = TextureWrapMode.Repeat,
+                filterMode = FilterMode.Bilinear,
+            };
+
+            var textureManager = new TextureExportManager(new Texture[] { tex0 });
+            var srcMaterial = new Material(Shader.Find("Standard"));
+
+            var offset = new Vector2(0.3f, 0.2f);
+            var scale = new Vector2(0.5f, 0.6f);
+
+            srcMaterial.mainTexture = tex0;
+            srcMaterial.mainTextureOffset = offset;
+            srcMaterial.mainTextureScale = scale;
+
+            var materialExporter = new MaterialExporter();
+            var gltfMaterial = materialExporter.ExportMaterial(srcMaterial, textureManager);
+
+            var shaderStore = new ShaderStore(null);
+            var materialImporter = new MaterialImporter(shaderStore, null);
+            var dstMaterial = materialImporter.CreateMaterial(0, gltfMaterial);
+
+            Assert.AreEqual(dstMaterial.mainTextureOffset, offset);
+            Assert.AreEqual(dstMaterial.mainTextureScale, scale);
+        }
+
         [Test]
         public void UnlitShaderImportTest()
         {

--- a/Assets/VRM/UniGLTF/Editor/Tests/MaterialTests.cs
+++ b/Assets/VRM/UniGLTF/Editor/Tests/MaterialTests.cs
@@ -29,12 +29,15 @@ namespace UniGLTF
             var materialExporter = new MaterialExporter();
             var gltfMaterial = materialExporter.ExportMaterial(srcMaterial, textureManager);
 
-            var shaderStore = new ShaderStore(null);
-            var materialImporter = new MaterialImporter(shaderStore, null);
-            var dstMaterial = materialImporter.CreateMaterial(0, gltfMaterial);
+            // ToDo: Add ImportTest
+            //var shaderStore = new ShaderStore(null);
+            //var materialImporter = new MaterialImporter(shaderStore, null);
+            //var dstMaterial = materialImporter.CreateMaterial(0, gltfMaterial);
 
-            Assert.AreEqual(dstMaterial.mainTextureOffset, offset);
-            Assert.AreEqual(dstMaterial.mainTextureScale, scale);
+            Assert.AreEqual(gltfMaterial.pbrMetallicRoughness.baseColorTexture.extensions.KHR_texture_transform.offset,
+                new float[] { offset.x, offset.y });
+            Assert.AreEqual(gltfMaterial.pbrMetallicRoughness.baseColorTexture.extensions.KHR_texture_transform.scale,
+                new float[] { scale.x, scale.y });
         }
 
         [Test]

--- a/Assets/VRM/UniGLTF/Scripts/Format/ExtensionsAndExtras/KHR_texture_transform.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/ExtensionsAndExtras/KHR_texture_transform.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UniJSON;
+
+namespace UniGLTF
+{
+    [Serializable]
+    public class glTF_KHR_texture_transform : JsonSerializableBase
+    {
+        public static string ExtensionName
+        {
+            get
+            {
+                return "KHR_texture_transform";
+            }
+        }
+
+        [JsonSchema(MinItems = 2, MaxItems = 2)]
+        public float[] offset = new float[2] { 0.0f, 0.0f };
+
+        public float rotation;
+
+        [JsonSchema(MinItems = 2, MaxItems = 2)]
+        public float[] scale = new float[2] { 1.0f, 1.0f };
+
+        [ItemJsonSchema(Minimum = 0)]
+        public int texCoord;
+
+        protected override void SerializeMembers(GLTFJsonFormatter f)
+        {
+            f.KeyValue(() => offset);
+            f.KeyValue(() => rotation);
+            f.KeyValue(() => scale);
+            f.KeyValue(() => texCoord);
+        }
+    }
+
+    [Serializable]
+    public class glTFTextureInfo_extensions : ExtensionsBase<glTFTextureInfo_extensions>
+    {
+        [JsonSchema(Required = true)]
+        public glTF_KHR_texture_transform KHR_texture_transform;
+
+        [JsonSerializeMembers]
+        void SerializeMembers_unlit(GLTFJsonFormatter f)
+        {
+            if (KHR_texture_transform != null)
+            {
+                f.KeyValue(() => KHR_texture_transform);
+            }
+        }
+    }
+}

--- a/Assets/VRM/UniGLTF/Scripts/Format/ExtensionsAndExtras/KHR_texture_transform.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/ExtensionsAndExtras/KHR_texture_transform.cs
@@ -42,8 +42,12 @@ namespace UniGLTF
         [JsonSchema(Required = true)]
         public glTF_KHR_texture_transform KHR_texture_transform;
 
+        /// <summary>
+        /// リフレクションでシリアライズする時は使われない
+        /// </summary>
+        /// <param name="f"></param>
         [JsonSerializeMembers]
-        void SerializeMembers_unlit(GLTFJsonFormatter f)
+        void SerializeMembers_textureInfo(GLTFJsonFormatter f)
         {
             if (KHR_texture_transform != null)
             {

--- a/Assets/VRM/UniGLTF/Scripts/Format/ExtensionsAndExtras/KHR_texture_transform.cs.meta
+++ b/Assets/VRM/UniGLTF/Scripts/Format/ExtensionsAndExtras/KHR_texture_transform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04b631e1572e84d47b88aebc3631865b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM/UniGLTF/Scripts/Format/glTFMaterial.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTFMaterial.cs
@@ -28,13 +28,17 @@ namespace UniGLTF
         public int texCoord;
 
         // empty schemas
-        public object extensions;
+        public glTFTextureInfo_extensions extensions;
         public object extras;
 
         protected override void SerializeMembers(GLTFJsonFormatter f)
         {
             f.KeyValue(() => index);
             f.KeyValue(() => texCoord);
+            if (extensions != null)
+            {
+                f.KeyValue(() => extensions);
+            }
         }
 
         public abstract glTFTextureTypes TextreType { get; }

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
@@ -53,7 +53,7 @@ namespace UniGLTF
                         index = index,
                     };
 
-                    Export_TextureTransform(m, material.pbrMetallicRoughness.baseColorTexture, "_MainTex");
+                    Export_MainTextureTransform(m, material.pbrMetallicRoughness.baseColorTexture);
                 }
             }
         }
@@ -80,7 +80,7 @@ namespace UniGLTF
                             index = index,
                         };
 
-                    Export_TextureTransform(m, material.pbrMetallicRoughness.metallicRoughnessTexture, "_MetallicGlossMap");
+                    Export_MainTextureTransform(m, material.pbrMetallicRoughness.metallicRoughnessTexture);
                 }
             }
 
@@ -116,7 +116,7 @@ namespace UniGLTF
                         index = index,
                     };
 
-                    Export_TextureTransform(m, material.normalTexture, "_BumpMap");
+                    Export_MainTextureTransform(m, material.normalTexture);
                 }
 
                 if (index != -1 && m.HasProperty("_BumpScale"))
@@ -138,7 +138,7 @@ namespace UniGLTF
                         index = index,
                     };
 
-                    Export_TextureTransform(m, material.occlusionTexture, "_OcclusionMap");
+                    Export_MainTextureTransform(m, material.occlusionTexture);
                 }
 
                 if (index != -1 && m.HasProperty("_OcclusionStrength"))
@@ -173,9 +173,14 @@ namespace UniGLTF
                         index = index,
                     };
 
-                    Export_TextureTransform(m, material.emissiveTexture, "_EmissionMap");
+                    Export_MainTextureTransform(m, material.emissiveTexture);
                 }
             }
+        }
+
+        static void Export_MainTextureTransform(Material m, glTFTextureInfo textureInfo)
+        {
+            Export_TextureTransform(m, textureInfo, "_MainTex");
         }
 
         static void Export_TextureTransform(Material m, glTFTextureInfo textureInfo, string propertyName)

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
@@ -182,12 +182,16 @@ namespace UniGLTF
         {
             if( textureInfo != null && m.HasProperty(propertyName))
             {
+                var offset = m.GetTextureOffset(propertyName);
+                var scale = m.GetTextureScale(propertyName);
+                offset.y = (offset.y + scale.y - 1) * -1.0f;
+
                 textureInfo.extensions = new glTFTextureInfo_extensions
                 {
                     KHR_texture_transform = new glTF_KHR_texture_transform()
                     {
-                        offset = new float[] { m.GetTextureOffset(propertyName).x, m.GetTextureOffset(propertyName).y },
-                        scale = new float[] { m.GetTextureScale(propertyName).x, m.GetTextureScale(propertyName).y },
+                        offset = new float[] { offset.x, offset.y },
+                        scale = new float[] { scale.x, scale.y },
                     }
                 };
             }

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
@@ -52,6 +52,8 @@ namespace UniGLTF
                     {
                         index = index,
                     };
+
+                    Export_TextureTransform(m, material.pbrMetallicRoughness.baseColorTexture, "_MainTex");
                 }
             }
         }
@@ -77,6 +79,8 @@ namespace UniGLTF
                         {
                             index = index,
                         };
+
+                    Export_TextureTransform(m, material.pbrMetallicRoughness.metallicRoughnessTexture, "_MetallicGlossMap");
                 }
             }
 
@@ -111,6 +115,8 @@ namespace UniGLTF
                     {
                         index = index,
                     };
+
+                    Export_TextureTransform(m, material.normalTexture, "_BumpMap");
                 }
 
                 if (index != -1 && m.HasProperty("_BumpScale"))
@@ -131,6 +137,8 @@ namespace UniGLTF
                     {
                         index = index,
                     };
+
+                    Export_TextureTransform(m, material.occlusionTexture, "_OcclusionMap");
                 }
 
                 if (index != -1 && m.HasProperty("_OcclusionStrength"))
@@ -161,7 +169,24 @@ namespace UniGLTF
                     {
                         index = index,
                     };
+
+                    Export_TextureTransform(m, material.emissiveTexture, "_EmissionMap");
                 }
+            }
+        }
+
+        static void Export_TextureTransform(Material m, glTFTextureInfo textureInfo, string propertyName)
+        {
+            if( textureInfo != null && m.HasProperty(propertyName))
+            {
+                textureInfo.extensions = new glTFTextureInfo_extensions
+                {
+                    KHR_texture_transform = new glTF_KHR_texture_transform()
+                    {
+                        offset = new float[] { m.GetTextureOffset(propertyName).x, m.GetTextureOffset(propertyName).y },
+                        scale = new float[] { m.GetTextureScale(propertyName).x, m.GetTextureScale(propertyName).y },
+                    }
+                };
             }
         }
 

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
@@ -293,10 +293,16 @@ namespace UniGLTF
             if (textureInfo.extensions != null && textureInfo.extensions.KHR_texture_transform != null)
             {
                 var textureTransform = textureInfo.extensions.KHR_texture_transform;
-                material.SetTextureOffset( propertyName,
-                    new Vector2(textureTransform.offset[0], textureTransform.offset[1]));
-                material.SetTextureScale( propertyName,
-                    new Vector2(textureTransform.scale[0], textureTransform.scale[1]));
+                if (textureTransform.offset != null && textureTransform.offset.Length == 2)
+                {
+                    material.SetTextureOffset(propertyName,
+                        new Vector2(textureTransform.offset[0], textureTransform.offset[1]));
+                }
+                if (textureTransform.scale != null && textureTransform.scale.Length == 2)
+                {
+                    material.SetTextureScale(propertyName,
+                        new Vector2(textureTransform.scale[0], textureTransform.scale[1]));
+                }
             }
         }
     }

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
@@ -96,6 +96,9 @@ namespace UniGLTF
                     {
                         material.mainTexture = texture.Texture;
                     }
+
+                    // Texture Offset and Scale
+                    SetTextureOffsetAndScale(material, x.pbrMetallicRoughness.baseColorTexture, "_MainTex");
                 }
 
                 // color
@@ -155,6 +158,9 @@ namespace UniGLTF
                     {
                         material.mainTexture = texture.Texture;
                     }
+
+                    // Texture Offset and Scale
+                    SetTextureOffsetAndScale(material, x.pbrMetallicRoughness.baseColorTexture, "_MainTex");
                 }
 
                 if (x.pbrMetallicRoughness.metallicRoughnessTexture != null && x.pbrMetallicRoughness.metallicRoughnessTexture.index != -1)
@@ -171,6 +177,9 @@ namespace UniGLTF
                     material.SetFloat("_Metallic", 1.0f);
                     // Set 1.0f as hard-coded. See: https://github.com/dwango/UniVRM/issues/212.
                     material.SetFloat("_GlossMapScale", 1.0f);
+
+                    // Texture Offset and Scale
+                    SetTextureOffsetAndScale(material, x.pbrMetallicRoughness.metallicRoughnessTexture, "_MetallicGlossMap");
                 }
                 else
                 {
@@ -189,6 +198,9 @@ namespace UniGLTF
                     material.SetTexture(prop, texture.ConvertTexture(prop));
                     material.SetFloat("_BumpScale", x.normalTexture.scale);
                 }
+
+                // Texture Offset and Scale
+                SetTextureOffsetAndScale(material, x.normalTexture, "_BumpMap");
             }
 
             if (x.occlusionTexture != null && x.occlusionTexture.index != -1)
@@ -200,6 +212,9 @@ namespace UniGLTF
                     material.SetTexture(prop, texture.ConvertTexture(prop));
                     material.SetFloat("_OcclusionStrength", x.occlusionTexture.strength);
                 }
+
+                // Texture Offset and Scale
+                SetTextureOffsetAndScale(material, x.occlusionTexture, "_OcclusionMap");
             }
 
             if (x.emissiveFactor != null
@@ -220,6 +235,9 @@ namespace UniGLTF
                     {
                         material.SetTexture("_EmissionMap", texture.Texture);
                     }
+
+                    // Texture Offset and Scale
+                    SetTextureOffsetAndScale(material, x.emissiveTexture, "_EmissionMap");
                 }
             }
 
@@ -268,6 +286,18 @@ namespace UniGLTF
 
             material.SetFloat("_Mode", (float)blendMode);
             return material;
+        }
+
+        private static void SetTextureOffsetAndScale(Material material, glTFTextureInfo textureInfo, string propertyName)
+        {
+            if (textureInfo.extensions != null && textureInfo.extensions.KHR_texture_transform != null)
+            {
+                var textureTransform = textureInfo.extensions.KHR_texture_transform;
+                material.SetTextureOffset( propertyName,
+                    new Vector2(textureTransform.offset[0], textureTransform.offset[1]));
+                material.SetTextureScale( propertyName,
+                    new Vector2(textureTransform.scale[0], textureTransform.scale[1]));
+            }
         }
     }
 }

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
@@ -293,16 +293,21 @@ namespace UniGLTF
             if (textureInfo.extensions != null && textureInfo.extensions.KHR_texture_transform != null)
             {
                 var textureTransform = textureInfo.extensions.KHR_texture_transform;
+                Vector2 offset = new Vector2(0, 0);
+                Vector2 scale = new Vector2(1, 1);
                 if (textureTransform.offset != null && textureTransform.offset.Length == 2)
                 {
-                    material.SetTextureOffset(propertyName,
-                        new Vector2(textureTransform.offset[0], textureTransform.offset[1]));
+                    offset = new Vector2(textureTransform.offset[0], textureTransform.offset[1]);
                 }
                 if (textureTransform.scale != null && textureTransform.scale.Length == 2)
                 {
-                    material.SetTextureScale(propertyName,
-                        new Vector2(textureTransform.scale[0], textureTransform.scale[1]));
+                    scale = new Vector2(textureTransform.scale[0], textureTransform.scale[1]);
                 }
+
+                offset.y = (offset.y + scale.y - 1.0f) * -1.0f;
+
+                material.SetTextureOffset(propertyName, offset);
+                material.SetTextureScale(propertyName, scale);
             }
         }
     }

--- a/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
@@ -99,6 +99,7 @@ namespace UniGLTF
             get
             {
                 yield return glTF_KHR_materials_unlit.ExtensionName;
+                yield return glTF_KHR_texture_transform.ExtensionName;
             }
         }
 


### PR DESCRIPTION
### このプルリクについて
* textureInfoの拡張であるKHR_texture_transformの対応
* https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_texture_transform
* #216 

### このプルリクで出来るようになること
* UnityのStanderd、UniUnlitShaderで指定したTiling,Scaleの値がエクスポート可能になる