### PR TITLE
Fix typo (local variables)

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/Extensions/UnityExtensions.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Extensions/UnityExtensions.cs
@@ -189,9 +189,9 @@ namespace UniGLTF
         {
             var current = self;
 
-            var splited = path.Split('/');
+            var split = path.Split('/');
 
-            foreach (var childName in splited)
+            foreach (var childName in split)
             {
                 current = current.GetChildByName(childName);
             }

--- a/Assets/VRM/UniGLTF/Scripts/IO/AnimationExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/AnimationExporter.cs
@@ -123,7 +123,7 @@ namespace UniGLTF
             };
 
 #if UNITY_5_6_OR_NEWER
-            List<AnimationCurveData> curveDatas = new List<AnimationCurveData>();
+            List<AnimationCurveData> curveDatum = new List<AnimationCurveData>();
 
             foreach (var binding in AnimationUtility.GetCurveBindings(clip))
             {
@@ -155,11 +155,11 @@ namespace UniGLTF
                 }
 
                 // 同一のsamplerIndexが割り当てられているcurveDataがある場合はそれを使用し、無ければ作る
-                    var curveData = curveDatas.FirstOrDefault(x => x.SamplerIndex == samplerIndex);
+                    var curveData = curveDatum.FirstOrDefault(x => x.SamplerIndex == samplerIndex);
                 if (curveData == null)
                 {
                     curveData = new AnimationCurveData(AnimationUtility.GetKeyRightTangentMode(curve, 0), property, samplerIndex, elementCount);
-                    curveDatas.Add(curveData);
+                    curveDatum.Add(curveData);
                 }
 
                 // 全てのキーフレームを回収
@@ -187,7 +187,7 @@ namespace UniGLTF
             }
 
             //キー挿入
-            foreach (var curve in curveDatas)
+            foreach (var curve in curveDatum)
             {
                 if (curve.Keyframes.Count == 0)
                     continue;

--- a/Assets/VRM/UniGLTF/Scripts/IO/AnimationImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/AnimationImporter.cs
@@ -157,7 +157,7 @@ namespace UniGLTF
 
         public static List<AnimationClip> ImportAnimationClip(ImporterContext ctx)
         {
-            List<AnimationClip> animasionClips = new List<AnimationClip>();
+            List<AnimationClip> animationClips = new List<AnimationClip>();
             for (int i = 0; i < ctx.GLTF.animations.Count; ++i)
             {
                 var clip = new AnimationClip();
@@ -302,10 +302,10 @@ namespace UniGLTF
                             break;
                     }
                 }
-                animasionClips.Add(clip);
+                animationClips.Add(clip);
             }
 
-            return animasionClips;
+            return animationClips;
         }
 
         public static void ImportAnimation(ImporterContext ctx)

--- a/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
@@ -170,11 +170,11 @@ namespace UniGLTF
                     node.mesh = renderers.IndexOf(meshRenderer);
                 }
 
-                var skinnredMeshRenderer = x.GetComponent<SkinnedMeshRenderer>();
-                if (skinnredMeshRenderer != null)
+                var skinnedMeshRenderer = x.GetComponent<SkinnedMeshRenderer>();
+                if (skinnedMeshRenderer != null)
                 {
-                    node.mesh = renderers.IndexOf(skinnredMeshRenderer);
-                    node.skin = skins.IndexOf(skinnredMeshRenderer);
+                    node.mesh = renderers.IndexOf(skinnedMeshRenderer);
+                    node.skin = skins.IndexOf(skinnedMeshRenderer);
                 }
             }
 

--- a/Assets/VRM/UniHumanoid/Scripts/BoneMapping.cs
+++ b/Assets/VRM/UniHumanoid/Scripts/BoneMapping.cs
@@ -51,8 +51,8 @@ namespace UniHumanoid
                 return;
             }
 
