### PR TITLE
Feature/remove unused blendshape

### DIFF
--- a/Assets/VRM/UniVRM/Scripts/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMExportSettings.cs
@@ -298,7 +298,6 @@ namespace VRM
                             for (int i = 0; i < blendShapeClipSize; i++)
                             {
                                 var clip = proxy.BlendShapeAvatar.Clips[i];
-                                Debug.LogFormat("[SPORADIC-E] name {0}:", clip.BlendShapeName);
                                 for(int j = 0; j < clip.Values.Length; j++) {
                                     if(clip.Values[j].RelativePath == child.name) isUsedInBlendShape[clip.Values[j].Index] = true;
                                 }

--- a/Assets/VRM/UniVRM/Scripts/SkinnedMeshUtility/MeshExtensions.cs
+++ b/Assets/VRM/UniVRM/Scripts/SkinnedMeshUtility/MeshExtensions.cs
@@ -26,7 +26,7 @@ namespace VRM
                 list[i] = true;
               }
             }
-            return CopyWithSelectedBlendShape(src, null);
+            return CopyWithSelectedBlendShape(src, list);
         }
 
 

--- a/Assets/VRM/UniVRM/Scripts/SkinnedMeshUtility/MeshExtensions.cs
+++ b/Assets/VRM/UniVRM/Scripts/SkinnedMeshUtility/MeshExtensions.cs
@@ -7,6 +7,30 @@ namespace VRM
     public static class MeshExtensions
     {
         public static Mesh Copy(this Mesh src, bool copyBlendShape)
+        {   
+            bool[] list = new bool[src.blendShapeCount];
+            for(int i = 0; i<list.Length; i++) {
+                list[i] = copyBlendShape;
+            }
+            return CopyWithSelectedBlendShape(src, list);
+        }
+
+
+        public static Mesh RemoveBlendShapeByIndex(this Mesh src, int index)
+        {
+            bool[] list = new bool[src.blendShapeCount];
+            for(int i = 0; i<list.Length; i++) {
+              if(i == index) {
+                list[i] = false;
+              }else{
+                list[i] = true;
+              }
+            }
+            return CopyWithSelectedBlendShape(src, null);
+        }
+
+
+        public static Mesh CopyWithSelectedBlendShape(this Mesh src, bool[] clist)
         {
             var dst = new Mesh();
             dst.name = src.name + "(copy)";
@@ -33,7 +57,7 @@ namespace VRM
 
             dst.RecalculateBounds();
 
-            if (copyBlendShape)
+            if (clist != null)
             {
                 var vertices = src.vertices;
                 var normals = src.normals;
@@ -45,14 +69,17 @@ namespace VRM
 
                 for (int i = 0; i < src.blendShapeCount; ++i)
                 {
-                    src.GetBlendShapeFrameVertices(i, 0, vertices, normals, tangents);
-                    dst.AddBlendShapeFrame(
-                        src.GetBlendShapeName(i),
-                        src.GetBlendShapeFrameWeight(i, 0),
-                        vertices,
-                        normals,
-                        tangents
-                        );
+                    if(clist[i])
+                    {
+                        src.GetBlendShapeFrameVertices(i, 0, vertices, normals, tangents);
+                        dst.AddBlendShapeFrame(
+                            src.GetBlendShapeName(i),
+                            src.GetBlendShapeFrameWeight(i, 0),
+                            vertices,
+                            normals,
+                            tangents
+                            );
+                    }
                 }
             }
 


### PR DESCRIPTION
#295 BlendShapeProxyで使われているBlendShapeを走査し，出力時に元のMeshから不使用なものを削除して出力するオプション「Remove Unused Blend Shapes」を追加しました．
![image](https://user-images.githubusercontent.com/13936540/61987493-0b020780-b052-11e9-93e7-3eeaddf9765f.png)
破壊的編集なので，最終出力時に利用者が任意で適応する形を想定しています．