### PR TITLE
Fix typo (AnimationProperties)

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/Format/glTFAnimation.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTFAnimation.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using UniJSON;
+using UnityEngine;
 
 
 namespace UniGLTF
@@ -42,7 +43,30 @@ namespace UniGLTF
         public const string PATH_WEIGHT = "weights";
         public const string NOT_IMPLEMENTED = "NotImplemented";
 
+        [Obsolete("Use AnimationProperties")]
         public enum AnimationPropertys
+        {
+            Translation = AnimationProperties.Translation,
+            EulerRotation = AnimationProperties.EulerRotation,
+            Rotation = AnimationProperties.Rotation,
+            Scale = AnimationProperties.Scale,
+            Weight = AnimationProperties.Weight,
+            BlendShape = AnimationProperties.BlendShape,
+
+            NotImplemented = AnimationProperties.NotImplemented
+        }
+
+        [Obsolete]
+        internal static AnimationProperties AnimationPropertysToAnimationProperties(AnimationPropertys property)
+        {
+            if (!Enum.IsDefined(typeof(AnimationProperties), property))
+            {
+                throw new InvalidCastException("Failed to convert AnimationPropertys '" + property + "' to AnimationProperties");
+            }
+            return (AnimationProperties)property;
+        }
+
+        public enum AnimationProperties
         {
             Translation,
             EulerRotation,
@@ -54,48 +78,60 @@ namespace UniGLTF
             NotImplemented
         }
 
+        [Obsolete]
         public static string GetPathName(AnimationPropertys property)
+        {
+            return GetPathName(AnimationPropertysToAnimationProperties(property));
+        }
+
+        public static string GetPathName(AnimationProperties property)
         {
             switch (property)
             {
-                case AnimationPropertys.Translation:
+                case AnimationProperties.Translation:
                     return PATH_TRANSLATION;
-                case AnimationPropertys.EulerRotation: 
-                case AnimationPropertys.Rotation:
+                case AnimationProperties.EulerRotation:
+                case AnimationProperties.Rotation:
                     return PATH_ROTATION;
-                case AnimationPropertys.Scale:
+                case AnimationProperties.Scale:
                     return PATH_SCALE;
-                case AnimationPropertys.BlendShape:
+                case AnimationProperties.BlendShape:
                     return PATH_WEIGHT;
                 default: throw new NotImplementedException();
             }
         }
 
-        public static AnimationPropertys GetAnimationProperty(string path)
+        public static AnimationProperties GetAnimationProperty(string path)
         {
             switch (path)
             {
                 case PATH_TRANSLATION:
-                    return AnimationPropertys.Translation;
+                    return AnimationProperties.Translation;
                 case PATH_ROTATION:
-                    return AnimationPropertys.Rotation;
+                    return AnimationProperties.Rotation;
                 case PATH_SCALE:
-                    return AnimationPropertys.Scale;
+                    return AnimationProperties.Scale;
                 case PATH_WEIGHT:
-                    return AnimationPropertys.BlendShape;
+                    return AnimationProperties.BlendShape;
                 default: throw new NotImplementedException();
             }
         }
 
+        [Obsolete]
         public static int GetElementCount(AnimationPropertys property)
+        {
+            return GetElementCount(AnimationPropertysToAnimationProperties(property));
+        }
+
+        public static int GetElementCount(AnimationProperties property)
         {
             switch (property)
             {
-                case AnimationPropertys.Translation: return 3;
-                case AnimationPropertys.EulerRotation: return 3;
-                case AnimationPropertys.Rotation: return 4;
-                case AnimationPropertys.Scale: return 3;
-                case AnimationPropertys.BlendShape: return 1;
+                case AnimationProperties.Translation: return 3;
+                case AnimationProperties.EulerRotation: return 3;
+                case AnimationProperties.Rotation: return 4;
+                case AnimationProperties.Scale: return 3;
+                case AnimationProperties.BlendShape: return 1;
                 default: throw new NotImplementedException();
             }
         }
