### PR TITLE
Refactor BlendShapeKey && BlendShapePreset.Unknown 以外のプリセットは独自の Name を持てない仕様に変更

### DIFF
--- a/Assets/VRM/UniVRM/Editor/Tests/VRMBlendShapeKeyTest.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/VRMBlendShapeKeyTest.cs
@@ -10,21 +10,22 @@ namespace VRM
     {
         static BlendShapeKey CreateBlendShapeKey(string name, BlendShapePreset preset)
         {
-            var argTypes = new Type[] { typeof(string), typeof(BlendShapePreset) };
+            var argTypes = new Type[] {typeof(string), typeof(BlendShapePreset)};
             // private constructor
             var constructor = typeof(BlendShapeKey).GetConstructor(
                 BindingFlags.Instance | BindingFlags.NonPublic,
                 null, argTypes, null);
-            return (BlendShapeKey)constructor.Invoke(new object[] { name, preset });
+            return (BlendShapeKey) constructor.Invoke(new object[] {name, preset});
         }
 
         [Test]
         public void KeyTest()
         {
-            var key = CreateBlendShapeKey("Blink", BlendShapePreset.Blink);
-            Assert.AreEqual(key, CreateBlendShapeKey("Blink", BlendShapePreset.Blink));
+            var key = BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink);
             Assert.AreEqual(key, BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink));
+            Assert.AreEqual(key, CreateBlendShapeKey("Blink", BlendShapePreset.Blink));
             Assert.AreEqual(key, CreateBlendShapeKey("xxx", BlendShapePreset.Blink));
+            Assert.AreEqual(key.Name, "Blink");
 
             var dict = new Dictionary<BlendShapeKey, float>();
             dict[key] = 1.0f;
@@ -35,17 +36,23 @@ namespace VRM
 
             dict.Clear();
 
-            var key2 = BlendShapeKey.CreateUnknown("Blink"); // name: Blink, Preset: Unknown
+            var key2 = BlendShapeKey.CreateUnknown("Blink"); // Name: Blink, Preset: Unknown
             dict[key2] = 1.0f;
 
             Assert.AreEqual(key2, CreateBlendShapeKey("Blink", BlendShapePreset.Unknown));
             Assert.AreNotEqual(key2, BlendShapeKey.CreateUnknown("blink"));
             Assert.AreNotEqual(key2, CreateBlendShapeKey("Blink", BlendShapePreset.Blink));
             Assert.AreNotEqual(key2, BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink));
+            Assert.AreEqual(key2.Name, "Blink");
 
             Assert.IsFalse(dict.ContainsKey(BlendShapeKey.CreateUnknown("blink")));
             Assert.IsFalse(dict.ContainsKey(CreateBlendShapeKey("Blink", BlendShapePreset.Blink)));
             Assert.IsFalse(dict.ContainsKey(BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink)));
+
+            var key3 = CreateBlendShapeKey("xxx", BlendShapePreset.Blink); // Unknown 以外は独自の名前を持てない
+            Assert.AreEqual(key3, BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink));
+            Assert.AreNotEqual(key3, CreateBlendShapeKey("xxx", BlendShapePreset.Unknown));
+            Assert.AreEqual(key3.Name, "Blink");
         }
     }
 }

--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
@@ -49,17 +49,15 @@ namespace VRM
             {
                 if (PresetNameCacheDictionary.TryGetValue(Preset, out var presetName))
                 {
-                    m_id = presetName;
+                    m_id = Name = presetName;
                 }
                 else
                 {
-                    presetName = Preset.ToString();
-                    m_id = presetName;
+                    // BlendShapePreset.Unknown 以外の場合、 name は捨てられる
+                    m_id = Name = Preset.ToString();
 
-                    PresetNameCacheDictionary.Add(Preset, presetName);
+                    PresetNameCacheDictionary.Add(Preset, Name);
                 }
-
-                Name = !string.IsNullOrEmpty(name) ? name : presetName;
             }
             else
             {

--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
@@ -103,7 +103,7 @@ namespace VRM
 
         public override string ToString()
         {
-            return m_id.Replace(UnknownPresetPrefix, "").ToUpper();
+            return m_id.Replace(UnknownPresetPrefix, "");
         }
 
         public bool Equals(BlendShapeKey other)

--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
@@ -4,58 +4,24 @@ using System.Collections.Generic;
 namespace VRM
 {
     [Serializable]
-    public struct BlendShapeKey : IEquatable<BlendShapeKey>, IComparable<BlendShapeKey>
+    public readonly struct BlendShapeKey : IEquatable<BlendShapeKey>, IComparable<BlendShapeKey>
     {
         /// <summary>
         /// Enum.ToString() のGC回避用キャッシュ
         /// </summary>
-        private static readonly Dictionary<BlendShapePreset, string> m_presetNameDictionary =
+        private static readonly Dictionary<BlendShapePreset, string> PresetNameCacheDictionary =
             new Dictionary<BlendShapePreset, string>();
-
 
         /// <summary>
         ///  BlendShapePresetと同名の名前を持つ独自に追加したBlendShapeを区別するためのprefix
         /// </summary>
         private static readonly string UnknownPresetPrefix = "Unknown_";
 
-        private readonly string m_name;
-
-        public string Name
-        {
-            get { return m_name; }
-        }
+        public string Name { get; }
 
         public readonly BlendShapePreset Preset;
 
-        string m_id;
-
-        string ID
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(m_id))
-                {
-                    if (Preset != BlendShapePreset.Unknown)
-                    {
-                        if (m_presetNameDictionary.ContainsKey(Preset))
-                        {
-                            m_id = m_presetNameDictionary[Preset];
-                        }
-                        else
-                        {
-                            m_presetNameDictionary.Add(Preset, Preset.ToString());
-                            m_id = m_presetNameDictionary[Preset];
-                        }
-                    }
-                    else
-                    {
-                        m_id = UnknownPresetPrefix + m_name;
-                    }
-                }
-
-                return m_id;
-            }
-        }
+        private readonly string m_id;
 
         /// <summary>
         /// name と preset のペアからBlendShapeKeyを生成するが、
