### PR TITLE
suppress blendshape gabage collection

### DIFF
--- a/Assets/VRM/UniVRM/Editor/Tests/VRMBlendShapeKeyTest.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/VRMBlendShapeKeyTest.cs
@@ -12,16 +12,31 @@ namespace VRM
         {
             var key = new BlendShapeKey("Blink", BlendShapePreset.Blink);
 
-            Assert.AreEqual(key, new BlendShapeKey("blink"));
+            Assert.AreEqual(key, new BlendShapeKey("Blink", BlendShapePreset.Blink));
             Assert.AreEqual(key, new BlendShapeKey(BlendShapePreset.Blink));
             Assert.AreEqual(key, new BlendShapeKey("xxx", BlendShapePreset.Blink));
 
             var dict = new Dictionary<BlendShapeKey, float>();
-            dict[new BlendShapeKey("xxx", BlendShapePreset.Blink)] = 1.0f;
+            dict[key] = 1.0f;
 
-            Assert.IsTrue(dict.ContainsKey(new BlendShapeKey("blink")));
+            Assert.IsTrue(dict.ContainsKey(new BlendShapeKey("Blink",BlendShapePreset.Blink)));
             Assert.IsTrue(dict.ContainsKey(new BlendShapeKey(BlendShapePreset.Blink)));
             Assert.IsTrue(dict.ContainsKey(new BlendShapeKey("xxx", BlendShapePreset.Blink)));
+            
+            dict.Clear();
+            
+            var key2 = new BlendShapeKey("Blink"); // name: Blink, Preset: Unknown
+            dict[key2] = 1.0f;
+            
+            Assert.AreEqual( key2, new BlendShapeKey("Blink", BlendShapePreset.Unknown));
+            Assert.AreNotEqual(key2, new BlendShapeKey("blink"));
+            Assert.AreNotEqual(key2, new BlendShapeKey("Blink", BlendShapePreset.Blink));
+            Assert.AreNotEqual(key2, new BlendShapeKey(BlendShapePreset.Blink));
+            
+            Assert.IsFalse(dict.ContainsKey(new BlendShapeKey("blink")));
+            Assert.IsFalse(dict.ContainsKey(new BlendShapeKey("Blink",BlendShapePreset.Blink)));
+            Assert.IsFalse(dict.ContainsKey(new BlendShapeKey(BlendShapePreset.Blink)));
+            
         }
     }
 }

--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 
 namespace VRM