-            var estimater = new BvhSkeletonEstimator();
-            var skeleton = estimater.Detect(hips.transform);
+            var estimator = new BvhSkeletonEstimator();
+            var skeleton = estimator.Detect(hips.transform);
             var bones = hips.transform.Traverse().ToArray();
             for (int i = 0; i < (int)HumanBodyBones.LastBone; ++i)
             {

--- a/Assets/VRM/UniHumanoid/Scripts/Format/Bvh.cs
+++ b/Assets/VRM/UniHumanoid/Scripts/Format/Bvh.cs
@@ -108,29 +108,29 @@ namespace UniHumanoid
 
         static Single3 ParseOffset(string line)
         {
-            var splited = line.Trim().Split();
-            if (splited[0] != "OFFSET")
+            var split = line.Trim().Split();
+            if (split[0] != "OFFSET")
             {
                 throw new BvhException("OFFSET is not found");
             }
 
-            var offset = splited.Skip(1).Where(x => !string.IsNullOrEmpty(x)).Select(x => float.Parse(x)).ToArray();
+            var offset = split.Skip(1).Where(x => !string.IsNullOrEmpty(x)).Select(x => float.Parse(x)).ToArray();
             return new Single3(offset[0], offset[1], offset[2]);
         }
 
         static Channel[] ParseChannel(string line)
         {
-            var splited = line.Trim().Split();
-            if (splited[0] != "CHANNELS")
+            var split = line.Trim().Split();
+            if (split[0] != "CHANNELS")
             {
                 throw new BvhException("CHANNELS is not found");
             }
-            var count = int.Parse(splited[1]);
-            if (count + 2 != splited.Length)
+            var count = int.Parse(split[1]);
+            if (count + 2 != split.Length)
             {
                 throw new BvhException("channel count is not match with splited count");
             }
-            return splited.Skip(2).Select(x => (Channel)Enum.Parse(typeof(Channel), x)).ToArray();
+            return split.Skip(2).Select(x => (Channel)Enum.Parse(typeof(Channel), x)).ToArray();
         }
 
         public IEnumerable<BvhNode> Traverse()
@@ -139,9 +139,9 @@ namespace UniHumanoid
 
             foreach (var child in Children)
             {
-                foreach (var descentant in child.Traverse())
+                foreach (var descendant in child.Traverse())
                 {
-                    yield return descentant;
+                    yield return descendant;
                 }
             }
         }
@@ -313,14 +313,14 @@ namespace UniHumanoid
 
         public void ParseFrame(int frame, string line)
         {
-            var splited = line.Trim().Split().Where(x => !string.IsNullOrEmpty(x)).ToArray();
-            if (splited.Length != Channels.Length)
+            var split = line.Trim().Split().Where(x => !string.IsNullOrEmpty(x)).ToArray();
+            if (split.Length != Channels.Length)
             {
                 throw new BvhException("frame key count is not match channel count");
             }
             for(int i=0; i<Channels.Length; ++i)
             {
-                Channels[i].SetKey(frame, float.Parse(splited[i]));
+                Channels[i].SetKey(frame, float.Parse(split[i]));
             }
         }
 
@@ -343,19 +343,19 @@ namespace UniHumanoid
                 var frameTime = 0.0f;
                 if (r.ReadLine() == "MOTION")
                 {
-                    var frameSplited = r.ReadLine().Split(':');
-                    if (frameSplited[0] != "Frames")
+                    var frameSplit = r.ReadLine().Split(':');
+                    if (frameSplit[0] != "Frames")
                     {
                         throw new BvhException("Frames is not found");
                     }
-                    frames = int.Parse(frameSplited[1]);
+                    frames = int.Parse(frameSplit[1]);
 
-                    var frameTimeSplited = r.ReadLine().Split(':');
-                    if (frameTimeSplited[0] != "Frame Time")
+                    var frameTimeSplit = r.ReadLine().Split(':');
+                    if (frameTimeSplit[0] != "Frame Time")
                     {
                         throw new BvhException("Frame Time is not found");
                     }
-                    frameTime = float.Parse(frameTimeSplited[1]);
+                    frameTime = float.Parse(frameTimeSplit[1]);
                 }
 
                 var bvh = new Bvh(root, frames, frameTime);
