### PR TITLE
Fix typo (ToJsonSchema)

### DIFF
--- a/Assets/VRM/UniJSON/Scripts/Json/JsonSchema.cs
+++ b/Assets/VRM/UniJSON/Scripts/Json/JsonSchema.cs
@@ -412,7 +412,7 @@ namespace UniJSON
             f.BeginMap(2);
             if (!string.IsNullOrEmpty(Title)) { f.Key("title"); f.Value(Title); }
             if (!string.IsNullOrEmpty(Description)) { f.Key("description"); f.Value(Description); }
-            Validator.ToJsonScheama(f);
+            Validator.ToJsonSchema(f);
             f.EndMap();
         }
 

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/IJsonSchemaValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/IJsonSchemaValidator.cs
@@ -69,7 +69,7 @@ namespace UniJSON
         /// <returns></returns>
         bool FromJsonSchema(IFileSystemAccessor fs, string key, ListTreeNode<JsonValue> value);
 
-        void ToJsonScheama(IFormatter f);
+        void ToJsonSchema(IFormatter f);
         #endregion
 
         #region Serializer

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonArrayValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonArrayValidator.cs
@@ -280,7 +280,7 @@ namespace UniJSON
             GenericSerializer<T>.Serialize(Items.Validator, f, c, o);
         }
 
-        public void ToJsonScheama(IFormatter f)
+        public void ToJsonSchema(IFormatter f)
         {
             f.Key("type"); f.Value("array");
 

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonBoolValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonBoolValidator.cs
@@ -27,7 +27,7 @@ namespace UniJSON
             return false;
         }
 
-        public void ToJsonScheama(IFormatter f)
+        public void ToJsonSchema(IFormatter f)
         {
             f.Key("type"); f.Value("boolean");
         }

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonDictionaryValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonDictionaryValidator.cs
@@ -201,7 +201,7 @@ namespace UniJSON
             return false;
         }
 
-        public void ToJsonScheama(IFormatter f)
+        public void ToJsonSchema(IFormatter f)
         {
             f.Key("type"); f.Value("object");
         }

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonEnumValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonEnumValidator.cs
@@ -196,7 +196,7 @@ namespace UniJSON
             throw new NotImplementedException();
         }
 
-        public void ToJsonScheama(IFormatter f)
+        public void ToJsonSchema(IFormatter f)
         {
             f.Key("type"); f.Value("string");
             f.Key("enum");
@@ -392,7 +392,7 @@ namespace UniJSON
             throw new NotImplementedException();
         }
 
-        public void ToJsonScheama(IFormatter f)
+        public void ToJsonSchema(IFormatter f)
         {
             f.Key("type"); f.Value("integer");
         }

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonNumberValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonNumberValidator.cs
@@ -118,7 +118,7 @@ namespace UniJSON
             return false;
         }
 
-        public void ToJsonScheama(IFormatter f)
+        public void ToJsonSchema(IFormatter f)
         {
             f.Key("type"); f.Value("integer");
             if (Minimum.HasValue)
@@ -326,7 +326,7 @@ namespace UniJSON
             return false;
         }
 
-        public void ToJsonScheama(IFormatter f)
+        public void ToJsonSchema(IFormatter f)
         {
             f.Key("type"); f.Value("number");
             if (Minimum.HasValue)

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonObjectValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonObjectValidator.cs
@@ -281,7 +281,7 @@ namespace UniJSON
             return false;
         }
 
-        public void ToJsonScheama(IFormatter f)
+        public void ToJsonSchema(IFormatter f)
         {
             f.Key("type"); f.Value("object");
             if (Properties.Count > 0)

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonStringValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonStringValidator.cs
@@ -98,7 +98,7 @@ namespace UniJSON
             return false;
         }
 
-        public void ToJsonScheama(IFormatter f)
+        public void ToJsonSchema(IFormatter f)
         {
             f.Key("type"); f.Value("string");
         }


### PR DESCRIPTION
ToJsonSchemaのtypoを修正しました。interfaceのメンバー名を変更したため、古い名前をObsoleteで残すことができないため単純にリネームしました。仕様変更になります。