### PR TITLE
fix MaterialImporter and TextureTransformTest

### DIFF
--- a/Assets/VRM/UniGLTF/Editor/Tests/MaterialTests.cs
+++ b/Assets/VRM/UniGLTF/Editor/Tests/MaterialTests.cs
@@ -29,15 +29,14 @@ namespace UniGLTF
             var materialExporter = new MaterialExporter();
             var gltfMaterial = materialExporter.ExportMaterial(srcMaterial, textureManager);
 
-            // ToDo: Add ImportTest
-            //var shaderStore = new ShaderStore(null);
-            //var materialImporter = new MaterialImporter(shaderStore, null);
-            //var dstMaterial = materialImporter.CreateMaterial(0, gltfMaterial);
+            var shaderStore = new ShaderStore(null);
+            var materialImporter = new MaterialImporter(shaderStore, (int index) => {return null;});
+            var dstMaterial = materialImporter.CreateMaterial(0,gltfMaterial, false);
 
-            Assert.AreEqual(gltfMaterial.pbrMetallicRoughness.baseColorTexture.extensions.KHR_texture_transform.offset,
-                new float[] { offset.x, offset.y });
-            Assert.AreEqual(gltfMaterial.pbrMetallicRoughness.baseColorTexture.extensions.KHR_texture_transform.scale,
-                new float[] { scale.x, scale.y });
+            Assert.AreEqual(dstMaterial.mainTextureOffset.x, offset.x, 0.001f);
+            Assert.AreEqual(dstMaterial.mainTextureOffset.y, offset.y, 0.001f);
+            Assert.AreEqual(dstMaterial.mainTextureScale.x, scale.x, 0.001f);
+            Assert.AreEqual(dstMaterial.mainTextureScale.y, scale.y, 0.001f);
         }
 
         [Test]

--- a/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
@@ -109,7 +109,7 @@ namespace UniGLTF
             {
                 if (m_materialImporter == null)
                 {
-                    m_materialImporter = new MaterialImporter(ShaderStore, this);
+                    m_materialImporter = new MaterialImporter(ShaderStore, (int index) => this.GetTexture(index));
                 }
                 return m_materialImporter;
             }

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
@@ -17,16 +17,12 @@ namespace UniGLTF
     {
         IShaderStore m_shaderStore;
 
-        ImporterContext m_context;
-        protected ImporterContext Context
-        {
-            get { return m_context; }
-        }
+        protected Func<int, TextureItem> GetTextureFunc;
 
-        public MaterialImporter(IShaderStore shaderStore, ImporterContext context)
+        public MaterialImporter(IShaderStore shaderStore, Func<int, TextureItem> getTextureFunc)
         {
             m_shaderStore = shaderStore;
-            m_context = context;
+            GetTextureFunc = getTextureFunc;
         }
 
         private enum BlendMode
@@ -91,7 +87,7 @@ namespace UniGLTF
                 // texture
                 if (x.pbrMetallicRoughness.baseColorTexture != null)
                 {
-                    var texture = m_context.GetTexture(x.pbrMetallicRoughness.baseColorTexture.index);
+                    var texture = GetTextureFunc(x.pbrMetallicRoughness.baseColorTexture.index);
                     if (texture != null)
                     {
                         material.mainTexture = texture.Texture;
@@ -159,7 +155,7 @@ namespace UniGLTF
 
                 if (x.pbrMetallicRoughness.baseColorTexture != null && x.pbrMetallicRoughness.baseColorTexture.index != -1)
                 {
-                    var texture = m_context.GetTexture(x.pbrMetallicRoughness.baseColorTexture.index);
+                    var texture = GetTextureFunc(x.pbrMetallicRoughness.baseColorTexture.index);
                     if (texture != null)
                     {
                         material.mainTexture = texture.Texture;
@@ -172,7 +168,7 @@ namespace UniGLTF
                 if (x.pbrMetallicRoughness.metallicRoughnessTexture != null && x.pbrMetallicRoughness.metallicRoughnessTexture.index != -1)
                 {
                     material.EnableKeyword("_METALLICGLOSSMAP");
-                    var texture = Context.GetTexture(x.pbrMetallicRoughness.metallicRoughnessTexture.index);
+                    var texture = GetTextureFunc(x.pbrMetallicRoughness.metallicRoughnessTexture.index);
                     if (texture != null)
                     {
                         var prop = "_MetallicGlossMap";
@@ -197,7 +193,7 @@ namespace UniGLTF
             if (x.normalTexture != null && x.normalTexture.index != -1)
             {
                 material.EnableKeyword("_NORMALMAP");
-                var texture = Context.GetTexture(x.normalTexture.index);
+                var texture = GetTextureFunc(x.normalTexture.index);
                 if (texture != null)
                 {
                     var prop = "_BumpMap";
@@ -211,7 +207,7 @@ namespace UniGLTF
 
             if (x.occlusionTexture != null && x.occlusionTexture.index != -1)
             {
-                var texture = Context.GetTexture(x.occlusionTexture.index);
+                var texture = GetTextureFunc(x.occlusionTexture.index);
                 if (texture != null)
                 {
                     var prop = "_OcclusionMap";
@@ -236,7 +232,7 @@ namespace UniGLTF
 
                 if (x.emissiveTexture != null && x.emissiveTexture.index != -1)
                 {
-                    var texture = Context.GetTexture(x.emissiveTexture.index);
+                    var texture = GetTextureFunc(x.emissiveTexture.index);
                     if (texture != null)
                     {
                         material.SetTexture("_EmissionMap", texture.Texture);

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMMaterialImporter.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMMaterialImporter.cs
@@ -9,7 +9,7 @@ namespace VRM
     public class VRMMaterialImporter : MaterialImporter
     {
         List<glTF_VRM_Material> m_materials;
-        public VRMMaterialImporter(ImporterContext context, List<glTF_VRM_Material> materials) : base(new ShaderStore(context), context)
+        public VRMMaterialImporter(ImporterContext context, List<glTF_VRM_Material> materials) : base(new ShaderStore(context), (int index) => context.GetTexture(index))
         {
             m_materials = materials;
         }
@@ -81,7 +81,7 @@ namespace VRM
             }
             foreach (var kv in item.textureProperties)
             {
-                var texture = Context.GetTexture(kv.Value);
+                var texture = base.GetTextureFunc(kv.Value);
                 if (texture != null)
                 {
                     var converted = texture.ConvertTexture(kv.Key);


### PR DESCRIPTION
ImporterContextをMaterialImporterに持ち運ばなくても動くように変更。
それに伴ってテストを修正。