### PR TITLE
Fix typo (error messages)

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshImporter.cs
@@ -23,7 +23,7 @@ namespace UniGLTF
             {
                 if (!gltfMesh.primitives[i].targets.SequenceEqual(targets))
                 {
-                    throw new NotImplementedException(string.Format("diffirent targets: {0} with {1}",
+                    throw new NotImplementedException(string.Format("different targets: {0} with {1}",
                         gltfMesh.primitives[i],
                         targets));
                 }
@@ -456,7 +456,7 @@ namespace UniGLTF
                         }
                         else
                         {
-                            Debug.LogWarningFormat("May be partial primitive has blendShape. Rquire separete mesh or extend blend shape, but not implemented: {0}", blendShape.Name);
+                            Debug.LogWarningFormat("May be partial primitive has blendShape. Require separate mesh or extend blend shape, but not implemented: {0}", blendShape.Name);
                         }
                     }
                     else

--- a/Assets/VRM/UniHumanoid/Scripts/Format/Bvh.cs
+++ b/Assets/VRM/UniHumanoid/Scripts/Format/Bvh.cs
@@ -128,7 +128,7 @@ namespace UniHumanoid
             var count = int.Parse(split[1]);
             if (count + 2 != split.Length)
             {
-                throw new BvhException("channel count is not match with splited count");
+                throw new BvhException("channel count is not match with split count");
             }
             return split.Skip(2).Select(x => (Channel)Enum.Parse(typeof(Channel), x)).ToArray();
         }
@@ -383,7 +383,7 @@ namespace UniHumanoid
                         return null;
                     }
                 }
-                throw new BvhException(String.Format("splited to {0}({1})", split.Length, firstline));
+                throw new BvhException(String.Format("split to {0}({1})", split.Length, firstline));
             }
 
             BvhNode node = null;

--- a/Assets/VRM/UniJSON/Scripts/Json/JsonFormatter.cs
+++ b/Assets/VRM/UniJSON/Scripts/Json/JsonFormatter.cs
@@ -106,7 +106,7 @@ namespace UniJSON
                     {
                         if (top.Count % 2 == 0)
                         {
-                            if (!isKey) throw new FormatterException("key exptected");
+                            if (!isKey) throw new FormatterException("key expected");
                             if (top.Count != 0)
                             {
                                 m_w.Write(',');
@@ -114,7 +114,7 @@ namespace UniJSON
                         }
                         else
                         {
-                            if (isKey) throw new FormatterException("key not exptected");
+                            if (isKey) throw new FormatterException("key not expected");
                         }
                     }
                     break;

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonArrayValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonArrayValidator.cs
@@ -156,7 +156,7 @@ namespace UniJSON
 
             if (MaxItems.HasValue && count > MaxItems.Value)
             {
-                return new JsonSchemaValidationException(context, "maxOtems");
+                return new JsonSchemaValidationException(context, "maxItems");
             }
 
             if (MinItems.HasValue && count < MinItems.Value)

--- a/Assets/VRM/UniVRM/Scripts/SkinnedMeshUtility/BoneNormalizer.cs
+++ b/Assets/VRM/UniVRM/Scripts/SkinnedMeshUtility/BoneNormalizer.cs
@@ -371,7 +371,7 @@ namespace VRM
                 srcRenderer.BakeMesh(blendShapeMesh);
                 if (blendShapeMesh.vertices.Length != mesh.vertices.Length)
                 {
-                    throw new Exception("diffrent vertex count");
+                    throw new Exception("different vertex count");
                 }
                 srcRenderer.SetBlendShapeWeight(i, 0);
 


### PR DESCRIPTION
エラーメッセージのtypoを修正しました。仕様変更にはなりますが、エラーメッセージを見て分岐などすることはそう無いだろうと判断し、一気にリネームしてしまっています。