### PR TITLE
UnitTestが通らなくなったのを修正

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
@@ -280,7 +280,11 @@ namespace UniGLTF
                         ExportOnlyBlendShapePosition, removeVertexColor))
                 {
                     gltf.meshes.Add(gltfMesh);
-                    MeshBlendShapeIndexMap.Add(mesh, blendShapeIndexMap);
+                    if (!MeshBlendShapeIndexMap.ContainsKey(mesh))
+                    {
+                        // 同じmeshが複数回現れた
+                        MeshBlendShapeIndexMap.Add(mesh, blendShapeIndexMap);
+                    }
                 }
                 Meshes = unityMeshes.Select(x => x.Mesh).ToList();
                 #endregion


### PR DESCRIPTION
空のマテリアルのindexずれ対策が、テスト `SameMeshButDifferentMaterialExport` にささった