### PR TITLE
Fix typo (Scheduler)

### DIFF
--- a/Assets/VRM/DepthFirstScheduler/Schedulable.cs
+++ b/Assets/VRM/DepthFirstScheduler/Schedulable.cs
@@ -12,7 +12,7 @@ namespace DepthFirstScheduler
         /// <returns>実行が終了したか？Coroutineの実行が一回で終わらない場合がある</returns>
         ExecutionStatus Execute();
         Exception GetError();
-        IScheduler Schedulder { get; }
+        IScheduler Scheduler { get; }
 
         ISchedulable Parent { get; set; }
         void AddChild(ISchedulable child);
@@ -66,7 +66,7 @@ namespace DepthFirstScheduler
             set;
         }
 
-        public IScheduler Schedulder
+        public IScheduler Scheduler
         {
             get;
             private set;
@@ -89,7 +89,7 @@ namespace DepthFirstScheduler
 
         public Schedulable(IScheduler scheduler, IFunctor<T> func)
         {
-            Schedulder = scheduler;
+            Scheduler = scheduler;
             Func = func;
         }
 

--- a/Assets/VRM/DepthFirstScheduler/TaskChain.cs
+++ b/Assets/VRM/DepthFirstScheduler/TaskChain.cs
@@ -29,14 +29,14 @@ namespace DepthFirstScheduler
 
             if (item.Enumerator.MoveNext())
             {
-                if (item.Enumerator.Current.Schedulder == null)
+                if (item.Enumerator.Current.Scheduler == null)
                 {
                     // default
                     Scheduler.MainThread.Enqueue(item);
                 }
                 else
                 {
-                    item.Enumerator.Current.Schedulder.Enqueue(item);
+                    item.Enumerator.Current.Scheduler.Enqueue(item);
                 }
             }
 
@@ -77,11 +77,11 @@ namespace DepthFirstScheduler
                 return ExecutionStatus.Done;
             }
 
-            if (Enumerator.Current.Schedulder != null)
+            if (Enumerator.Current.Scheduler != null)
             {
                 // Scheduleして中断
                 ChainStatus = ChainStatus.Continue;
-                Enumerator.Current.Schedulder.Enqueue(this);
+                Enumerator.Current.Scheduler.Enqueue(this);
                 return ExecutionStatus.Done;
             }
 


### PR DESCRIPTION
Schedulerのtypoを修正しました。interfaceのメンバー名を変更する際、古い名前をObsoleteで残すことができないため単純にリネームしました。仕様変更になります。