### PR TITLE
add VRM Export Option. Reduce BlendShape Size

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
@@ -113,7 +113,8 @@ namespace UniGLTF
             var usePosition = blendShapeVertices != null && blendShapeVertices.Length > 0;
 
             var blendShapeNormals = mesh.normals;
-            var useNormal = usePosition && blendShapeNormals != null && blendShapeNormals.Length == blendShapeVertices.Length && !exportOnlyBlendShapePosition;
+            var useNormal = usePosition && blendShapeNormals != null && blendShapeNormals.Length == blendShapeVertices.Length;
+            // var useNormal = usePosition && blendShapeNormals != null && blendShapeNormals.Length == blendShapeVertices.Length && !exportOnlyBlendShapePosition;
 
             var blendShapeTangents = mesh.tangents.Select(y => (Vector3)y).ToArray();
             //var useTangent = usePosition && blendShapeTangents != null && blendShapeTangents.Length == blendShapeVertices.Length;

--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
@@ -106,13 +106,14 @@ namespace UniGLTF
 
         static gltfMorphTarget ExportMorphTarget(glTF gltf, int bufferIndex,
             Mesh mesh, int j,
-            bool useSparseAccessorForMorphTarget)
+            bool useSparseAccessorForMorphTarget,
+            bool exportOnlyBlendShapePosition)
         {
             var blendShapeVertices = mesh.vertices;
             var usePosition = blendShapeVertices != null && blendShapeVertices.Length > 0;
 
             var blendShapeNormals = mesh.normals;
-            var useNormal = usePosition && blendShapeNormals != null && blendShapeNormals.Length == blendShapeVertices.Length;
+            var useNormal = usePosition && blendShapeNormals != null && blendShapeNormals.Length == blendShapeVertices.Length && exportOnlyBlendShapePosition;
 
             var blendShapeTangents = mesh.tangents.Select(y => (Vector3)y).ToArray();
             //var useTangent = usePosition && blendShapeTangents != null && blendShapeTangents.Length == blendShapeVertices.Length;
@@ -228,7 +229,8 @@ namespace UniGLTF
 
         public static void ExportMeshes(glTF gltf, int bufferIndex,
             List<MeshWithRenderer> unityMeshes, List<Material> unityMaterials,
-            bool useSparseAccessorForMorphTarget)
+            bool useSparseAccessorForMorphTarget,
+            bool exportOnlyBlendShapePosition)
         {
             for (int i = 0; i < unityMeshes.Count; ++i)
             {
@@ -244,7 +246,8 @@ namespace UniGLTF
                 {
                     var morphTarget = ExportMorphTarget(gltf, bufferIndex,
                         mesh, j,
-                        useSparseAccessorForMorphTarget);
+                        useSparseAccessorForMorphTarget,
+                        exportOnlyBlendShapePosition);
 
                     //
                     // all primitive has same blendShape

--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
@@ -113,7 +113,7 @@ namespace UniGLTF
             var usePosition = blendShapeVertices != null && blendShapeVertices.Length > 0;
 
             var blendShapeNormals = mesh.normals;
-            var useNormal = usePosition && blendShapeNormals != null && blendShapeNormals.Length == blendShapeVertices.Length && exportOnlyBlendShapePosition;
+            var useNormal = usePosition && blendShapeNormals != null && blendShapeNormals.Length == blendShapeVertices.Length && !exportOnlyBlendShapePosition;
 
             var blendShapeTangents = mesh.tangents.Select(y => (Vector3)y).ToArray();
             //var useTangent = usePosition && blendShapeTangents != null && blendShapeTangents.Length == blendShapeVertices.Length;

--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshImporter.cs
@@ -450,7 +450,7 @@ namespace UniGLTF
                         {
                             mesh.AddBlendShapeFrame(blendShape.Name, FRAME_WEIGHT,
                                 blendShape.Positions.ToArray(),
-                                (meshContext.normals != null && meshContext.normals.Length == mesh.vertexCount) ? blendShape.Normals.ToArray() : null,
+                                (meshContext.normals != null && meshContext.normals.Length == mesh.vertexCount && blendShape.Normals.Count() == blendShape.Positions.Count()) ? blendShape.Normals.ToArray() : null,
                                 null
                                 );
                         }

--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshImporter.cs
@@ -450,7 +450,7 @@ namespace UniGLTF
                         {
                             mesh.AddBlendShapeFrame(blendShape.Name, FRAME_WEIGHT,
                                 blendShape.Positions.ToArray(),
-                                (meshContext.normals != null && meshContext.normals.Length == mesh.vertexCount && blendShape.Normals.Count() == blendShape.Positions.Count()) ? blendShape.Normals.ToArray() : null,
+                                (meshContext.normals != null && meshContext.normals.Length == mesh.vertexCount) ? blendShape.Normals.ToArray() : null,
                                 null
                                 );
                         }

--- a/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
@@ -60,6 +60,12 @@ namespace UniGLTF
             set;
         }
 
+        public bool ExportOnlyBlendShapePosition
+        {
+            get;
+            set;
+        }
+
         public GameObject Copy
         {
             get;
@@ -240,7 +246,7 @@ namespace UniGLTF
                         return true;
                     })
                     .ToList();
