### PR TITLE
Unity2019 asset pipeline v2 support

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
@@ -892,12 +892,21 @@ namespace UniGLTF
             {
                 Debug.LogFormat("replace prefab: {0}", prefabPath);
                 var prefab = prefabPath.LoadAsset<GameObject>();
+#if UNITY_2018_3_OR_NEWER
+                PrefabUtility.SaveAsPrefabAssetAndConnect(Root, prefabPath.Value, InteractionMode.AutomatedAction);
+#else
                 PrefabUtility.ReplacePrefab(Root, prefab, ReplacePrefabOptions.ReplaceNameBased);
+#endif
+
             }
             else
             {
                 Debug.LogFormat("create prefab: {0}", prefabPath);
+#if UNITY_2018_3_OR_NEWER
+                PrefabUtility.SaveAsPrefabAssetAndConnect(Root, prefabPath.Value, InteractionMode.AutomatedAction);
+#else
                 PrefabUtility.CreatePrefab(prefabPath.Value, Root);
+#endif
             }
             foreach (var x in paths)
             {

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMImporterContext.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMImporterContext.cs
@@ -370,6 +370,24 @@ namespace VRM
                 var assetPath = dir.Child(o.name.EscapeFilePath() + ".asset");
                 return assetPath;
             }
+            else if (o is Avatar)
+            {
+                var dir = prefabPath.GetAssetFolder(".Avatar");
+                var assetPath = dir.Child(o.name.EscapeFilePath() + ".asset");
+                return assetPath;
+            }
+            else if (o is VRMMetaObject)
+            {
+                var dir = prefabPath.GetAssetFolder(".MetaObject");
+                var assetPath = dir.Child(o.name.EscapeFilePath() + ".asset");
+                return assetPath;
+            }
+            else if (o is UniHumanoid.AvatarDescription)
+            {
+                var dir = prefabPath.GetAssetFolder(".AvatarDescription");
+                var assetPath = dir.Child(o.name.EscapeFilePath() + ".asset");
+                return assetPath;
+            }
             else
             {
                 return base.GetAssetPath(prefabPath, o);


### PR DESCRIPTION
Prefab SubAsset had an error in AssetPipeline v2, so the following measures were taken
* SubAsset is deprecated
* Use SaveAsPrefabAssetAndConnect
* What was SubAsset is expanded to each directory
![image (1)](https://user-images.githubusercontent.com/39366194/70429837-ccc72b00-1abc-11ea-85a0-1e35e31a2db4.png)

issue
#292 #294 #321