### PR TITLE
Fix: SpringBone LateUpdate to FixedUpdate

### DIFF
--- a/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs
+++ b/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs
@@ -281,7 +281,7 @@ namespace VRM
         }
 
         List<SphereCollider> m_colliderList = new List<SphereCollider>();
-        void LateUpdate()
+        void FixedUpdate()
         {
             if (m_verlet == null || m_verlet.Count == 0)
             {
@@ -312,8 +312,8 @@ namespace VRM
                 }
             }
 
-            var stiffness = m_stiffnessForce * Time.deltaTime;
-            var external = m_gravityDir * (m_gravityPower * Time.deltaTime);
+            var stiffness = m_stiffnessForce * Time.fixedDeltaTime;
+            var external = m_gravityDir * (m_gravityPower * Time.fixedDeltaTime);
 
             foreach (var verlet in m_verlet)
             {

--- a/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs
+++ b/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs
@@ -48,6 +48,14 @@ namespace VRM
         [SerializeField]
         public VRMSpringBoneColliderGroup[] ColliderGroups;
 
+        public enum SpringBoneUpdateType
+        {
+            LateUpdate,
+            FixedUpdate,
+        }
+        [SerializeField]
+        public SpringBoneUpdateType m_updateType = SpringBoneUpdateType.LateUpdate;
+
         /// <summary>
         /// 
         /// original from
@@ -274,6 +282,22 @@ namespace VRM
             }
         }
 
+        void LateUpdate()
+        {
+            if (m_updateType == SpringBoneUpdateType.LateUpdate)
+            {
+                UpdateProcess(Time.deltaTime);
+            }
+        }
+        
+        void FixedUpdate()
+        {
+            if (m_updateType == SpringBoneUpdateType.FixedUpdate)
+            {
+                UpdateProcess(Time.fixedDeltaTime);
+            }
+        }
+
         public struct SphereCollider
         {
             public Vector3 Position;
@@ -281,7 +305,7 @@ namespace VRM
         }
 
         List<SphereCollider> m_colliderList = new List<SphereCollider>();
-        void FixedUpdate()
+        private void UpdateProcess(float deltaTime)
         {
             if (m_verlet == null || m_verlet.Count == 0)
             {
@@ -312,8 +336,8 @@ namespace VRM
                 }
             }
 
-            var stiffness = m_stiffnessForce * Time.fixedDeltaTime;
-            var external = m_gravityDir * (m_gravityPower * Time.fixedDeltaTime);
+            var stiffness = m_stiffnessForce * deltaTime;
+            var external = m_gravityDir * (m_gravityPower * deltaTime);
 
             foreach (var verlet in m_verlet)
             {


### PR DESCRIPTION
SpringBoneの更新がLateUpdateのためにアニメーションや物理挙動をVRMモデルに加えた時にSpringBoneのコライダが暴れてしまうので、LateUpdateをFixedUpdateに直したところ暴れる事はなくなりました。

LateUpdateをFixedUpdateに変える事によって起こる副作用がこちらでは解らないので、問題がある場合は取り下げていただければと思います。