### PR TITLE
Fix: Large heap allocation in BoneMeshEraser.ExcludeTriangles

### DIFF
--- a/Assets/VRM/UniVRM/Scripts/SkinnedMeshUtility/BoneMeshEraser.cs
+++ b/Assets/VRM/UniVRM/Scripts/SkinnedMeshUtility/BoneMeshEraser.cs
@@ -8,6 +8,22 @@ namespace VRM
 {
     public static class BoneMeshEraser
     {
+        private struct ExcludeBoneIndex
+        {
+            public readonly bool Bone0;
+            public readonly bool Bone1;
+            public readonly bool Bone2;
+            public readonly bool Bone3;
+
+            public ExcludeBoneIndex(bool bone0, bool bone1, bool bone2, bool bone3)
+            {
+                Bone0 = bone0;
+                Bone1 = bone1;
+                Bone2 = bone2;
+                Bone3 = bone3;
+            }
+        }
+
         [Serializable]
         public struct EraseBone
         {
@@ -23,7 +39,7 @@ namespace VRM
         static int ExcludeTriangles(int[] triangles, BoneWeight[] bws, int[] exclude)
         {
             int count = 0;
-            if (bws != null && bws.Length>0)
+            if (bws != null && bws.Length > 0)
             {
                 for (int i = 0; i < triangles.Length; i += 3)
                 {
@@ -33,24 +49,27 @@ namespace VRM
 
                     {
                         var bw = bws[a];
-                        if (bw.weight0 > 0 && exclude.Contains(bw.boneIndex0)) continue;
-                        if (bw.weight1 > 0 && exclude.Contains(bw.boneIndex1)) continue;
-                        if (bw.weight2 > 0 && exclude.Contains(bw.boneIndex2)) continue;
-                        if (bw.weight3 > 0 && exclude.Contains(bw.boneIndex3)) continue;
+                        var eb = AreBoneContains(ref exclude, bw.boneIndex0, bw.boneIndex1, bw.boneIndex2, bw.boneIndex3);
+                        if (bw.weight0 > 0 && eb.Bone0) continue;
+                        if (bw.weight1 > 0 && eb.Bone1) continue;
+                        if (bw.weight2 > 0 && eb.Bone2) continue;
+                        if (bw.weight3 > 0 && eb.Bone3) continue;
                     }
                     {
                         var bw = bws[b];
-                        if (bw.weight0 > 0 && exclude.Contains(bw.boneIndex0)) continue;
-                        if (bw.weight1 > 0 && exclude.Contains(bw.boneIndex1)) continue;
-                        if (bw.weight2 > 0 && exclude.Contains(bw.boneIndex2)) continue;
-                        if (bw.weight3 > 0 && exclude.Contains(bw.boneIndex3)) continue;
+                        var eb = AreBoneContains(ref exclude, bw.boneIndex0, bw.boneIndex1, bw.boneIndex2, bw.boneIndex3);
+                        if (bw.weight0 > 0 && eb.Bone0) continue;
+                        if (bw.weight1 > 0 && eb.Bone1) continue;
+                        if (bw.weight2 > 0 && eb.Bone2) continue;
+                        if (bw.weight3 > 0 && eb.Bone3) continue;
                     }
                     {
                         var bw = bws[c];
-                        if (bw.weight0 > 0 && exclude.Contains(bw.boneIndex0)) continue;
-                        if (bw.weight1 > 0 && exclude.Contains(bw.boneIndex1)) continue;
-                        if (bw.weight2 > 0 && exclude.Contains(bw.boneIndex2)) continue;
-                        if (bw.weight3 > 0 && exclude.Contains(bw.boneIndex3)) continue;
+                        var eb = AreBoneContains(ref exclude, bw.boneIndex0, bw.boneIndex1, bw.boneIndex2, bw.boneIndex3);
+                        if (bw.weight0 > 0 && eb.Bone0) continue;
+                        if (bw.weight1 > 0 && eb.Bone1) continue;
+                        if (bw.weight2 > 0 && eb.Bone2) continue;
+                        if (bw.weight3 > 0 && eb.Bone3) continue;
                     }
 
                     triangles[count++] = a;
@@ -58,7 +77,44 @@ namespace VRM
                     triangles[count++] = c;
                 }
             }
+
             return count;
+        }
+
+        private static ExcludeBoneIndex AreBoneContains(ref int[] exclude, int boneIndex0, int boneIndex1,
+            int boneIndex2, int boneIndex3)
+        {
+            var b0 = false;
+            var b1 = false;
+            var b2 = false;
+            var b3 = false;
+            for (int i = 0; i < exclude.Length; i++)
+            {
+                if (exclude[i] == boneIndex0)
+                {
+                    b0 = true;
+                    continue;
+                }
+
+                if (exclude[i] == boneIndex1)
+                {
+                    b1 = true;
+                    continue;
+                }
+
+                if (exclude[i] == boneIndex2)
+                {
+                    b2 = true;
+                    continue;
+                }
+
+                if (exclude[i] == boneIndex3)
+                {
+                    b3 = true;
+                }
+            }
+
+            return new ExcludeBoneIndex(b0, b1, b2, b3);
         }
 
         public static Mesh CreateErasedMesh(Mesh src, int[] eraseBoneIndices)


### PR DESCRIPTION
頂点数が多いモデルを読み込んだ時に、`BoneMeshEraser.ExcludeTriangles`内で大量のヒープアロケートが発生していたので対処しました。

対策前
![image](https://user-images.githubusercontent.com/861868/79315321-b4b95980-7f3d-11ea-8e7f-c6c4686a36cd.png)


対策後
![image](https://user-images.githubusercontent.com/861868/79315047-7f147080-7f3d-11ea-89df-41af5d71ea7e.png)

