### PR TITLE
Fix typo (public class members)

### DIFF
--- a/Assets/VRM/DepthFirstScheduler/IEnumeratorExtensions.cs
+++ b/Assets/VRM/DepthFirstScheduler/IEnumeratorExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 
 
@@ -7,7 +8,13 @@ namespace
 {
     public static class IEnumeratorExtensions
     {
+        [Obsolete("Use CoroutineToEnd")]
         public static void CoroutinetoEnd(this IEnumerator coroutine)
+        {
+            CoroutineToEnd(coroutine);
+        }
+
+        public static void CoroutineToEnd(this IEnumerator coroutine)
         {
             var stack = new Stack<IEnumerator>();
             stack.Push(coroutine);

--- a/Assets/VRM/UniGLTF/Editor/gltfAssetPostprocessor.cs
+++ b/Assets/VRM/UniGLTF/Editor/gltfAssetPostprocessor.cs
@@ -48,7 +48,7 @@ namespace UniGLTF
             context.Parse(src);
 
             // Extract textures to assets folder
-            context.ExtranctImages(prefabPath);
+            context.ExtractImages(prefabPath);
 
             ImportDelayed(src, prefabPath, context);
         }

--- a/Assets/VRM/UniGLTF/Scripts/Extensions/UnityExtensions.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Extensions/UnityExtensions.cs
@@ -219,7 +219,13 @@ namespace UniGLTF
             }
         }
 
+        [Obsolete("Use FindDescendant(name)")]
         public static Transform FindDescenedant(this Transform t, string name)
+        {
+            return FindDescendant(t, name);
+        }
+
+        public static Transform FindDescendant(this Transform t, string name)
         {
             return t.Traverse().First(x => x.name == name);
         }

--- a/Assets/VRM/UniGLTF/Scripts/Format/BytesBuffer.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/BytesBuffer.cs
@@ -49,7 +49,13 @@ namespace UniGLTF
 
         const string DataPrefix3 = "data:image/jpeg;base64,";
 
+        [Obsolete("Use ReadEmbedded(uri)")]
         public static Byte[] ReadEmbeded(string uri)