-                MeshExporter.ExportMeshes(gltf, bufferIndex, unityMeshes, Materials, useSparseAccessorForMorphTarget);
+                MeshExporter.ExportMeshes(gltf, bufferIndex, unityMeshes, Materials, useSparseAccessorForMorphTarget, ExportOnlyBlendShapePosition);
                 Meshes = unityMeshes.Select(x => x.Mesh).ToList();
                 #endregion
 

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMExportSettings.cs
@@ -6,6 +6,7 @@ using UniGLTF;
 using System.IO;
 #if UNITY_EDITOR
 using UnityEditor;
+
 #endif
 
 
@@ -25,6 +26,8 @@ namespace VRM
         public bool PoseFreeze = true;
 
         public bool UseExperimentalExporter = true;
+
+        public bool ReduceBlendshapeSize = false;
 
         public IEnumerable<string> CanExport()
         {
@@ -152,6 +155,7 @@ namespace VRM
                     {
                         dst.m_center = map[src.m_center];
                     }
+
                     dst.RootBones = src.RootBones.Select(x => map[x]).ToList();
                     dst.m_hitRadius = src.m_hitRadius;
                     if (src.ColliderGroups != null)
@@ -271,7 +275,7 @@ namespace VRM
 
             {
                 var sw = System.Diagnostics.Stopwatch.StartNew();
-                var vrm = VRMExporter.Export(target);
+                var vrm = VRMExporter.Export(target, ReduceBlendshapeSize);
                 vrm.extensions.VRM.meta.title = Title;
                 vrm.extensions.VRM.meta.author = Author;
 

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMExportSettings.cs
@@ -372,7 +372,11 @@ namespace VRM
                 Debug.LogFormat("Export elapsed {0}", sw.Elapsed);
             }
 
+#if UNITY_2018_3_OR_NEWER
+            PrefabUtility.RevertPrefabInstance(target, InteractionMode.AutomatedAction);
+#else
             PrefabUtility.RevertPrefabInstance(target);
+#endif
 
             if (path.StartsWithUnityAssetPath())
             {

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMExporter.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMExporter.cs
@@ -19,7 +19,7 @@ namespace VRM
             gltf.extensions.VRM = new glTF_VRM_extensions();
         }
 
-        public new static glTF Export(GameObject go)
+        public new static glTF Export(GameObject go, bool exportOnlyBlendShapePosition = false)
         {
             var gltf = new glTF();
 
@@ -27,12 +27,14 @@ namespace VRM
             {
 #if VRM_EXPORTER_USE_SPARSE
                 // experimental
-                UseSparseAccessorForBlendShape=true
+                UseSparseAccessorForBlendShape = true
 #endif
+                ExportOnlyBlendShapePosition = exportOnlyBlendShapePosition
             })
             {
                 _Export(gltf, exporter, go);
             }
+
             return gltf;
         }
 
@@ -60,6 +62,7 @@ namespace VRM
                         // use description
                         gltf.extensions.VRM.humanoid.Apply(description, nodes);
                     }
+
                     if (isCreated)
                     {
                         GameObject.DestroyImmediate(description);
@@ -119,6 +122,7 @@ namespace VRM
                     {
                         gltf.extensions.VRM.meta.texture = TextureIO.ExportTexture(gltf, gltf.buffers.Count - 1, meta.Thumbnail, glTFTextureTypes.Unknown);
                     }
+
                     gltf.extensions.VRM.meta.licenseType = meta.LicenseType;
                     gltf.extensions.VRM.meta.otherLicenseUrl = meta.OtherLicenseUrl;
                     gltf.extensions.VRM.meta.reference = meta.Reference;


### PR DESCRIPTION
https://github.com/vrm-c/UniVRM/issues/295 

~VRMExportする際にBlendShapeの法線・接線データを削るオプションを追加しました。
接線データはもともと含まれていなかったので、チェックを入れた場合、法線データが含まれないようになります。~
古いverのUniVRMのImporterとの互換性がなくなるため、法線削除は一時的に塞ぎました。
使っていないBlendShapeの削除のみ行うようにしています。


![image](https://user-images.githubusercontent.com/44762673/63846509-eb4e5e00-c9c6-11e9-8779-99be67d7caec.png)
