### PR TITLE
空のモーフターゲットが出力されglTF違反になってしまうことがあるのを修正

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
@@ -232,7 +232,7 @@ namespace UniGLTF
             };
         }
 
-        public static void ExportMeshes(glTF gltf, int bufferIndex,
+        public static IEnumerable<(Mesh, glTFMesh, Dictionary<int, int>)> ExportMeshes(glTF gltf, int bufferIndex,
             List<MeshWithRenderer> unityMeshes, List<Material> unityMaterials,
             bool useSparseAccessorForMorphTarget,
             bool exportOnlyBlendShapePosition,
@@ -248,6 +248,8 @@ namespace UniGLTF
                     x.Renderer.name,
                     mesh, materials, unityMaterials, removeVertexColor);
 
+                var blendShapeIndexMap = new Dictionary<int, int>();
+                int exportBlendShapes = 0;
                 for (int j = 0; j < mesh.blendShapeCount; ++j)
                 {
                     var morphTarget = ExportMorphTarget(gltf, bufferIndex,
@@ -259,6 +261,10 @@ namespace UniGLTF
                         continue;
                     }
 
+                    // maybe skip
+
+                    blendShapeIndexMap.Add(j, exportBlendShapes++);
+
                     //
                     // all primitive has same blendShape
                     //
@@ -269,7 +275,7 @@ namespace UniGLTF
                     }
                 }
 
-                gltf.meshes.Add(gltfMesh);
+                yield return (mesh, gltfMesh, blendShapeIndexMap);
             }
         }
     }

--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
@@ -254,6 +254,10 @@ namespace UniGLTF
                         mesh, j,
                         useSparseAccessorForMorphTarget,
                         exportOnlyBlendShapePosition);
+                    if (morphTarget.POSITION < 0 && morphTarget.NORMAL < 0 && morphTarget.TANGENT < 0)
+                    {
+                        continue;
+                    }
 
                     //
                     // all primitive has same blendShape

--- a/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
@@ -91,6 +91,18 @@ namespace UniGLTF
             private set;
         }
 
+        /// <summary>
+        /// Mesh毎に、元のBlendShapeIndex => ExportされたBlendShapeIndex の対応を記録する
+        /// 
+        /// BlendShape が空の場合にスキップするので
+        /// </summary>
+        /// <value></value>
+        public Dictionary<Mesh, Dictionary<int, int>> MeshBlendShapeIndexMap
+        {
+            get;
+            private set;
+        }
+
         public List<Transform> Nodes
         {
             get;
@@ -261,8 +273,15 @@ namespace UniGLTF
                         return true;
                     })
                     .ToList();
-                MeshExporter.ExportMeshes(gltf, bufferIndex, unityMeshes, Materials, useSparseAccessorForMorphTarget,
-                                          ExportOnlyBlendShapePosition, removeVertexColor);
+
+                MeshBlendShapeIndexMap = new Dictionary<Mesh, Dictionary<int, int>>();
+                foreach (var (mesh, gltfMesh, blendShapeIndexMap) in MeshExporter.ExportMeshes(
+                        gltf, bufferIndex, unityMeshes, Materials, useSparseAccessorForMorphTarget,
+                        ExportOnlyBlendShapePosition, removeVertexColor))
+                {
+                    gltf.meshes.Add(gltfMesh);
+                    MeshBlendShapeIndexMap.Add(mesh, blendShapeIndexMap);
+                }
                 Meshes = unityMeshes.Select(x => x.Mesh).ToList();
                 #endregion
 

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMExporter.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMExporter.cs
@@ -100,10 +100,9 @@ namespace VRM
                 var avatar = master.BlendShapeAvatar;
                 if (avatar != null)
                 {
-                    var meshes = exporter.Meshes;
                     foreach (var x in avatar.Clips)
                     {
-                        gltf.extensions.VRM.blendShapeMaster.Add(x, exporter.Copy.transform, meshes);
+                        gltf.extensions.VRM.blendShapeMaster.Add(x, exporter);
                     }
                 }
             }


### PR DESCRIPTION
v0.56.3のデフォルトのエクスポート設定でglTF違反のデータを出力してしまうことがあるの修正しました。

[こちらのVRM](https://github.com/pixiv/three-vrm/blob/09e1ede108c5ff1993ad5c53bee7fdc41810be09/examples/models/three-vrm-girl.vrm) をUniVRM v0.56.3でインポートし、デフォルトの設定をいじらずエクスポートした結果の拡張子をglbとし、 https://github.khronos.org/glTF-Validator/ にかけた結果を次に示します。

| 修正前 | 修正後 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/532872/88481109-86afd080-cf94-11ea-88ee-e9fc6936554f.png" width="300"> |  <img src="https://user-images.githubusercontent.com/532872/88480919-bf9b7580-cf93-11ea-9089-d6c54a8c6242.png" width="300"> |

変換前のVRMのエラーは0件です。残りの276件のエラーは、おそらくsparse accessorがデフォルトになった影響かと思いますが、今回は未調査です。