### PR TITLE
Fix export nonactive mesh

### DIFF
--- a/Assets/VRM/UniVRM/Editor/Format/VRMExporterMenu.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExporterMenu.cs
@@ -25,6 +25,18 @@ namespace VRM
             wiz.OnWizardUpdate();
         }
 
+        void OnEnable()
+        {
+            // Debug.Log("OnEnable");
+            EditorApplication.hierarchyWindowChanged += OnWizardUpdate;
+        }
+
+        void OnDisable()
+        {
+            // Debug.Log("OnDisable");
+            EditorApplication.hierarchyWindowChanged -= OnWizardUpdate;
+        }
+
         void OnWizardCreate()
         {
             // save dialog

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMExportSettings.cs
@@ -83,6 +83,11 @@ namespace VRM
             {
                 yield return "ReduceBlendshapeSize is need VRMBlendShapeProxy, you need to convert to VRM once.";
             }
+
+            if(Source.GetComponentsInChildren<Renderer>().All(x => !x.gameObject.activeInHierarchy))
+            {
+                yield return "No active mesh";
+            }
         }
 
         public void InitializeFrom(GameObject go)

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRMExtensions.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRMExtensions.cs
@@ -55,7 +55,7 @@ namespace VRM
                     var bind = Create(transform, meshes, value);
                     if (bind == null)
                     {
-                        Debug.LogFormat("{0}: skip blendshapebind", clip.name);
+                        // Debug.LogFormat("{0}: skip blendshapebind", clip.name);
                         continue;
                     }
                     list.Add(bind);

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRMExtensions.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRMExtensions.cs
@@ -19,8 +19,22 @@ namespace VRM
         {
             var transform = UniGLTF.UnityExtensions.GetFromPath(root.transform, binding.RelativePath);
             var renderer = transform.GetComponent<SkinnedMeshRenderer>();
+            if (renderer == null)
+            {
+                return null;
+            }
+
+            if(!renderer.gameObject.activeInHierarchy)
+            {
+                return null;
+            }
+
             var mesh = renderer.sharedMesh;
             var meshIndex = meshes.IndexOf(mesh);
+            if (meshIndex == -1)
+            {
+                return null;
+            }
 
             return new glTF_VRM_BlendShapeBind
             {
@@ -36,7 +50,16 @@ namespace VRM
             var list = new List<glTF_VRM_BlendShapeBind>();
             if (clip.Values != null)
             {
-                list.AddRange(clip.Values.Select(y => Create(transform, meshes.ToList(), y)));
+                foreach (var value in clip.Values)
+                {
+                    var bind = Create(transform, meshes, value);
+                    if (bind == null)
+                    {
+                        Debug.LogFormat("{0}: skip blendshapebind", clip.name);
+                        continue;
+                    }
+                    list.Add(bind);
+                }
             }
 
             var materialList = new List<glTF_VRM_MaterialValueBind>();


### PR DESCRIPTION
#398

修正しました。

* BlendShapeClip の BlendShapeBinding が参照する mesh が active でないときにこれをエクスポートしない
* VRM のエクスポート前のエラーチェックで active な mesh が 0 であるこを検知する。 `No active mesh`
* ExportWizard のヴァリデーションを EditorApplication.hierarchyWindowChanged でも実行する。GameObject のアクティブ切り替えで Export 可否が即座に反映します。

![exporter_check_activemesh](https://user-images.githubusercontent.com/68057/82283876-90381d80-99d2-11ea-8649-c2049a9a8aef.jpg)

