### PR TITLE
Fix: empty gltfNode children export empty array

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
@@ -168,6 +168,10 @@ namespace UniGLTF
                 scale = x.transform.localScale.ToArray(),
             };
 
+            if (node.children.Length == 0) {
+                node.children = null;
+            }
+
             if (x.gameObject.activeInHierarchy)
             {
                 var meshRenderer = x.GetComponent<MeshRenderer>();


### PR DESCRIPTION
fix export VRM is invalid gltf format, when gltfNode has empty children

https://github.com/vrm-c/UniVRM/issues/350