### PR TITLE
activeInHierarchy が prefab にヒットする件

### DIFF
--- a/Assets/VRM/UniVRM/Editor/ExporterExtensions.cs
+++ b/Assets/VRM/UniVRM/Editor/ExporterExtensions.cs
@@ -1,0 +1,18 @@
+using System.Linq;
+using UnityEngine;
+
+namespace VRM
+{
+    public static class ExporterExtensions
+    {
+        public static bool EnableForExport(this Component mono)
+        {
+            if (mono.transform.GetComponentsInParent<Transform>().Any(x => !x.gameObject.activeSelf))
+            {
+                // 自分か祖先に !activeSelf がいる
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Assets/VRM/UniVRM/Editor/ExporterExtensions.cs.meta
+++ b/Assets/VRM/UniVRM/Editor/ExporterExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84a3f0f4ae5319a46839f08a76ae0edd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM/UniVRM/Editor/FirstPerson/VRMFirstPersonValidator.cs
+++ b/Assets/VRM/UniVRM/Editor/FirstPerson/VRMFirstPersonValidator.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace VRM
+{
+    public static class VRMFirstPersonValidator
+    {
+        public static IEnumerable<Validation> Validate(this VRMFirstPerson self)
+        {
+            var hierarchy = self.GetComponentsInChildren<Transform>(true);
+
+            for (int i = 0; i < self.Renderers.Count; ++i)
+            {
+                var r = self.Renderers[i];
+                if (r.Renderer == null)
+                {
+                    yield return Validation.Error($"[VRMFirstPerson]{self.name}.Renderers[{i}].Renderer is null");
+                }
+                if (!hierarchy.Contains(r.Renderer.transform))
+                {
+                    yield return Validation.Error($"[VRMFirstPerson]{self.name}.Renderers[{i}].Renderer is out of hierarchy");
+                }
+                if (!r.Renderer.EnableForExport())
+                {
+                    yield return Validation.Error($"[VRMFirstPerson]{self.name}.Renderers[{i}].Renderer is not active");
+                }
+            }
+            yield break;
+        }
+    }
+}

--- a/Assets/VRM/UniVRM/Editor/FirstPerson/VRMFirstPersonValidator.cs.meta
+++ b/Assets/VRM/UniVRM/Editor/FirstPerson/VRMFirstPersonValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48854dc6374b64d45a8a5e099bf5ced0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExporterWizard.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExporterWizard.cs
@@ -139,20 +139,6 @@ namespace VRM
             return Vector3.Cross(lr, Vector3.up);
         }
 
-        static bool EnableRenderer(Renderer renderer)
-        {
-            if (renderer.transform.GetComponentsInParent<Transform>().Any(x => !x.gameObject.activeSelf))
-            {
-                // 自分か祖先に !activeSelf がいる
-                return false;
-            }
-            if (!renderer.enabled)
-            {
-                return false;
-            }
-            return true;
-        }
-
         static string Msg(VRMExporterWizardMessages key)
         {
             return M17N.Getter.Msg(key);
@@ -389,7 +375,7 @@ namespace VRM
             }
 
             var renderers = ExportRoot.GetComponentsInChildren<Renderer>();
-            if (renderers.All(x => !EnableRenderer(x)))
+            if (renderers.All(x => !x.EnableForExport()))
             {
                 Validation.Error(Msg(VRMExporterWizardMessages.NO_ACTIVE_MESH)).DrawGUI();
                 return;

--- a/Assets/VRM/UniVRM/Editor/SpringBone/VRMSpringBoneValidator.cs
+++ b/Assets/VRM/UniVRM/Editor/SpringBone/VRMSpringBoneValidator.cs
@@ -33,7 +33,7 @@ namespace VRM
                         yield return Validation.Error($"[VRMSpringBone]{sb.name}.RootBones[{i}] is out of hierarchy");
                         continue;
                     }
-                    if (!springRoot.gameObject.activeInHierarchy)
+                    if (!springRoot.transform.EnableForExport())
                     {
                         yield return Validation.Error($"[VRMSpringBone]{sb.name}.RootBones[{i}] is not active");
                         continue;

--- a/Assets/VRM/UniVRM/Scripts/FirstPerson/VRMFirstPerson.cs
+++ b/Assets/VRM/UniVRM/Scripts/FirstPerson/VRMFirstPerson.cs
@@ -50,29 +50,6 @@ namespace VRM
         [SerializeField]
         public List<RendererFirstPersonFlags> Renderers = new List<RendererFirstPersonFlags>();
 
-        public IEnumerable<Validation> Validate()
-        {
-            var hierarchy = GetComponentsInChildren<Transform>(true);
-
-            for (int i = 0; i < Renderers.Count; ++i)
-            {
-                var r = Renderers[i];
-                if (r.Renderer == null)
-                {
-                    yield return Validation.Error($"[VRMFirstPerson]{name}.Renderers[{i}].Renderer is null");
-                }
-                if (!hierarchy.Contains(r.Renderer.transform))
-                {
-                    yield return Validation.Error($"[VRMFirstPerson]{name}.Renderers[{i}].Renderer is out of hierarchy");
-                }
-                if (!r.Renderer.gameObject.activeInHierarchy)
-                {
-                    yield return Validation.Error($"[VRMFirstPerson]{name}.Renderers[{i}].Renderer is not active");
-                }
-            }
-            yield break;
-        }
-
         public void CopyTo(GameObject _dst, Dictionary<Transform, Transform> map)
         {
             var dst = _dst.AddComponent<VRMFirstPerson>();


### PR DESCRIPTION
SprngBone/FirstPerson のついた prefab をシーンに出さずに ExportRoot にセットすると、activeInHierarchy  で `not active` 判定になってしまう。
fbx の prefab には `SprngBone/FirstPerson` がアタッチされていることは無いので、起こらない。
