### PR TITLE
正規化するときは、 `ExportRootに回転・拡大縮小` があってもよい。

### DIFF
--- a/Assets/VRM/UniVRM/Editor/Format/VRMExporterWizard.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExporterWizard.cs
@@ -368,11 +368,6 @@ namespace VRM
                 Validation.Error(Msg(VRMExporterWizardMessages.NO_PARENT)).DrawGUI();
                 return;
             }
-            if (ExportRoot.transform.localRotation != Quaternion.identity || ExportRoot.transform.localScale != Vector3.one)
-            {
-                Validation.Error(Msg(VRMExporterWizardMessages.ROOT_WITHOUT_ROTATION_AND_SCALING_CHANGED)).DrawGUI();
-                return;
-            }
 
             var renderers = ExportRoot.GetComponentsInChildren<Renderer>();
             if (renderers.All(x => !x.EnableForExport()))


### PR DESCRIPTION
`VRMExporterWizardMessages.ROOT_WITHOUT_ROTATION_AND_SCALING_CHANGED` 時のエクスポート禁止を削除。
`VRMExporterWizardMessages.ROTATION_OR_SCALEING_INCLUDED_IN_NODE` 警告が出るのでよし。