### PR TITLE
ボーン名重複と、RootのTRSを警告に下げてエクスポートできるようにした

### DIFF
--- a/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
@@ -186,7 +186,7 @@ namespace VRM
 
             if (DuplicateBoneNameExists())
             {
-                yield return Validation.Warning("Find duplicate Bone names. Please check model's bone names. ");
+                yield return Validation.Warning("There is a bone with the same name in the hierarchy. If exported, these bones will be automatically renamed.");
             }
 
             if (string.IsNullOrEmpty(Title))

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
@@ -156,8 +156,8 @@ namespace VRM
                 Source.transform.rotation != Quaternion.identity ||
                 Source.transform.localScale != Vector3.one)
             {
-                EditorUtility.DisplayDialog("Error", "The Root transform should have Default translation, rotation and scale.", "ok");
-                yield return Validation.Error("The Root transform should have Default translation, rotation and scale.");
+                // EditorUtility.DisplayDialog("Error", "The Root transform should have Default translation, rotation and scale.", "ok");
+                yield return Validation.Warning("The Root translation, rotation and scale will be dropped.");
             }
 
             var animator = Source.GetComponent<Animator>();
@@ -206,7 +206,7 @@ namespace VRM
             {
                 yield return Validation.Error("ReduceBlendshapeSize needs VRMBlendShapeProxy. You need to convert to VRM once.");
             }
-            
+
             var vertexColor = Source.GetComponentsInChildren<SkinnedMeshRenderer>().Any(x => x.sharedMesh.colors.Length > 0);
             if (vertexColor)
             {

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
@@ -186,7 +186,7 @@ namespace VRM
 
             if (DuplicateBoneNameExists())
             {
-                yield return Validation.Error("Find duplicate Bone names. Please check model's bone names. ");
+                yield return Validation.Warning("Find duplicate Bone names. Please check model's bone names. ");
             }
 
             if (string.IsNullOrEmpty(Title))


### PR DESCRIPTION
#475

* ボーンは自動的にリネームする
* Rootは特に何もしない。エクスポート時に値が無くなってしまう警告
