### PR TITLE
Fix typo (TextureType)

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/Format/glTFMaterial.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTFMaterial.cs
@@ -15,7 +15,7 @@ namespace UniGLTF
 
     public interface IglTFTextureinfo
     {
-        glTFTextureTypes TextreType { get; }
+        glTFTextureTypes TextureType { get; }
     }
 
     [Serializable]
@@ -37,14 +37,14 @@ namespace UniGLTF
             f.KeyValue(() => texCoord);
         }
 
-        public abstract glTFTextureTypes TextreType { get; }
+        public abstract glTFTextureTypes TextureType { get; }
     }
 
 
     [Serializable]
     public class glTFMaterialBaseColorTextureInfo : glTFTextureInfo
     {
-        public override glTFTextureTypes TextreType
+        public override glTFTextureTypes TextureType
         {
             get { return glTFTextureTypes.BaseColor; }
         }
@@ -53,7 +53,7 @@ namespace UniGLTF
     [Serializable]
     public class glTFMaterialMetallicRoughnessTextureInfo : glTFTextureInfo
     {
-        public override glTFTextureTypes TextreType
+        public override glTFTextureTypes TextureType
         {
             get { return glTFTextureTypes.Metallic; }
         }
@@ -70,7 +70,7 @@ namespace UniGLTF
             base.SerializeMembers(f);
         }
 
-        public override glTFTextureTypes TextreType
+        public override glTFTextureTypes TextureType
         {
             get { return glTFTextureTypes.Normal; }
         }
@@ -88,7 +88,7 @@ namespace UniGLTF
             base.SerializeMembers(f);
         }
 
-        public override glTFTextureTypes TextreType
+        public override glTFTextureTypes TextureType
         {
             get { return glTFTextureTypes.Occlusion; }
         }
@@ -97,7 +97,7 @@ namespace UniGLTF
     [Serializable]
     public class glTFMaterialEmissiveTextureInfo : glTFTextureInfo
     {
-        public override glTFTextureTypes TextreType
+        public override glTFTextureTypes TextureType
         {
             get { return glTFTextureTypes.Emissive; }
         }

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureIO.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureIO.cs
@@ -53,7 +53,7 @@ namespace UniGLTF
                 var textureInfo = material.GetTextures().FirstOrDefault(x => (x!=null) && x.index == textureIndex);
                 if (textureInfo != null)
                 {
-                    return textureInfo.TextreType;
+                    return textureInfo.TextureType;
                 }
             }
             return glTFTextureTypes.Unknown;


### PR DESCRIPTION
TextureTypeのtypoを修正しました。interfaceのメンバー名を変更する際、古い名前をObsoleteで残すことができないため単純にリネームしました。仕様変更になります。