### PR TITLE
Fix typo (private fields)

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/AnimationImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/AnimationImporter.cs
@@ -34,7 +34,7 @@ namespace UniGLTF
             }
         }
 
-        private static void CalculateTanget(List<Keyframe> keyframes, int current)
+        private static void CalculateTangent(List<Keyframe> keyframes, int current)
         {
             int back = current - 1;
             if (back < 0)
@@ -134,7 +134,7 @@ namespace UniGLTF
                             keyframes[i].Add(new Keyframe(time, reversed[i], 0, 0));
                             if (keyframes[i].Count > 0)
                             {
-                                CalculateTanget(keyframes[i], keyframes[i].Count - 1);
+                                CalculateTangent(keyframes[i], keyframes[i].Count - 1);
                             }
                         }
                         else if (tangentMode == TangentMode.Constant)

--- a/Assets/VRM/UniGLTF/Scripts/IO/ShaderStore.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/ShaderStore.cs
@@ -74,13 +74,13 @@ namespace UniGLTF
             }
         }
 
-        Shader m_unlitCoutout;
+        Shader m_unlitCutout;
         Shader UnlitCutout
         {
             get
             {
-                if (m_unlitCoutout == null) m_unlitCoutout = Shader.Find("Unlit/Transparent Cutout");
-                return m_unlitCoutout;
+                if (m_unlitCutout == null) m_unlitCutout = Shader.Find("Unlit/Transparent Cutout");
+                return m_unlitCutout;
             }
         }
 

