### PR TITLE
Fix unknown material

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
@@ -199,21 +199,6 @@ namespace UniGLTF
             }
         }
 
-        public static bool UseUnlit(string shaderName)
-        {
-            switch (shaderName)
-            {
-                case "Unlit/Color":
-                case "Unlit/Texture":
-                case "Unlit/Transparent":
-                case "Unlit/Transparent Cutout":
-                case "UniGLTF/UniUnlit":
-                    return true;
-            }
-            return false;
-
-        }
-
         protected virtual glTFMaterial CreateMaterial(Material m)
         {
             switch (m.shader.name)

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
@@ -228,7 +228,7 @@ namespace VRM
                     continue;
                 }
 
-                if (MaterialExporter.UseUnlit(material.shader.name))
+                if (VRMMaterialExporter.UseUnlit(material.shader.name))
                 {
                     // unlit
                     continue;
@@ -240,7 +240,7 @@ namespace VRM
                     continue;
                 }
 
-                yield return Validation.Warning(string.Format("{0}: unknown material '{0}' is used. this will export as `Standard` fallback",
+                yield return Validation.Warning(string.Format("{0}: unknown shader '{1}' is used. this will export as `Standard` fallback",
                     material.name,
                     material.shader.name));
             }

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
@@ -240,7 +240,9 @@ namespace VRM
                     continue;
                 }
 
-                yield return Validation.Warning(string.Format("unknown material '{0}' is used. this will export as `Standard` fallback", material.shader.name));
+                yield return Validation.Warning(string.Format("{0}: unknown material '{0}' is used. this will export as `Standard` fallback",
+                    material.name,
+                    material.shader.name));
             }
 
             foreach (var material in materials)

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMMaterialExporter.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMMaterialExporter.cs
@@ -10,6 +10,23 @@ namespace VRM
 {
     public class VRMMaterialExporter : MaterialExporter
     {
+        public static bool UseUnlit(string shaderName)
+        {
+            switch (shaderName)
+            {
+                case "Unlit/Color":
+                case "Unlit/Texture":
+                case "Unlit/Transparent":
+                case "Unlit/Transparent Cutout":
+                case "UniGLTF/UniUnlit":
+                case "VRM/UnlitTexture":
+                case "VRM/UnlitTransparent":
+                case "VRM/UnlitCutout":
+                    return true;
+            }
+            return false;
+        }
+
         protected override glTFMaterial CreateMaterial(Material m)
         {
             switch (m.shader.name)


### PR DESCRIPTION
エクスポートダイアログで、`unlit` としてエクスポートできるにも関わらず警告メッセージ

`unknown material` 

が表示されてしまうのを修正。

* VRM/UnlitTexture
* VRM/UnlitTransparent
* VRM/UnlitCutout

を対象。

* VRM/UnlitTransparentZWrite

は削除予定なので見送り。

#496 に関連。
