### PR TITLE
EditorExport時にアセットが見つかったTextureは、それを使う

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureExportManager.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureExportManager.cs
@@ -57,6 +57,14 @@ namespace UniGLTF
                 return -1;
             }
 
+#if UNITY_EDITOR
+            if (!string.IsNullOrEmpty(UnityEditor.AssetDatabase.GetAssetPath(texture)))
+            {
+                m_exportTextures[index] = texture;
+                return index;
+            }
+#endif
+
             // ToDo: may already exists
             m_exportTextures[index] = TextureItem.CopyTexture(texture, readWrite, null);
 

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureIO.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureIO.cs
@@ -129,7 +129,15 @@ namespace UniGLTF
                         Bytes = System.IO.File.ReadAllBytes(path.FullPath),
                         Mime = "image/png",
                     };
-                }                    
+                }
+                if (path.Extension == ".jpg")
+                {
+                    return new BytesWithMime
+                    {
+                        Bytes = System.IO.File.ReadAllBytes(path.FullPath),
+                        Mime = "image/jpeg",
+                    };
+                }
             }
 #endif
 


### PR DESCRIPTION
#245

https://docs.unity3d.com/ScriptReference/AssetDatabase.GetAssetPath.html

path が得られた場合は、コピーせずにそのバイナリ(png or jpg)をそのまま使う。
