### PR TITLE
初回Export時のmeta受け渡し方法を修正

### DIFF
--- a/Assets/VRM/UniVRM/Editor/Format/VRMEditorExporter.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMEditorExporter.cs
@@ -16,12 +16,12 @@ namespace VRM
         /// </summary>
         /// <param name="path">出力先</param>
         /// <param name="settings">エクスポート設定</param>
-        public static void Export(string path, GameObject exportRoot, VRMExportSettings settings)
+        public static void Export(string path, GameObject exportRoot, VRMMetaObject meta, VRMExportSettings settings)
         {
             List<GameObject> destroy = new List<GameObject>();
             try
             {
-                Export(path, exportRoot, settings, destroy);
+                Export(path, exportRoot, meta, settings, destroy);
             }
             finally
             {
@@ -136,13 +136,25 @@ namespace VRM
         /// <param name="path"></param>
         /// <param name="settings"></param>
         /// <param name="destroy">作業が終わったらDestoryするべき一時オブジェクト</param>
-        static void Export(string path, GameObject exportRoot, VRMExportSettings settings, List<GameObject> destroy)
+        static void Export(string path, GameObject exportRoot, VRMMetaObject meta, VRMExportSettings settings, List<GameObject> destroy)
         {
             var target = exportRoot;
 
             // 常にコピーする。シーンを変化させない
             target = GameObject.Instantiate(target);
             destroy.Add(target);
+
+            var metaBehaviour = target.GetComponent<VRMMeta>();
+            if (metaBehaviour == null)
+            {
+                metaBehaviour = target.AddComponent<VRMMeta>();
+                metaBehaviour.Meta = meta;
+            }
+            if (metaBehaviour.Meta == null)
+            {
+                // 来ないはず
+                throw new Exception("meta required");
+            }
 
             {
                 // copy元

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExporterWizard.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExporterWizard.cs
@@ -695,20 +695,7 @@ namespace VRM
             m_lastExportDir = Path.GetDirectoryName(path).Replace("\\", "/");
 
             // export
-            if (Meta == null)
-            {
-                var metaB = ExportRoot.GetComponent<VRMMeta>();
-                if (metaB == null)
-                {
-                    metaB = ExportRoot.AddComponent<VRMMeta>();
-                }
-                metaB.Meta = m_tmpMeta;
-            }
-            VRMEditorExporter.Export(path, ExportRoot, m_settings);
-            if (Meta == null)
-            {
-                UnityEngine.GameObject.DestroyImmediate(ExportRoot.GetComponent<VRMMeta>());
-            }
+            VRMEditorExporter.Export(path, ExportRoot, Meta != null ? Meta : m_tmpMeta, m_settings);
         }
 
         void OnWizardUpdate()


### PR DESCRIPTION
#528

エクスポートダイアログで、fbxを直接指定してエクスポートすると、

`target.AddComponent<VRMMeta>()`

が失敗して、エラーになる。(fbxのprefabは変更不可のため)
別の方法を使うようにした。
