### PR TITLE
check invalid file name

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/Extensions/StringExtensions.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 namespace UniGLTF
@@ -63,6 +64,8 @@ namespace UniGLTF
         };
         public static string EscapeFilePath(this string path)
         {
+            path = Regex.Replace(path, @"[\u0000-\u001F\u007F]", "+");
+
             foreach(var x in EscapeChars)
             {
                 path = path.Replace(x, '+');

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
@@ -93,7 +93,10 @@ namespace VRM
         public bool RemoveVertexColor = false;
         #endregion
 
-        private const int MAX_LENGTH = 64;
+        public static bool IsFileNameLengthTooLong(string fileName)
+        {
+            return fileName.Length > 64;
+        }
 
         public struct Validation
         {
@@ -234,7 +237,7 @@ namespace VRM
 
             foreach (var material in materials)
             {
-                if (material.name.Length > MAX_LENGTH)
+                if (IsFileNameLengthTooLong(material.name))
                     yield return Validation.Error(string.Format("FileName '{0}' is too long. ", material.name));
             }
 
@@ -259,29 +262,23 @@ namespace VRM
 
             foreach (var textureName in textureNameList)
             {
-                if (textureName.Length > MAX_LENGTH)
+                if (IsFileNameLengthTooLong(textureName))
                     yield return Validation.Error(string.Format("FileName '{0}' is too long. ", textureName));
             }
 
             var vrmMeta = Source.GetComponent<VRMMeta>();
-            if (vrmMeta != null)
+            if (vrmMeta != null && vrmMeta.Meta != null && vrmMeta.Meta.Thumbnail != null)
             {
-                if (vrmMeta.Meta != null)
-                {
-                    if (vrmMeta.Meta.Thumbnail != null)
-                    {
-                        var thumbnailName = vrmMeta.Meta.Thumbnail.name;
-                        if (thumbnailName.Length > MAX_LENGTH)
-                            yield return Validation.Error(string.Format("FileName '{0}' is too long. ", thumbnailName));
-                    }
-                }
+                var thumbnailName = vrmMeta.Meta.Thumbnail.name;
+                if (IsFileNameLengthTooLong(thumbnailName))
+                    yield return Validation.Error(string.Format("FileName '{0}' is too long. ", thumbnailName));
             }
 
             var meshFilters = Source.GetComponentsInChildren<MeshFilter>();
             var meshesName = meshFilters.Select(x => x.sharedMesh.name).Distinct();
             foreach (var meshName in meshesName)
             {
-                if (meshName.Length > MAX_LENGTH)
+                if (IsFileNameLengthTooLong(meshName))
                     yield return Validation.Error(string.Format("FileName '{0}' is too long. ", meshName));
             }
 
@@ -289,7 +286,7 @@ namespace VRM
             var skinnedmeshesName = skinnedmeshRenderers.Select(x => x.sharedMesh.name).Distinct();
             foreach (var skinnedmeshName in skinnedmeshesName)
             {
-                if (skinnedmeshName.Length > MAX_LENGTH)
+                if (IsFileNameLengthTooLong(skinnedmeshName))
                     yield return Validation.Error(string.Format("FileName '{0}' is too long. ", skinnedmeshName));
             }
         }

--- a/Assets/VRM/UniVRM/Editor/Tests/InvalidFileNameTest.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/InvalidFileNameTest.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+using System.Linq;
+using System.IO;
+
+namespace VRM
+{
+    public class InvalidFileNameTest
+    {
+        [Test]
+        [TestCase("VRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMVRMV", true)]
+        [TestCase("VRMFormatVRMFormatVRMFormatVRMFormatVRMFormatVRMFormatVRMFormat", false)]
+        [TestCase("UniVRMUniVRMUniVRMUniVRMUniVRMUniVRMUniVRMUniVRMUniVRMUniVRMUniVRM", true)]
+        [TestCase("UniVRMUniVRMUniVRMUniVRMUniVRMUniVRMUniVRMUniVRMUniVRMUniVRMUniV", false)]
+        [TestCase("AliciaAliciaAliciaAliciaAliciaAliciaAliciaAliciaAliciaAliciaAliciaAlicia", true)]
+        public void DetectFileNameLength(string fileName, bool isIllegal)
+        {
+            var result = VRMExportSettings.IsFileNameLengthTooLong(fileName);
+            Assert.AreEqual(result, isIllegal);
+        }
+
+        [Test]
+        [TestCase("\u0000\u0042\u0062", true)]
+        [TestCase("\u0045\u0046\u0047\u0065\u0068\u0036", false)]
+        [TestCase("\u0043\u0045\u0047\u007F", true)]
+        [TestCase("\u0000\u0042\u0062", true)]
+        [TestCase("\u003A\u0039\u005C\u0060\u0074", false)]
+        [TestCase("\u005D\u006F\u001C\u007A\u0036\u0049", true)]
+        public void DetectControlCharacters(string fileName, bool isIllegal)
+        {
+            var result = fileName.Any(x => char.IsControl(x));
+            Assert.AreEqual(result, isIllegal);
+        }
+
+        [Test]
+        [TestCase("VRM|Alicia?VRM", true)]
+        [TestCase("UniVRMUniVRM:UniVRM", true)]
+        [TestCase("VRMIsVRFileFormat", false)]
+        [TestCase("Alicia<Alicia>Alicia", true)]
+        [TestCase("UniVRMIsVRMImplementationInUnityPlatform", false)]
+        [TestCase("Avator*Avator/Avator", true)]
+        public void DetectInvalidCharacters(string fileName, bool isIllegal)
+        {
+            char[] invalidPathChars = Path.GetInvalidFileNameChars();
+            var result = fileName.Any(x => invalidPathChars.Contains(x));
+            Assert.AreEqual(result, isIllegal);
+        }
+    }
+}

--- a/Assets/VRM/UniVRM/Editor/Tests/InvalidFileNameTest.cs.meta
+++ b/Assets/VRM/UniVRM/Editor/Tests/InvalidFileNameTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8511ed091b59bca4da4fd280693b7c82
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM/UniVRM/Editor/Tests/UniVRM.Editor.Tests.asmdef
+++ b/Assets/VRM/UniVRM/Editor/Tests/UniVRM.Editor.Tests.asmdef
@@ -2,7 +2,8 @@
     "name": "UniVRM.Editor.Tests",
     "references": [
         "VRM",
-        "UniJSON"
+        "UniJSON",
+        "UniVRM.Editor"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"
@@ -11,5 +12,9 @@
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
 }


### PR DESCRIPTION
#152 #153 

ファイル名前が長すぎるの場合はエクスポートを禁止。
エスケープ文字を追加：制御文字。

参考：https://github.com/vrm-c/vrm-specification/issues/40