### PR TITLE
親をたどる時、非アクティブなTransformが取得できなくなっていたのを修正

### DIFF
--- a/Assets/VRM/UniVRM/Editor/ExporterExtensions.cs
+++ b/Assets/VRM/UniVRM/Editor/ExporterExtensions.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using MeshUtility;
 using UnityEngine;
 
 namespace VRM
@@ -7,7 +8,7 @@ namespace VRM
     {
         public static bool EnableForExport(this Component mono)
         {
-            if (mono.transform.GetComponentsInParent<Transform>().Any(x => !x.gameObject.activeSelf))
+            if (mono.transform.Ancestors().Any(x => !x.gameObject.activeSelf))
             {
                 // 自分か祖先に !activeSelf がいる
                 return false;

--- a/Assets/VRM/UniVRM/Scripts/FirstPerson/VRMFirstPerson.cs
+++ b/Assets/VRM/UniVRM/Scripts/FirstPerson/VRMFirstPerson.cs
@@ -195,7 +195,7 @@ namespace VRM
             var eraseBones = bones.Select((x, i) =>
             {
                 // 祖先に削除対象が存在するか
-                bool erase = x.GetComponentsInParent<Transform>().Any(y => y == eraseRoot);
+                bool erase = x.Ancestors().Any(y => y == eraseRoot);
                 return new
                 {
                     i,


### PR DESCRIPTION
- https://github.com/vrm-c/UniVRM/commit/22eb7749f9827b1f59184c7b606c533b64198103 にて、親の取得方法が `Ancestor()` から `GetComponentsInParents<Transform>()` に変更されたが、その結果非アクティブな場合に取得できなくなっていた
  - 非アクティブな場合にHeadlessModelが作成されなくなっていた
  - EnableForExportが常にtrueを返すようになってしまっていた
- `GetComponentsInParents<Transform>(true)` にする方法も考えられるが、元に戻すのが安全だと判断しました