@@ -77,24 +43,24 @@ namespace VRM
         /// <param name="preset"></param>
         private BlendShapeKey(string name, BlendShapePreset preset)
         {
-            m_name = name;
             Preset = preset;
 
             if (Preset != BlendShapePreset.Unknown)
             {
-                if (m_presetNameDictionary.ContainsKey((Preset)))
+                if (PresetNameCacheDictionary.TryGetValue(Preset, out var presetName))
                 {
-                    m_id = m_presetNameDictionary[Preset];
+                    m_id = Name = presetName;
                 }
                 else
                 {
-                    m_presetNameDictionary.Add(Preset, Preset.ToString());
-                    m_id = m_presetNameDictionary[Preset];
+                    var n = m_id = Name = Preset.ToString();
+                    PresetNameCacheDictionary.Add(Preset, n);
                 }
             }
             else
             {
-                m_id = UnknownPresetPrefix + m_name;
+                Name = name;
+                m_id = UnknownPresetPrefix + Name;
             }
         }
 
@@ -105,7 +71,7 @@ namespace VRM
         /// <returns></returns>
         public static BlendShapeKey CreateFromPreset(BlendShapePreset preset)
         {
-            return new BlendShapeKey(preset.ToString(), preset);
+            return new BlendShapeKey("", preset);
         }
 
         /// <summary>
@@ -135,19 +101,19 @@ namespace VRM
 
         public override string ToString()
         {
-            return ID.Replace(UnknownPresetPrefix, "").ToUpper();
+            return m_id.Replace(UnknownPresetPrefix, "").ToUpper();
         }
 
         public bool Equals(BlendShapeKey other)
         {
-            return ID == other.ID;
+            return m_id == other.m_id;
         }
 
         public override bool Equals(object obj)
         {
             if (obj is BlendShapeKey)
             {
-                return Equals((BlendShapeKey)obj);
+                return Equals((BlendShapeKey) obj);
             }
             else
             {
@@ -157,7 +123,7 @@ namespace VRM
 
         public override int GetHashCode()
         {
-            return ID.GetHashCode();
+            return m_id.GetHashCode();
         }
 
         public bool Match(BlendShapeClip clip)

--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
@@ -53,8 +53,8 @@ namespace VRM
                 }
                 else
                 {
-                    var n = m_id = Name = Preset.ToString();
-                    PresetNameCacheDictionary.Add(Preset, n);
+                    m_id = Name = Preset.ToString();
+                    PresetNameCacheDictionary.Add(Preset, Name);
                 }
             }
             else

--- a/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
+++ b/Assets/VRM/UniVRM/Scripts/BlendShape/BlendShapeKey.cs
@@ -49,17 +49,21 @@ namespace VRM
             {
                 if (PresetNameCacheDictionary.TryGetValue(Preset, out var presetName))
                 {
-                    m_id = Name = presetName;
+                    m_id = presetName;
                 }
                 else
                 {
-                    m_id = Name = Preset.ToString();
-                    PresetNameCacheDictionary.Add(Preset, Name);
+                    presetName = Preset.ToString();
+                    m_id = presetName;
+
+                    PresetNameCacheDictionary.Add(Preset, presetName);
                 }
+
+                Name = !string.IsNullOrEmpty(name) ? name : presetName;
             }
             else
             {
-                Name = name;
+                Name = !string.IsNullOrEmpty(name) ? name : "";
                 m_id = UnknownPresetPrefix + Name;
             }
         }


### PR DESCRIPTION
リファクタ
- ID の判定重複部分を削除して readonly struct に
- CreateFromPreset 時の Enum.ToString() を削除

仕様変更
- BlendShapeClip から生成された BlendShapePreset.Unknown 以外のプリセットの Name は、各プリセット名を ToString() したものになるように
- BlendShapeKey.ToString() が旧仕様の ToUpper() された値を返していたため、 ToUpper() を削除