+        {
+            return ReadEmbedded(uri);
+        }
+
+        public static Byte[] ReadEmbedded(string uri)
         {
             var pos = uri.IndexOf(";base64,");
             if (pos < 0)
@@ -64,7 +70,7 @@ namespace UniGLTF
 
         Byte[] ReadFromUri(string baseDir, string uri)
         {
-            var bytes = ReadEmbeded(uri);
+            var bytes = ReadEmbedded(uri);
             if (bytes != null)
             {
                 return bytes;

--- a/Assets/VRM/UniGLTF/Scripts/IO/IStorage.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/IStorage.cs
@@ -53,7 +53,7 @@ namespace UniGLTF
         {
             var bytes =
                 (url.StartsWith("data:"))
-                ? UriByteBuffer.ReadEmbeded(url)
+                ? UriByteBuffer.ReadEmbedded(url)
                 : File.ReadAllBytes(Path.Combine(m_root, url))
                 ;
             return new ArraySegment<byte>(bytes);

--- a/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
@@ -238,7 +238,7 @@ namespace UniGLTF
         /// <param name="bytes"></param>
         public void ParseGlb(Byte[] bytes)
         {
-            var chunks = glbImporter.ParseGlbChanks(bytes);
+            var chunks = glbImporter.ParseGlbChunks(bytes);
 
             if (chunks.Count != 2)
             {
@@ -905,11 +905,17 @@ namespace UniGLTF
             }
         }
 
+        [Obsolete("Use ExtractImages(prefabPath)")]
+        public void ExtranctImages(UnityPath prefabPath)
+        {
+            ExtractImages(prefabPath);
+        }
+
         /// <summary>
         /// Extract images from glb or gltf out of Assets folder.
         /// </summary>
         /// <param name="prefabPath"></param>
-        public void ExtranctImages(UnityPath prefabPath)
+        public void ExtractImages(UnityPath prefabPath)
         {
             var prefabParentDir = prefabPath.Parent;
 

--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
@@ -8,7 +8,9 @@ namespace UniGLTF
     public struct MeshWithRenderer
     {
         public Mesh Mesh;
-        public Renderer Rendererer;
+        [Obsolete("Use Renderer")]
+        public Renderer Rendererer { get { return Renderer; } set { Renderer = value; } }
+        public Renderer Renderer;
     }
 
     public static class MeshExporter
@@ -232,10 +234,10 @@ namespace UniGLTF
             {
                 var x = unityMeshes[i];
                 var mesh = x.Mesh;
-                var materials = x.Rendererer.sharedMaterials;
+                var materials = x.Renderer.sharedMaterials;
 
                 var gltfMesh = ExportPrimitives(gltf, bufferIndex,
-                    x.Rendererer.name,
+                    x.Renderer.name,
                     mesh, materials, unityMaterials);
 
                 for (int j = 0; j < mesh.blendShapeCount; ++j)

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
@@ -141,7 +141,7 @@ namespace UniGLTF
         public void Process(glTF gltf, IStorage storage)
         {
             ProcessOnAnyThread(gltf, storage);
-            ProcessOnMainThreadCoroutine(gltf).CoroutinetoEnd();
+            ProcessOnMainThreadCoroutine(gltf).CoroutineToEnd();
         }
 
         public IEnumerator ProcessCoroutine(glTF gltf, IStorage storage)

--- a/Assets/VRM/UniGLTF/Scripts/IO/UnityPath.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/UnityPath.cs
@@ -286,7 +286,13 @@ namespace UniGLTF
         }
         #endregion
 
+        [Obsolete("Use TraverseDir()")]
         public IEnumerable<UnityPath> TravserseDir()
+        {
+            return TraverseDir();
+        }
+
+        public IEnumerable<UnityPath> TraverseDir()
         {
             if (IsDirectoryExists)
             {
@@ -294,7 +300,7 @@ namespace UniGLTF
 
                 foreach(var child in ChildDirs)
                 {
-                    foreach(var x in child.TravserseDir())
+                    foreach(var x in child.TraverseDir())
                     {
                         yield return x;
                     }

--- a/Assets/VRM/UniGLTF/Scripts/IO/glbImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/glbImporter.cs
@@ -27,7 +27,13 @@ namespace UniGLTF
             }
         }
 
+        [Obsolete("Use ParseGlbChunks(bytes)")]
         public static List<GlbChunk> ParseGlbChanks(Byte[] bytes)
+        {
+            return ParseGlbChunks(bytes);
+        }
+
+        public static List<GlbChunk> ParseGlbChunks(Byte[] bytes)
         {
             if (bytes.Length == 0)
             {

--- a/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
@@ -223,7 +223,7 @@ namespace UniGLTF
                     .Select(x => new MeshWithRenderer
                     {
                         Mesh = x.GetSharedMesh(),
-                        Rendererer = x.GetComponent<Renderer>(),
+                        Renderer = x.GetComponent<Renderer>(),
                     })
                     .Where(x =>
                     {
@@ -231,8 +231,8 @@ namespace UniGLTF
                         {
                             return false;
                         }
-                        if (x.Rendererer.sharedMaterials == null
-                        || x.Rendererer.sharedMaterials.Length == 0)
+                        if (x.Renderer.sharedMaterials == null
+                        || x.Renderer.sharedMaterials.Length == 0)
                         {
                             return false;
                         }
@@ -251,7 +251,7 @@ namespace UniGLTF
                         && x.bones != null
                         && x.bones.Length > 0)
                     .ToList();
-                gltf.nodes = Nodes.Select(x => ExportNode(x, Nodes, unityMeshes.Select(y => y.Rendererer).ToList(), unitySkins)).ToList();
+                gltf.nodes = Nodes.Select(x => ExportNode(x, Nodes, unityMeshes.Select(y => y.Renderer).ToList(), unitySkins)).ToList();
                 gltf.scenes = new List<gltfScene>
                 {
                     new gltfScene

--- a/Assets/VRM/UniHumanoid/PoseModifier/HandPose.cs
+++ b/Assets/VRM/UniHumanoid/PoseModifier/HandPose.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 
 namespace UniHumanoid
@@ -8,19 +9,29 @@ namespace UniHumanoid
     {
         public class HandPose
         {
-            public float ThumbStrech;
+            [Obsolete("Use ThumbStretch")]
+            public float ThumbStrech { get {  return ThumbStretch; } set { ThumbStretch = value; } }
+            public float ThumbStretch;
             public float ThumbSpread;
 
-            public float IndexStrech;
+            [Obsolete("Use IndexStretch")]
+            public float IndexStrech { get { return IndexStretch; } set { IndexStretch = value; } }
+            public float IndexStretch;
             public float IndexSpread;
 
-            public float MiddleStrech;
+            [Obsolete("Use MiddleStretch")]
+            public float MiddleStrech { get { return MiddleStretch; } set { MiddleStretch = value; } }
+            public float MiddleStretch;
             public float MiddleSpread;
 
-            public float RingStrech;
+            [Obsolete("Use RingStretch")]
+            public float RingStrech { get { return RingStretch; } set { RingStretch = value; } }
+            public float RingStretch;
             public float RingSpread;
 
-            public float LittleStrech;
+            [Obsolete("Use LittleStretch")]
+            public float LittleStrech { get { return LittleStretch; } set { LittleStretch = value; } }
+            public float LittleStretch;
             public float LittleSpread;
         }
         public HandPose LeftHandPose
@@ -125,21 +136,21 @@ namespace UniHumanoid
         {
             if (LeftHandPose != null)
             {
-                pose.muscles[this.LeftThumb1Stretched] = LeftHandPose.ThumbStrech;
-                pose.muscles[this.LeftThumb2Stretched] = LeftHandPose.ThumbStrech;
-                pose.muscles[this.LeftThumb3Stretched] = LeftHandPose.ThumbStrech;
-                pose.muscles[this.LeftIndex1Stretched] = LeftHandPose.IndexStrech;
-                pose.muscles[this.LeftIndex2Stretched] = LeftHandPose.IndexStrech;
-                pose.muscles[this.LeftIndex3Stretched] = LeftHandPose.IndexStrech;
-                pose.muscles[this.LeftMiddle1Stretched] = LeftHandPose.MiddleStrech;
-                pose.muscles[this.LeftMiddle2Stretched] = LeftHandPose.MiddleStrech;
-                pose.muscles[this.LeftMiddle3Stretched] = LeftHandPose.MiddleStrech;
-                pose.muscles[this.LeftRing1Stretched] = LeftHandPose.RingStrech;
-                pose.muscles[this.LeftRing2Stretched] = LeftHandPose.RingStrech;
-                pose.muscles[this.LeftRing3Stretched] = LeftHandPose.RingStrech;
-                pose.muscles[this.LeftLittle1Stretched] = LeftHandPose.LittleStrech;
-                pose.muscles[this.LeftLittle2Stretched] = LeftHandPose.LittleStrech;
-                pose.muscles[this.LeftLittle3Stretched] = LeftHandPose.LittleStrech;
+                pose.muscles[this.LeftThumb1Stretched] = LeftHandPose.ThumbStretch;
+                pose.muscles[this.LeftThumb2Stretched] = LeftHandPose.ThumbStretch;
+                pose.muscles[this.LeftThumb3Stretched] = LeftHandPose.ThumbStretch;
+                pose.muscles[this.LeftIndex1Stretched] = LeftHandPose.IndexStretch;
+                pose.muscles[this.LeftIndex2Stretched] = LeftHandPose.IndexStretch;
+                pose.muscles[this.LeftIndex3Stretched] = LeftHandPose.IndexStretch;
+                pose.muscles[this.LeftMiddle1Stretched] = LeftHandPose.MiddleStretch;
+                pose.muscles[this.LeftMiddle2Stretched] = LeftHandPose.MiddleStretch;
+                pose.muscles[this.LeftMiddle3Stretched] = LeftHandPose.MiddleStretch;
+                pose.muscles[this.LeftRing1Stretched] = LeftHandPose.RingStretch;
+                pose.muscles[this.LeftRing2Stretched] = LeftHandPose.RingStretch;
+                pose.muscles[this.LeftRing3Stretched] = LeftHandPose.RingStretch;
+                pose.muscles[this.LeftLittle1Stretched] = LeftHandPose.LittleStretch;
+                pose.muscles[this.LeftLittle2Stretched] = LeftHandPose.LittleStretch;
+                pose.muscles[this.LeftLittle3Stretched] = LeftHandPose.LittleStretch;
                 pose.muscles[this.LeftThumbSpread] = LeftHandPose.ThumbSpread;
                 pose.muscles[this.LeftIndexSpread] = LeftHandPose.IndexSpread;
                 pose.muscles[this.LeftMiddleSpread] = LeftHandPose.MiddleSpread;
@@ -149,21 +160,21 @@ namespace UniHumanoid
 
             if (RightHandPose != null)
             {
-                pose.muscles[this.RightThumb1Stretched] = RightHandPose.ThumbStrech;
-                pose.muscles[this.RightThumb2Stretched] = RightHandPose.ThumbStrech;
-                pose.muscles[this.RightThumb3Stretched] = RightHandPose.ThumbStrech;
-                pose.muscles[this.RightIndex1Stretched] = RightHandPose.IndexStrech;
-                pose.muscles[this.RightIndex2Stretched] = RightHandPose.IndexStrech;
-                pose.muscles[this.RightIndex3Stretched] = RightHandPose.IndexStrech;
-                pose.muscles[this.RightMiddle1Stretched] = RightHandPose.MiddleStrech;
-                pose.muscles[this.RightMiddle2Stretched] = RightHandPose.MiddleStrech;
-                pose.muscles[this.RightMiddle3Stretched] = RightHandPose.MiddleStrech;
-                pose.muscles[this.RightRing1Stretched] = RightHandPose.RingStrech;
-                pose.muscles[this.RightRing2Stretched] = RightHandPose.RingStrech;
-                pose.muscles[this.RightRing3Stretched] = RightHandPose.RingStrech;
-                pose.muscles[this.RightLittle1Stretched] = RightHandPose.LittleStrech;
-                pose.muscles[this.RightLittle2Stretched] = RightHandPose.LittleStrech;
-                pose.muscles[this.RightLittle3Stretched] = RightHandPose.LittleStrech;
+                pose.muscles[this.RightThumb1Stretched] = RightHandPose.ThumbStretch;
+                pose.muscles[this.RightThumb2Stretched] = RightHandPose.ThumbStretch;
+                pose.muscles[this.RightThumb3Stretched] = RightHandPose.ThumbStretch;
+                pose.muscles[this.RightIndex1Stretched] = RightHandPose.IndexStretch;
+                pose.muscles[this.RightIndex2Stretched] = RightHandPose.IndexStretch;
+                pose.muscles[this.RightIndex3Stretched] = RightHandPose.IndexStretch;
+                pose.muscles[this.RightMiddle1Stretched] = RightHandPose.MiddleStretch;
+                pose.muscles[this.RightMiddle2Stretched] = RightHandPose.MiddleStretch;
+                pose.muscles[this.RightMiddle3Stretched] = RightHandPose.MiddleStretch;
+                pose.muscles[this.RightRing1Stretched] = RightHandPose.RingStretch;
+                pose.muscles[this.RightRing2Stretched] = RightHandPose.RingStretch;
+                pose.muscles[this.RightRing3Stretched] = RightHandPose.RingStretch;
+                pose.muscles[this.RightLittle1Stretched] = RightHandPose.LittleStretch;
+                pose.muscles[this.RightLittle2Stretched] = RightHandPose.LittleStretch;
+                pose.muscles[this.RightLittle3Stretched] = RightHandPose.LittleStretch;
                 pose.muscles[this.RightThumbSpread] = RightHandPose.ThumbSpread;
                 pose.muscles[this.RightIndexSpread] = RightHandPose.IndexSpread;
                 pose.muscles[this.RightMiddleSpread] = RightHandPose.MiddleSpread;

--- a/Assets/VRM/UniHumanoid/PoseModifier/HandPose.cs
+++ b/Assets/VRM/UniHumanoid/PoseModifier/HandPose.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 
 namespace UniHumanoid

--- a/Assets/VRM/UniHumanoid/PoseModifier/HandRig.cs
+++ b/Assets/VRM/UniHumanoid/PoseModifier/HandRig.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.Serialization;
 
 
 namespace UniHumanoid
@@ -12,14 +13,16 @@ namespace UniHumanoid
             get { return m_animator; }
         }
 
+        [FormerlySerializedAs("LeftStrech")]
         [SerializeField, Range(-1, 1)]
-        public float LeftStrech;
+        public float LeftStretch;
 
         [SerializeField, Range(-1, 1)]
         public float LeftSpread;
 
+        [FormerlySerializedAs("RightStrech")]
         [SerializeField, Range(-1, 1)]
-        public float RightStrech;
+        public float RightStretch;
 
         [SerializeField, Range(-1, 1)]
         public float RightSpread;
@@ -67,26 +70,26 @@ namespace UniHumanoid
 
         private void Update()
         {
-            m_leftHand.ThumbStrech = LeftStrech;
+            m_leftHand.ThumbStretch = LeftStretch;
             m_leftHand.ThumbSpread = LeftSpread;
-            m_leftHand.IndexStrech = LeftStrech;
+            m_leftHand.IndexStretch = LeftStretch;
             m_leftHand.IndexSpread = LeftSpread;
-            m_leftHand.MiddleStrech = LeftStrech;
+            m_leftHand.MiddleStretch = LeftStretch;
             m_leftHand.MiddleSpread = LeftSpread;
-            m_leftHand.RingStrech = LeftStrech;
+            m_leftHand.RingStretch = LeftStretch;
             m_leftHand.RingSpread = LeftSpread;
-            m_leftHand.LittleStrech = LeftStrech;
+            m_leftHand.LittleStretch = LeftStretch;
             m_leftHand.LittleSpread = LeftSpread;
 
-            m_rightHand.ThumbStrech = RightStrech;
+            m_rightHand.ThumbStretch = RightStretch;
             m_rightHand.ThumbSpread = RightSpread;
-            m_rightHand.IndexStrech = RightStrech;
+            m_rightHand.IndexStretch = RightStretch;
             m_rightHand.IndexSpread = RightSpread;
-            m_rightHand.MiddleStrech = RightStrech;
+            m_rightHand.MiddleStretch = RightStretch;
             m_rightHand.MiddleSpread = RightSpread;
-            m_rightHand.RingStrech = RightStrech;
+            m_rightHand.RingStretch = RightStretch;
             m_rightHand.RingSpread = RightSpread;
-            m_rightHand.LittleStrech = RightStrech;
+            m_rightHand.LittleStretch = RightStretch;
             m_rightHand.LittleSpread = RightSpread;
 
             m_updater.LeftHandPose = m_leftHand;

--- a/Assets/VRM/UniJSON/Scripts/ListTreeNode/ListTreeNode.cs
+++ b/Assets/VRM/UniJSON/Scripts/ListTreeNode/ListTreeNode.cs
@@ -379,7 +379,7 @@ namespace UniJSON
         {
             get
             {
-                return this.GetArrrayItem(index);
+                return this.GetArrayItem(index);
             }
         }
         #endregion

--- a/Assets/VRM/UniJSON/Scripts/ListTreeNode/ListTreeNodeArrayExtensions.cs
+++ b/Assets/VRM/UniJSON/Scripts/ListTreeNode/ListTreeNodeArrayExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 
@@ -12,7 +13,14 @@ namespace UniJSON
             return self.Children;
         }
 
-        public static ListTreeNode<T> GetArrrayItem<T>(this ListTreeNode<T> self, int index) 
+        [Obsolete("Use GetArrayItem(index)")]
+        public static ListTreeNode<T> GetArrrayItem<T>(this ListTreeNode<T> self, int index)
+            where T : IListTreeItem, IValue<T>
+        {
+            return GetArrayItem(self, index);
+        }
+
+        public static ListTreeNode<T> GetArrayItem<T>(this ListTreeNode<T> self, int index)
             where T : IListTreeItem, IValue<T>
         {
             int i = 0;

--- a/Assets/VRM/UniUnlit/Editor/UniUnlitEditor.cs
+++ b/Assets/VRM/UniUnlit/Editor/UniUnlitEditor.cs
@@ -27,7 +27,7 @@ namespace UniGLTF.UniUnlit
             _cutoff = FindProperty(Utils.PropNameCutoff, properties);
             _blendMode = FindProperty(Utils.PropNameBlendMode, properties);
             _cullMode = FindProperty(Utils.PropNameCullMode, properties);
-            _vColBlendMode = FindProperty(Utils.PropeNameVColBlendMode, properties);
+            _vColBlendMode = FindProperty(Utils.PropNameVColBlendMode, properties);
 //            _srcBlend = FindProperty(PropNameSrcBlend, properties);
 //            _dstBlend = FindProperty(PropNameDstBlend, properties);
 //            _zWrite = FindProperty(PropNameZWrite, properties);

--- a/Assets/VRM/UniUnlit/Scripts/Utils.cs
+++ b/Assets/VRM/UniUnlit/Scripts/Utils.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using UnityEngine.Rendering;
 
 namespace UniGLTF.UniUnlit
@@ -30,7 +31,9 @@ namespace UniGLTF.UniUnlit
         public const string PropNameCutoff = "_Cutoff";
         public const string PropNameBlendMode = "_BlendMode";
         public const string PropNameCullMode = "_CullMode";
-        public const string PropeNameVColBlendMode = "_VColBlendMode";
+        [Obsolete("Use PropNameVColBlendMode")]
+        public const string PropeNameVColBlendMode = PropNameVColBlendMode;
+        public const string PropNameVColBlendMode = "_VColBlendMode";
         public const string PropNameSrcBlend = "_SrcBlend";
         public const string PropNameDstBlend = "_DstBlend";
         public const string PropNameZWrite = "_ZWrite";
@@ -77,7 +80,7 @@ namespace UniGLTF.UniUnlit
         {
             SetupBlendMode(material, (UniUnlitRenderMode)material.GetFloat(PropNameBlendMode),
                 isRenderModeChangedByUser);
-            SetupVertexColorBlendOp(material, (UniUnlitVertexColorBlendOp)material.GetFloat(PropeNameVColBlendMode));
+            SetupVertexColorBlendOp(material, (UniUnlitVertexColorBlendOp)material.GetFloat(PropNameVColBlendMode));
         }
 
         private static void SetupBlendMode(Material material, UniUnlitRenderMode renderMode,

--- a/Assets/VRM/UniVRM/Editor/Format/VRMImporterMenu.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMImporterMenu.cs
@@ -50,7 +50,7 @@ namespace VRM
                 var prefabPath = UnityPath.FromUnityPath(assetPath);
                 var context = new VRMImporterContext();
                 context.ParseGlb(File.ReadAllBytes(path));
-                context.ExtranctImages(prefabPath);
+                context.ExtractImages(prefabPath);
 
                 EditorApplication.delayCall += () =>
                 {

--- a/Assets/VRM/UniVRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -41,7 +41,7 @@ namespace VRM
             var prefabPath = path.Parent.Child(path.FileNameWithoutExtension + ".prefab");
 
             // save texture assets !
-            context.ExtranctImages(prefabPath);
+            context.ExtractImages(prefabPath);
 
             EditorApplication.delayCall += () =>
             {

--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeClipHandler.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeClipHandler.cs
@@ -8,7 +8,12 @@ namespace VRM
     public class BlendShapeClipHandler
     {
         BlendShapeClip m_clip;
+        [Obsolete("Use Clip")]
         public BlendShapeClip Cilp
+        {
+            get { return Clip; }
+        }
+        public BlendShapeClip Clip
         {
             get { return m_clip; }
         }

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRMExtensions.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRMExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using UniGLTF;
 using UnityEngine;
@@ -8,7 +9,13 @@ namespace VRM
 {
     public static class glTF_VRMExtensions
     {
+        [Obsolete("Use Create(root, meshes, binding)")]
         public static glTF_VRM_BlendShapeBind Cerate(Transform root, List<Mesh> meshes, BlendShapeBinding binding)
+        {
+            return Create(root, meshes, binding);
+        }
+
+        public static glTF_VRM_BlendShapeBind Create(Transform root, List<Mesh> meshes, BlendShapeBinding binding)
         {
             var transform = UniGLTF.UnityExtensions.GetFromPath(root.transform, binding.RelativePath);
             var renderer = transform.GetComponent<SkinnedMeshRenderer>();
@@ -29,7 +36,7 @@ namespace VRM
             var list = new List<glTF_VRM_BlendShapeBind>();
             if (clip.Values != null)
             {
-                list.AddRange(clip.Values.Select(y => Cerate(transform, meshes.ToList(), y)));
+                list.AddRange(clip.Values.Select(y => Create(transform, meshes.ToList(), y)));
             }
 
             var materialList = new List<glTF_VRM_MaterialValueBind>();


### PR DESCRIPTION
publicメンバーのtypoを修正しました。古い項目はすべてObsoleteをつけて残すようにしたため、リフレクションなどが使われていない限り後方互換性があります。