@@ -373,37 +373,37 @@ namespace UniHumanoid
         static BvhNode ParseNode(StringReader r, int level = 0)
         {
             var firstline = r.ReadLine().Trim();
-            var splited = firstline.Split();
-            if (splited.Length != 2)
+            var split = firstline.Split();
+            if (split.Length != 2)
             {
-                if (splited.Length == 1)
+                if (split.Length == 1)
                 {
-                    if(splited[0] == "}")
+                    if(split[0] == "}")
                     {
                         return null;
                     }
                 }
-                throw new BvhException(String.Format("splited to {0}({1})", splited.Length, firstline));
+                throw new BvhException(String.Format("splited to {0}({1})", split.Length, firstline));
             }
 
             BvhNode node = null;
-            if (splited[0] == "ROOT")
+            if (split[0] == "ROOT")
             {
                 if (level != 0)
                 {
                     throw new BvhException("nested ROOT");
                 }
-                node = new BvhNode(splited[1]);
+                node = new BvhNode(split[1]);
             }
-            else if (splited[0] == "JOINT")
+            else if (split[0] == "JOINT")
             {
                 if (level == 0)
                 {
                     throw new BvhException("should ROOT, but JOINT");
                 }
-                node = new BvhNode(splited[1]);
+                node = new BvhNode(split[1]);
             }
-            else if (splited[0] == "End")
+            else if (split[0] == "End")
             {
                 if (level == 0)
                 {
@@ -413,7 +413,7 @@ namespace UniHumanoid
             }
             else
             {
-                throw new BvhException("unknown type: " + splited[0]);
+                throw new BvhException("unknown type: " + split[0]);
             }
 
             if(r.ReadLine().Trim() != "{")

--- a/Assets/VRM/UniHumanoid/Scripts/Skeleton.cs
+++ b/Assets/VRM/UniHumanoid/Scripts/Skeleton.cs
@@ -53,8 +53,8 @@ namespace UniHumanoid
 
         public static Skeleton Estimate(Transform hips)
         {
-            var estimater = new BvhSkeletonEstimator();
-            return estimater.Detect(hips);
+            var estimator = new BvhSkeletonEstimator();
+            return estimator.Detect(hips);
         }
 
         /// <summary>

--- a/Assets/VRM/UniJSON/Scripts/Json/JsonPointer.cs
+++ b/Assets/VRM/UniJSON/Scripts/Json/JsonPointer.cs
@@ -58,8 +58,8 @@ namespace UniJSON
                 throw new ArgumentException();
             }
 
-            var splited = pointer.Split((Byte)'/').ToArray();
-            Path = new ArraySegment<Utf8String>(splited, 1, splited.Length - 1);
+            var split = pointer.Split((Byte)'/').ToArray();
+            Path = new ArraySegment<Utf8String>(split, 1, split.Length - 1);
         }
 
         public override string ToString()

--- a/Assets/VRM/UniJSON/Scripts/Utf8String/Utf8StringExtensions.cs
+++ b/Assets/VRM/UniJSON/Scripts/Utf8String/Utf8StringExtensions.cs
@@ -84,13 +84,13 @@ namespace UniJSON
             return false;
         }
 
-        public static IEnumerable<Utf8String> Split(this Utf8String src, byte delemeter)
+        public static IEnumerable<Utf8String> Split(this Utf8String src, byte delimiter)
         {
             var start = 0;
             var p = new Utf8Iterator(src.Bytes);
             while (p.MoveNext())
             {
-                if (p.Current == delemeter)
+                if (p.Current == delimiter)
                 {
                     if (p.BytePosition - start == 0)
                     {


### PR DESCRIPTION
ローカル変数のtypoを修正しました。splitは過去形や過去分詞形では `-ed` などの変化はせず、splitのままです。