### PR TITLE
Fix typo (Base64Embedded)

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/Format/glTF.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTF.cs
@@ -247,7 +247,7 @@ namespace UniGLTF
             {
                 if (image.uri.StartsWith("data:"))
                 {
-                    textureName = !string.IsNullOrEmpty(image.name) ? image.name : string.Format("{0:00}#Base64Embeded", imageIndex);
+                    textureName = !string.IsNullOrEmpty(image.name) ? image.name : string.Format("{0:00}#Base64Embedded", imageIndex);
                 }
                 else
                 {


### PR DESCRIPTION
glTFインポート時に自動命名されるテクスチャー名のtypoを修正しました。仕様変更になります。いちおう修正PRとして出しましたが、テクスチャー名を使って何か処理をしているプログラムが想定される場合はそのままのほうが安全かもしれません。