@@ -179,7 +215,13 @@ namespace UniGLTF
             f.Key("samplers"); f.GLTFValue(samplers);
         }
 
+        [Obsolete]
         public int AddChannelAndGetSampler(int nodeIndex, glTFAnimationTarget.AnimationPropertys property)
+        {
+            return AddChannelAndGetSampler(nodeIndex, glTFAnimationTarget.AnimationPropertysToAnimationProperties(property));
+        }
+
+        public int AddChannelAndGetSampler(int nodeIndex, glTFAnimationTarget.AnimationProperties property)
         {
             // find channel
             var channel = channels.FirstOrDefault(x => x.target.node == nodeIndex && x.target.path == glTFAnimationTarget.GetPathName(property));

--- a/Assets/VRM/UniGLTF/Scripts/IO/AnimationCurveData.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/AnimationCurveData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -12,12 +13,18 @@ namespace UniGLTF
     {
 #if UNITY_EDITOR
         public AnimationUtility.TangentMode TangentMode { get; private set; }
-        public glTFAnimationTarget.AnimationPropertys AnimationProperty { get; private set; }
+        public glTFAnimationTarget.AnimationProperties AnimationProperty { get; private set; }
         public int SamplerIndex { get; private set; }
         public int ElementCount { get; private set; }
         public readonly List<AnimationKeyframeData> Keyframes = new List<AnimationKeyframeData>();
 
+        [Obsolete]
         public AnimationCurveData(AnimationUtility.TangentMode tangentMode, glTFAnimationTarget.AnimationPropertys property, int samplerIndex, int elementCount)
+            : this(tangentMode, glTFAnimationTarget.AnimationPropertysToAnimationProperties(property), samplerIndex, elementCount)
+        {
+        }
+
+        public AnimationCurveData(AnimationUtility.TangentMode tangentMode, glTFAnimationTarget.AnimationProperties property, int samplerIndex, int elementCount)
         {
             TangentMode = tangentMode;
             AnimationProperty = property;
@@ -92,25 +99,37 @@ namespace UniGLTF
         /// </summary>
         /// <param name="property"></param>
         /// <returns></returns>
-        private static AnimationKeyframeData GetKeyframeData(glTFAnimationTarget.AnimationPropertys property, int elementCount)
+        [Obsolete]
+        private static AnimationKeyframeData GetKeyframeData(glTFAnimationTarget.AnimationPropertys property,
+            int elementCount)
+        {
+            return GetKeyframeData(glTFAnimationTarget.AnimationPropertysToAnimationProperties(property), elementCount);
+        }
+
+        /// <summary>
+        /// アニメーションプロパティに対応したキーフレームを挿入する
+        /// </summary>
+        /// <param name="property"></param>
+        /// <returns></returns>
+        private static AnimationKeyframeData GetKeyframeData(glTFAnimationTarget.AnimationProperties property, int elementCount)
         {
             switch (property)
             {
-                case glTFAnimationTarget.AnimationPropertys.Translation:
+                case glTFAnimationTarget.AnimationProperties.Translation:
                     return new AnimationKeyframeData(elementCount, (values) =>
                     {
                         var temp = new Vector3(values[0], values[1], values[2]);
                         return temp.ReverseZ().ToArray();
                     });
-                case glTFAnimationTarget.AnimationPropertys.Rotation:
+                case glTFAnimationTarget.AnimationProperties.Rotation:
                     return new AnimationKeyframeData(elementCount, (values) =>
                     {
                         var temp = new Quaternion(values[0], values[1], values[2], values[3]);
                         return temp.ReverseZ().ToArray();
                     });
-                case glTFAnimationTarget.AnimationPropertys.Scale:
+                case glTFAnimationTarget.AnimationProperties.Scale:
                     return new AnimationKeyframeData(elementCount, null);
-                case glTFAnimationTarget.AnimationPropertys.BlendShape:
+                case glTFAnimationTarget.AnimationProperties.BlendShape:
                     return new AnimationKeyframeData(elementCount, null);
                 default:
                     return null;

--- a/Assets/VRM/UniGLTF/Scripts/IO/AnimationExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/AnimationExporter.cs
@@ -63,31 +63,31 @@ namespace UniGLTF
             return nodes.IndexOf(descendant);
         }
 
-        public static glTFAnimationTarget.AnimationPropertys PropertyToTarget(string property)
+        public static glTFAnimationTarget.AnimationProperties PropertyToTarget(string property)
         {
             if (property.StartsWith("m_LocalPosition."))
             {
-                return glTFAnimationTarget.AnimationPropertys.Translation;
+                return glTFAnimationTarget.AnimationProperties.Translation;
             }
             else if (property.StartsWith("localEulerAnglesRaw."))
             {
-                return glTFAnimationTarget.AnimationPropertys.EulerRotation;
+                return glTFAnimationTarget.AnimationProperties.EulerRotation;
             }
             else if (property.StartsWith("m_LocalRotation."))
             {
-                return glTFAnimationTarget.AnimationPropertys.Rotation;
+                return glTFAnimationTarget.AnimationProperties.Rotation;
             }
             else if (property.StartsWith("m_LocalScale."))
             {
-                return glTFAnimationTarget.AnimationPropertys.Scale;
+                return glTFAnimationTarget.AnimationProperties.Scale;
             }
             else if (property.StartsWith("blendShape."))
             {
-                return glTFAnimationTarget.AnimationPropertys.BlendShape;
+                return glTFAnimationTarget.AnimationProperties.BlendShape;
             }
             else
             {
-                return glTFAnimationTarget.AnimationPropertys.NotImplemented;
+                return glTFAnimationTarget.AnimationProperties.NotImplemented;
             }
         }
 
@@ -130,12 +130,12 @@ namespace UniGLTF
                 var curve = AnimationUtility.GetEditorCurve(clip, binding);
 
                 var property = AnimationExporter.PropertyToTarget(binding.propertyName);
-                if (property == glTFAnimationTarget.AnimationPropertys.NotImplemented)
+                if (property == glTFAnimationTarget.AnimationProperties.NotImplemented)
                 {
                     Debug.LogWarning("Not Implemented keyframe property : " + binding.propertyName);
                     continue;
                 }
-                if (property == glTFAnimationTarget.AnimationPropertys.EulerRotation)
+                if (property == glTFAnimationTarget.AnimationProperties.EulerRotation)
                 {
                     Debug.LogWarning("Interpolation setting of AnimationClip should be Quaternion");
                     continue;
@@ -144,7 +144,7 @@ namespace UniGLTF
                 var nodeIndex = GetNodeIndex(root, nodes, binding.path);
                 var samplerIndex = animation.Animation.AddChannelAndGetSampler(nodeIndex, property);
                 var elementCount = 0;
-                if (property == glTFAnimationTarget.AnimationPropertys.BlendShape)
+                if (property == glTFAnimationTarget.AnimationProperties.BlendShape)
                 {
                     var mesh = nodes[nodeIndex].GetComponent<SkinnedMeshRenderer>().sharedMesh;
                     elementCount = mesh.blendShapeCount;
@@ -165,7 +165,7 @@ namespace UniGLTF
                 // 全てのキーフレームを回収
                 int elementOffset = 0;
                 float valueFactor = 1.0f;
-                if (property == glTFAnimationTarget.AnimationPropertys.BlendShape)
+                if (property == glTFAnimationTarget.AnimationProperties.BlendShape)
                 {
                     var mesh = nodes[nodeIndex].GetComponent<SkinnedMeshRenderer>().sharedMesh;
                     var blendShapeName = binding.propertyName.Replace("blendShape.", "");


### PR DESCRIPTION
AnimationPropertiesのtypoを修正しました。互換性の無い変更として、下記の項目の戻り値型がAnimationPropertiesへ変更されます。

- UniGLTF.glTFAnimationTarget.GetAnimationProperty()
- UniGLTF.AnimationCurveData.AnimationProperty 