### PR TITLE
Check bone names duplicate when export vrm file.

### DIFF
--- a/Assets/VRM/UniVRM/Scripts/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMExportSettings.cs
@@ -60,7 +60,12 @@ namespace VRM
             {
                 yield return "Animator.avatar is not humanoid. Please change model's AnimationType to humanoid. ";
             }
-
+            
+            if (DuplicateBoneNameExists())
+            {
+                yield return "Find duplicate Bone names. Please check model's bone names. ";
+            }
+            
             if (string.IsNullOrEmpty(Title))
             {
                 yield return "Require Title. ";
@@ -401,6 +406,18 @@ namespace VRM
             {
                 AssetDatabase.ImportAsset(path.ToUnityRelativePath());
             }
+        }
+
+        //ここで重複ボーン名のチェックをする
+        bool DuplicateBoneNameExists()
+        {
+            var bones = Source.transform.Traverse().ToArray();
+            var duplicates = bones
+                .GroupBy(p => p.name)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key);
+            
+            return (duplicates.Any());
         }
 #endif
     }


### PR DESCRIPTION
solve 
https://github.com/vrm-c/UniVRM/issues/376

UnityEditor上からのvrm Export時に同名boneを含めたまま出力できてしまうと、ランタイムインポートも動かない場合が多いのでチェックを追加しました。

vrm-specificationで定義されている1.0のglTF Schemaにもnameはユニークを要求しているので規格にも合致する実装だと考えています。

https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_vrm-1.0_draft#naming-restrictions