### PR TITLE
Fix blendshape uppercase bug.

### DIFF
--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
@@ -22,7 +22,7 @@ namespace VRM
 
         public string Name
         {
-            get { return m_name.ToUpper(); }
+            get { return m_name; }
         }
 
         public BlendShapePreset Preset;


### PR DESCRIPTION
#330 で行われた破壊的変更により独自に設定したキーがモデルからキーの一覧を取得した際に大文字で返ってくるため、小文字で設定したキーの適用が不可能になっていた問題を修正しました。

また、この時の変更によりデフォルトのJOYやFUN等のキーが文字列での指定をすることが不可能になってしまったため、アプリ開発者側で変更が必要になっています。
以前`new BlendShapeKey("JOY")`はBlendShapePreset.Joyを指していましたが、
BlendShapePreset.Unknownの名前がJOYのキーを指すようになってしまっています。
(標準のキーはEnumでの指定しか出来ないようにした仕様変更と理解していますが、意図したものかの確認をお願いします。)

テストコード
```csharp
using System;
using System.Collections;
using System.Collections.Generic;
using System.Linq;
using UnityEngine;
using VRM;

public class UniVRMTest : MonoBehaviour
{

    [SerializeField]
    private VRMBlendShapeProxy proxy;

    private List<string> keyList;

    // Start is called before the first frame update
    void Start()
    {
        keyList = proxy.BlendShapeAvatar.Clips.Select(d => BlendShapeKey.CreateFrom(d).Name).ToList();

        foreach (var key in keyList)
        {
            Debug.Log($"BlendShapeKey:{key}");
        }
    }

    public Vector2 scrollPosition = Vector2.zero;

    private void OnGUI()
    {
        int width = 200, height = 30, left = 30, top = 30, margin = 5;

        scrollPosition = GUI.BeginScrollView(new Rect(10, 10, width + left * 2 + 20, Screen.height - top * 2), scrollPosition, new Rect(0, 0, width + left * 2 + 10, top * 2 + (height + margin) * keyList.Count));
        foreach (var key in keyList)
        {
            if (GUI.Button(new Rect(left, top, width, height), key))
            {
                SetBlendShapeKey(key);
            }
            top += height + margin;
        }
        GUI.EndScrollView();
    }

    private void SetBlendShapeKey(string key)
    {
        foreach(var keyName in keyList)
        {
            BlendShapeAccumulate(keyName, 0.0f);
        }
        BlendShapeAccumulate(key, 1.0f);
        proxy.Apply();
    }
    private void BlendShapeAccumulate(string key,float value)
    {
        var preset = BlendShapePreset.Unknown;
        foreach (BlendShapePreset p in Enum.GetValues(typeof(BlendShapePreset)))
        {
            if (p.ToString() == key)
            {
                preset = p;
                break;
            }
        }
        var blendShapeKey = new BlendShapeKey(key, preset);
        proxy.AccumulateValue(blendShapeKey, value);
    }

    // Update is called once per frame
    void Update()
    {

    }
}
```
このテストコードではすべてのBlendShapeKeyを文字列で列挙
`proxy.BlendShapeAvatar.Clips.Select(d => BlendShapeKey.CreateFrom(d).Name).ToList()`
し、ボタンでその表情に変更するサンプルです。
しかし、標準の表情はNameで取得できるにもかかわらず、`new BlendShapeKey(Name)`をしてしまうと、`Unknown_`が付加されてしまうため、`Enum.GetValues(typeof(BlendShapePreset))`から同名のキーを見つけた際にそちらを利用しています(0.53までの動作を再現するのに必要なコードです)。

テストに使用したVRMモデル：
[8801565727279527051.zip](https://github.com/vrm-c/UniVRM/files/4639068/8801565727279527051.zip)
テスト用に"TEST1","Test2","test3"のBlendShapeKeyが追加されたモデルです。
大文字のみ、大文字小文字、小文字のみのキーです。
0.53以前は全て大文字として扱われ動作します。
0.55では大文字小文字を区別するが、Nameを取得するとToUpperで返されるため、TEST1しか動作しません。

テストコードを実行した画面：
![image](https://user-images.githubusercontent.com/30430584/82128029-bdc67080-97f2-11ea-8668-e326598a4d59.png)

現在UniVRM0.55を利用して同じ動作をさせるためにprivateなm_nameをリフレクションして取得するコードがすでに作られているので取り込んでいただけると助かります。

よろしくおねがいします