--- a/Assets/VRM/UniHumanoid/Scripts/SkeletonMeshUtility.cs
+++ b/Assets/VRM/UniHumanoid/Scripts/SkeletonMeshUtility.cs
@@ -10,7 +10,7 @@ namespace UniHumanoid
     {
         class MeshBuilder
         {
-            List<Vector3> m_positioins = new List<Vector3>();
+            List<Vector3> m_positions = new List<Vector3>();
             List<int> m_indices = new List<int>();
             List<BoneWeight> m_boneWeights = new List<BoneWeight>();
 
@@ -78,11 +78,11 @@ namespace UniHumanoid
 
             void AddQuad(Vector3 v0, Vector3 v1, Vector3 v2, Vector3 v3, int boneIndex, bool reverse=false)
             {
-                var i = m_positioins.Count;
-                m_positioins.Add(v0);
-                m_positioins.Add(v1);
-                m_positioins.Add(v2);
-                m_positioins.Add(v3);
+                var i = m_positions.Count;
+                m_positions.Add(v0);
+                m_positions.Add(v1);
+                m_positions.Add(v2);
+                m_positions.Add(v3);
 
                 var bw = new BoneWeight
                 {
@@ -119,7 +119,7 @@ namespace UniHumanoid
             public Mesh CreateMesh()
             {
                 var mesh = new Mesh();
-                mesh.SetVertices(m_positioins);
+                mesh.SetVertices(m_positions);
                 mesh.boneWeights = m_boneWeights.ToArray();
                 mesh.triangles = m_indices.ToArray();
                 mesh.RecalculateNormals();

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonDictionaryValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonDictionaryValidator.cs
@@ -55,7 +55,7 @@ namespace UniJSON
             get; set;
         }
 
-        Dictionary<string, string[]> m_depndencies;
+        Dictionary<string, string[]> m_dependencies;
         /// <summary>
         /// http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.7
         /// </summary>
@@ -63,11 +63,11 @@ namespace UniJSON
         {
             get
             {
-                if (m_depndencies == null)
+                if (m_dependencies == null)
                 {
-                    m_depndencies = new Dictionary<string, string[]>();
+                    m_dependencies = new Dictionary<string, string[]>();
                 }
-                return m_depndencies;
+                return m_dependencies;
             }
         }
 

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonObjectValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonObjectValidator.cs
@@ -68,7 +68,7 @@ namespace UniJSON
             get; set;
         }
 
-        Dictionary<string, string[]> m_depndencies;
+        Dictionary<string, string[]> m_dependencies;
         /// <summary>
         /// http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.7
         /// </summary>
@@ -76,11 +76,11 @@ namespace UniJSON
         {
             get
             {
-                if (m_depndencies == null)
+                if (m_dependencies == null)
                 {
-                    m_depndencies = new Dictionary<string, string[]>();
+                    m_dependencies = new Dictionary<string, string[]>();
                 }
-                return m_depndencies;
+                return m_dependencies;
             }
         }
 

--- a/Assets/VRM/UniVRM/DevOnly/Editor/VRMExportUnityPackage.cs
+++ b/Assets/VRM/UniVRM/DevOnly/Editor/VRMExportUnityPackage.cs
@@ -85,7 +85,7 @@ namespace VRM.DevOnly.PackageExporter
             return path;
         }
 
-        static readonly string[] ignoredFilesForGrob = new string[] {
+        static readonly string[] ignoredFilesForGlob = new string[] {
             ".git",
             ".circleci",
             "DevOnly",
@@ -93,12 +93,12 @@ namespace VRM.DevOnly.PackageExporter
             "Profiling",
         };
 
-        static IEnumerable<string> GrobFiles(string path)
+        static IEnumerable<string> GlobFiles(string path)
         {
             var fileName = Path.GetFileName(path);
 
             // Domain specific filter logic
-            if (ignoredFilesForGrob.Any(f => fileName.EndsWithAndMeta(f))) {
+            if (ignoredFilesForGlob.Any(f => fileName.EndsWithAndMeta(f))) {
                 yield break;
             }
 
@@ -106,7 +106,7 @@ namespace VRM.DevOnly.PackageExporter
             {
                 foreach (var child in Directory.GetFileSystemEntries(path))
                 {
-                    foreach (var x in GrobFiles(child))
+                    foreach (var x in GlobFiles(child))
                     {
                         yield return x;
                     }
@@ -157,7 +157,7 @@ namespace VRM.DevOnly.PackageExporter
                     {"UniGLTF-standalone", new string[] {"UniGLTF", "UniHumanoid", "UniJSON", "UniUnlit", "DepthFirstScheduler"}},
                 };
 
-                var fileNames = GrobFiles(basePath).ToArray();
+                var fileNames = GlobFiles(basePath).ToArray();
                 foreach(var packagePair in packages) {
                     CreateUnityPackage(outputDir, packagePair.Key, packagePair.Value, basePath, fileNames);
                 }
@@ -165,8 +165,8 @@ namespace VRM.DevOnly.PackageExporter
 
             // UniVRM Samples
             {
-                var fileNames = GrobFiles("Assets/VRM.Samples")
-                    .Concat(GrobFiles("Assets/StreamingAssets/VRM.Samples"))
+                var fileNames = GlobFiles("Assets/VRM.Samples")
+                    .Concat(GlobFiles("Assets/StreamingAssets/VRM.Samples"))
                     .ToArray();
                 CreateUnityPackage(outputDir, "UniVRM-samples", null /*All*/, "", fileNames);
             }

--- a/Assets/VRM/UniVRM/Editor/Meta/VRMMetaEditor.cs
+++ b/Assets/VRM/UniVRM/Editor/Meta/VRMMetaEditor.cs
@@ -70,7 +70,7 @@ namespace VRM
         }
 
         bool m_foldoutInfo = true;
-        bool m_foldoutPersmission = true;
+        bool m_foldoutPermission = true;
         bool m_foldoutDistribution = true;
         void VRMMetaObjectGUI(SerializedObject so)
         {
@@ -103,8 +103,8 @@ namespace VRM
 
             EditorGUILayout.LabelField("License ", EditorStyles.boldLabel);
 
-            m_foldoutPersmission = EditorGUILayout.Foldout(m_foldoutPersmission, "Personation / Characterization Permission");
-            if (m_foldoutPersmission)
+            m_foldoutPermission = EditorGUILayout.Foldout(m_foldoutPermission, "Personation / Characterization Permission");
+            if (m_foldoutPermission)
             {
                 EditorGUILayout.PropertyField(m_propMap["AllowedUser"], new GUIContent("A person who can perform with this avatar"), false);
                 EditorGUILayout.PropertyField(m_propMap["ViolentUssage"], new GUIContent("Violent acts using this avatar"));

--- a/Assets/VRM/UniVRM/Scripts/LookAt/VRMLookAtBlendShapeApplyer.cs
+++ b/Assets/VRM/UniVRM/Scripts/LookAt/VRMLookAtBlendShapeApplyer.cs
@@ -29,12 +29,12 @@ namespace VRM
         }
 
         VRMLookAtHead m_head;
-        VRMBlendShapeProxy m_propxy;
+        VRMBlendShapeProxy m_proxy;
 
         private void Start()
         {
             m_head = GetComponent<VRMLookAtHead>();
-            m_propxy = GetComponent<VRMBlendShapeProxy>();
+            m_proxy = GetComponent<VRMBlendShapeProxy>();
             if (m_head == null)
             {
                 enabled = false;
@@ -49,27 +49,27 @@ namespace VRM
             if (yaw < 0)
             {
                 // Left
-                m_propxy.SetValue(BlendShapePreset.LookRight, 0, !m_notSetValueApply); // clear first
-                m_propxy.SetValue(BlendShapePreset.LookLeft, Mathf.Clamp(Horizontal.Map(-yaw), 0, 1.0f), !m_notSetValueApply);
+                m_proxy.SetValue(BlendShapePreset.LookRight, 0, !m_notSetValueApply); // clear first
+                m_proxy.SetValue(BlendShapePreset.LookLeft, Mathf.Clamp(Horizontal.Map(-yaw), 0, 1.0f), !m_notSetValueApply);
             }
             else
             {
                 // Right
-                m_propxy.SetValue(BlendShapePreset.LookLeft, 0, !m_notSetValueApply); // clear first
-                m_propxy.SetValue(BlendShapePreset.LookRight, Mathf.Clamp(Horizontal.Map(yaw), 0, 1.0f), !m_notSetValueApply);
+                m_proxy.SetValue(BlendShapePreset.LookLeft, 0, !m_notSetValueApply); // clear first
+                m_proxy.SetValue(BlendShapePreset.LookRight, Mathf.Clamp(Horizontal.Map(yaw), 0, 1.0f), !m_notSetValueApply);
             }
 
             if (pitch < 0)
             {
                 // Down
-                m_propxy.SetValue(BlendShapePreset.LookUp, 0, !m_notSetValueApply); // clear first
-                m_propxy.SetValue(BlendShapePreset.LookDown, Mathf.Clamp(VerticalDown.Map(-pitch), 0, 1.0f), !m_notSetValueApply);
+                m_proxy.SetValue(BlendShapePreset.LookUp, 0, !m_notSetValueApply); // clear first
+                m_proxy.SetValue(BlendShapePreset.LookDown, Mathf.Clamp(VerticalDown.Map(-pitch), 0, 1.0f), !m_notSetValueApply);
             }
             else
             {
                 // Up
-                m_propxy.SetValue(BlendShapePreset.LookDown, 0, !m_notSetValueApply); // clear first
-                m_propxy.SetValue(BlendShapePreset.LookUp, Mathf.Clamp(VerticalUp.Map(pitch), 0, 1.0f), !m_notSetValueApply);
+                m_proxy.SetValue(BlendShapePreset.LookDown, 0, !m_notSetValueApply); // clear first
+                m_proxy.SetValue(BlendShapePreset.LookUp, Mathf.Clamp(VerticalUp.Map(pitch), 0, 1.0f), !m_notSetValueApply);
             }
 #pragma warning restore 0618
         }


### PR DESCRIPTION
プライベートなもののtypoを修正しました。リフレクションなどを使わない限りリネームは安全と判断して、Obsoleteなどで古いものを残すことはしませんでした。