@@ -6,11 +7,20 @@ namespace VRM
     [Serializable]
     public struct BlendShapeKey : IEquatable<BlendShapeKey>, IComparable<BlendShapeKey>
     {
-        public string Name;
+        // Enum.ToString() のGC回避用キャッシュ
+        private static readonly Dictionary<BlendShapePreset, string> m_presetNameDictionary =
+            new Dictionary<BlendShapePreset, string>();
+
+        private string m_name;
+        public string Name
+        {
+            get { return m_name.ToUpper(); }
+        }
+
         public BlendShapePreset Preset;
 
         string m_id;
-        string ID
+        private string ID
         {
             get
             {
@@ -18,13 +28,22 @@ namespace VRM
                 {
                     if (Preset != BlendShapePreset.Unknown)
                     {
-                        m_id = Preset.ToString().ToUpper();
+                        if (m_presetNameDictionary.ContainsKey(Preset))
+                        {
+                            m_id = m_presetNameDictionary[Preset];
+                        }
+                        else
+                        {
+                            m_presetNameDictionary.Add(Preset, Preset.ToString());
+                            m_id = m_presetNameDictionary[Preset];
+                        }
                     }
                     else
                     {
-                        m_id = Name;
+                        m_id = m_name;
                     }
                 }
+
                 return m_id;
             }
         }
@@ -39,33 +58,42 @@ namespace VRM
 
         public BlendShapeKey(string name, BlendShapePreset preset)
         {
-            Name = name.ToUpper();
+            m_name = name;
             Preset = preset;
+
             if (Preset != BlendShapePreset.Unknown)
             {
-                m_id = Preset.ToString().ToUpper();
+                if (m_presetNameDictionary.ContainsKey((Preset)))
+                {
+                    m_id = m_presetNameDictionary[Preset];
+                }
+                else
+                {
+                    m_presetNameDictionary.Add(Preset, Preset.ToString());
+                    m_id = m_presetNameDictionary[Preset];
+                }
             }
             else
             {
-                m_id = Name;
+                m_id = m_name;
             }
         }
 
         public override string ToString()
         {
-            return ID;
+            return ID.ToUpper();
         }
 
         public bool Equals(BlendShapeKey other)
         {
-            return ID == other.ID;
+            return String.Compare(ID, other.ID, StringComparison.OrdinalIgnoreCase) == 0;
         }
 
         public override bool Equals(object obj)
         {
             if (obj is BlendShapeKey)
             {
-                return Equals((BlendShapeKey)obj);
+                return Equals((BlendShapeKey) obj);
             }
             else
             {
@@ -84,6 +112,7 @@ namespace VRM
             {
                 return default(BlendShapeKey);
             }
+
             return new BlendShapeKey(clip.BlendShapeName, clip.Preset);
         }
 

--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
@@ -1,19 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-
 
 namespace VRM
 {
     [Serializable]
     public struct BlendShapeKey : IEquatable<BlendShapeKey>, IComparable<BlendShapeKey>
     {
-        // Enum.ToString() のGC回避用キャッシュ
+        /// <summary>
+        /// Enum.ToString() のGC回避用キャッシュ
+        /// </summary>
         private static readonly Dictionary<BlendShapePreset, string> m_presetNameDictionary =
             new Dictionary<BlendShapePreset, string>();
 
+
+        /// <summary>
+        ///  BlendShapePresetと同名の名前を持つ独自に追加したBlendShapeを区別するためのprefix
+        /// </summary>
         private static readonly string UnknownPresetPrefix = "Unknown_";
-        
+
         private string m_name;
 
         public string Name
@@ -24,6 +28,7 @@ namespace VRM
         public BlendShapePreset Preset;
 
         string m_id;
+
         string ID
         {
             get
@@ -81,12 +86,12 @@ namespace VRM
 
         public override string ToString()
         {
-            return ID.Replace(UnknownPresetPrefix,"").ToUpper();
+            return ID.Replace(UnknownPresetPrefix, "").ToUpper();
         }
 
         public bool Equals(BlendShapeKey other)
         {
-            return this.ID == other.ID;
+            return ID == other.ID;
         }
 
         public override bool Equals(object obj)

--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 
 namespace VRM
@@ -12,6 +13,9 @@ namespace VRM
             new Dictionary<BlendShapePreset, string>();
 
         private string m_name;
+
+        private const string UnknownPresetPrefix = "Unknown_";
+        
         public string Name
         {
             get { return m_name.ToUpper(); }
@@ -19,8 +23,8 @@ namespace VRM
 
         public BlendShapePreset Preset;
 
-        string m_id;
-        private string ID
+        public string m_id;
+        public string ID
         {
             get
             {
@@ -40,7 +44,7 @@ namespace VRM
                     }
                     else
                     {
-                        m_id = m_name;
+                        m_id = UnknownPresetPrefix + m_name;
                     }
                 }
 
@@ -75,7 +79,7 @@ namespace VRM
             }
             else
             {
-                m_id = m_name;
+                m_id = UnknownPresetPrefix + m_name;
             }
         }
 

--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
@@ -12,10 +12,10 @@ namespace VRM
         private static readonly Dictionary<BlendShapePreset, string> m_presetNameDictionary =
             new Dictionary<BlendShapePreset, string>();
 
+        private static readonly string UnknownPresetPrefix = "Unknown_";
+        
         private string m_name;
 
-        private const string UnknownPresetPrefix = "Unknown_";
-        
         public string Name
         {
             get { return m_name.ToUpper(); }
@@ -23,8 +23,8 @@ namespace VRM
 
         public BlendShapePreset Preset;
 
-        public string m_id;
-        public string ID
+        string m_id;
+        string ID
         {
             get
             {
@@ -52,15 +52,11 @@ namespace VRM
             }
         }
 
-        public BlendShapeKey(string name) : this(name, BlendShapePreset.Unknown)
+        public BlendShapeKey(BlendShapePreset preset) : this(preset.ToString(), preset)
         {
         }
 
-        public BlendShapeKey(BlendShapePreset preset) : this(preset.ToString(), BlendShapePreset.Unknown)
-        {
-        }
-
-        public BlendShapeKey(string name, BlendShapePreset preset)
+        public BlendShapeKey(string name, BlendShapePreset preset = BlendShapePreset.Unknown)
         {
             m_name = name;
             Preset = preset;
@@ -85,12 +81,12 @@ namespace VRM
 
         public override string ToString()
         {
-            return ID.ToUpper();
+            return ID.Replace(UnknownPresetPrefix,"").ToUpper();
         }
 
         public bool Equals(BlendShapeKey other)
         {
-            return String.Compare(ID, other.ID, StringComparison.OrdinalIgnoreCase) == 0;
+            return this.ID == other.ID;
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
BlendShapeKeyクラスで頻繁に発生していたGCを低減
`string.ToUpper()` , `Enum.ToString() `  を呼び出す頻度が少なくなるように修正

この変更により一部挙動が以下のように変わります。
- BlendShapeKeyのNameが`Blink` のような定義済みPresetと同名であれば、Preset=BlendShapePreset.BlinkのBlendShapeKeyと同一と見なせていたものが別扱いになる

- NameがToUpper()によって大文字と小文字の区別がされていなかったものが区別されるようになる


