### PR TITLE
add BlendShapeClip Validation

### DIFF
--- a/Assets/VRM/UniVRM/Editor/BlendShape/VRMBlendShapeProxyValidator.cs
+++ b/Assets/VRM/UniVRM/Editor/BlendShape/VRMBlendShapeProxyValidator.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace VRM
+{
+    public static class VRMBlendShapeProxyValidator
+    {
+        public static IEnumerable<Validation> Validate(this VRMBlendShapeProxy p)
+        {
+            if (p == null)
+            {
+                yield return Validation.Error("VRMBlendShapeProxy is null");
+                yield break;
+            }
+
+            if (p.BlendShapeAvatar == null)
+            {
+                yield return Validation.Error("BlendShapeAvatar is null");
+                yield break;
+            }
+
+            // presetがユニークか
+            var used = new HashSet<BlendShapeKey>();
+            foreach (var c in p.BlendShapeAvatar.Clips)
+            {
+                var key = c.Key;
+                if (used.Contains(key))
+                {
+                    yield return Validation.Error($"duplicated BlendShapeKey: {c}");
+                }
+                else
+                {
+                    used.Add(key);
+                }
+            }
+
+            var materialNames = new HashSet<string>();
+            foreach (var r in p.GetComponentsInChildren<Renderer>(true))
+            {
+                foreach (var m in r.sharedMaterials)
+                {
+                    if (!materialNames.Contains(m.name))
+                    {
+                        materialNames.Add(m.name);
+                    }
+                }
+            }
+
+            // 参照が生きているか
+            foreach (var c in p.BlendShapeAvatar.Clips)
+            {
+                for (int i = 0; i < c.Values.Length; ++i)
+                {
+                    var v = c.Values[i];
+                    var target = p.transform.Find(v.RelativePath);
+                    if (target == null)
+                    {
+                        yield return Validation.Error($"{c}.Values[{i}].RelativePath({v.RelativePath} is not found");
+                    }
+                }
+
+                for (int i = 0; i < c.MaterialValues.Length; ++i)
+                {
+                    var v = c.MaterialValues[i];
+                    if (!materialNames.Contains(v.MaterialName))
+                    {
+                        yield return Validation.Error($"{c}.MaterialValues[{i}].MaterialName({v.MaterialName} is not found");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/VRM/UniVRM/Editor/BlendShape/VRMBlendShapeProxyValidator.cs
+++ b/Assets/VRM/UniVRM/Editor/BlendShape/VRMBlendShapeProxyValidator.cs
@@ -26,7 +26,7 @@ namespace VRM
                 var key = c.Key;
                 if (used.Contains(key))
                 {
-                    yield return Validation.Error($"duplicated BlendShapeKey: {c}");
+                    yield return Validation.Error($"duplicated BlendShapeKey: {key}");
                 }
                 else
                 {
@@ -55,7 +55,7 @@ namespace VRM
                     var target = p.transform.Find(v.RelativePath);
                     if (target == null)
                     {
-                        yield return Validation.Error($"{c}.Values[{i}].RelativePath({v.RelativePath} is not found");
+                        yield return Validation.Warning($"{c}.Values[{i}].RelativePath({v.RelativePath} is not found");
                     }
                 }
 
@@ -64,7 +64,7 @@ namespace VRM
                     var v = c.MaterialValues[i];
                     if (!materialNames.Contains(v.MaterialName))
                     {
-                        yield return Validation.Error($"{c}.MaterialValues[{i}].MaterialName({v.MaterialName} is not found");
+                        yield return Validation.Warning($"{c}.MaterialValues[{i}].MaterialName({v.MaterialName} is not found");
                     }
                 }
             }

--- a/Assets/VRM/UniVRM/Editor/BlendShape/VRMBlendShapeProxyValidator.cs.meta
+++ b/Assets/VRM/UniVRM/Editor/BlendShape/VRMBlendShapeProxyValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50a28b39ccee4874b85d99c095180e5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM/UniVRM/Editor/FirstPerson/RendererFirstPersonFlagsDrawer.cs
+++ b/Assets/VRM/UniVRM/Editor/FirstPerson/RendererFirstPersonFlagsDrawer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
 
 
@@ -11,11 +9,11 @@ namespace VRM
     {
         static Rect LeftSide(Rect position, float width)
         {
-            return new Rect(position.x, position.y, position.width-width, position.height);
+            return new Rect(position.x, position.y, position.width - width, position.height);
         }
         static Rect RightSide(Rect position, float width)
         {
-            return new Rect(position.x + (position.width-width), position.y, width, position.height);
+            return new Rect(position.x + (position.width - width), position.y, width, position.height);
         }
 
         public override void OnGUI(Rect position,
@@ -28,13 +26,5 @@ namespace VRM
             EditorGUI.PropertyField(LeftSide(position, WIDTH), rendererProp, new GUIContent(""), true);
             EditorGUI.PropertyField(RightSide(position, WIDTH), flagProp, new GUIContent(""), true);
         }
-
-        /*
-        public override float GetPropertyHeight(SerializedProperty property,
-                                                                  GUIContent label)
-        {
-            return 60.0f;
-        }
-        */
     }
 }

--- a/Assets/VRM/UniVRM/Editor/FirstPerson/VRMFirstPersonValidator.cs
+++ b/Assets/VRM/UniVRM/Editor/FirstPerson/VRMFirstPersonValidator.cs
@@ -6,28 +6,43 @@ namespace VRM
 {
     public static class VRMFirstPersonValidator
     {
+        public static Transform[] Hierarchy;
+
+        public static bool IsValid(this VRMFirstPerson.RendererFirstPersonFlags r, string name, out Validation validation)
+        {
+            if (r.Renderer == null)
+            {
+                validation = Validation.Error($"{name}.Renderer is null");
+                return false;
+            }
+
+            if (!Hierarchy.Contains(r.Renderer.transform))
+            {
+                validation = Validation.Error($"{name}.Renderer is out of hierarchy");
+                return false;
+            }
+
+            if (!r.Renderer.EnableForExport())
+            {
+                validation = Validation.Error($"{name}.Renderer is not active");
+                return false;
+            }
+
+            validation = default;
+            return true;
+        }
+
         public static IEnumerable<Validation> Validate(this VRMFirstPerson self)
         {
-            var hierarchy = self.GetComponentsInChildren<Transform>(true);
+            Hierarchy = self.GetComponentsInChildren<Transform>(true);
 
             for (int i = 0; i < self.Renderers.Count; ++i)
             {
-                var r = self.Renderers[i];
-                if (r.Renderer == null)
+                if (!IsValid(self.Renderers[i], $"[VRMFirstPerson]{self.name}.Renderers[{i}]", out Validation v))
                 {
-                    yield return Validation.Error($"[VRMFirstPerson]{self.name}.Renderers[{i}].Renderer is null");
-                    continue;
-                }
-                if (!hierarchy.Contains(r.Renderer.transform))
-                {
-                    yield return Validation.Error($"[VRMFirstPerson]{self.name}.Renderers[{i}].Renderer is out of hierarchy");
-                }
-                if (!r.Renderer.EnableForExport())
-                {
-                    yield return Validation.Error($"[VRMFirstPerson]{self.name}.Renderers[{i}].Renderer is not active");
+                    yield return v;
                 }
             }
-            yield break;
         }
     }
 }

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExporterWizard.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExporterWizard.cs
@@ -178,6 +178,8 @@ namespace VRM
             if (Event.current.type == EventType.Layout)
             {
                 // ArgumentException: Getting control 1's position in a group with only 1 controls when doing repaint Aborting
+                // Validation により GUI の表示項目が変わる場合があるので、
+                // EventType.Layout と EventType.Repaint 間で内容が変わらないようしている。
                 if (m_requireValidation)
                 {
                     m_validator.Validate(ExportRoot, m_settings, Meta != null ? Meta : m_tmpMeta);
@@ -186,7 +188,7 @@ namespace VRM
             }
 
             //
-            // 事前チェック。ここで失敗する場合は Export UI を表示しない
+            // Humanoid として適正か？ ここで失敗する場合は Export UI を表示しない
             //
             if (!m_validator.RootAndHumanoidCheck(ExportRoot, m_settings))
             {
@@ -202,7 +204,7 @@ namespace VRM
             GUIUtility.GetControlID(645789, FocusType.Passive);
 
             //
-            // その他の Validation
+            // VRM の Validation
             //
             foreach (var v in m_validator.Validations)
             {

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRMExtensions.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRMExtensions.cs
@@ -19,7 +19,12 @@ namespace VRM
         public static glTF_VRM_BlendShapeBind Create(Transform root, BlendShapeBinding binding,
             gltfExporter exporter)
         {
-            var transform = UniGLTF.UnityExtensions.GetFromPath(root.transform, binding.RelativePath);
+            var transform = root.transform.Find(binding.RelativePath);
+            if (transform == null)
+            {
+                Debug.LogWarning($"{binding.RelativePath} not found");
+                return null;
+            }
             var renderer = transform.GetComponent<SkinnedMeshRenderer>();
             if (renderer == null)
             {
@@ -38,7 +43,7 @@ namespace VRM
                 return null;
             }
 
-            if(!exporter.MeshBlendShapeIndexMap.TryGetValue(mesh, out Dictionary<int, int> blendShapeIndexMap))
+            if (!exporter.MeshBlendShapeIndexMap.TryGetValue(mesh, out Dictionary<int, int> blendShapeIndexMap))
             {
                 // この Mesh は  エクスポートされていない
                 return null;

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRMExtensions.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRMExtensions.cs
@@ -19,13 +19,27 @@ namespace VRM
         public static glTF_VRM_BlendShapeBind Create(Transform root, BlendShapeBinding binding,
             gltfExporter exporter)
         {
-            var transform = root.transform.Find(binding.RelativePath);
-            if (transform == null)
+            if (string.IsNullOrEmpty((binding.RelativePath)))
             {
-                Debug.LogWarning($"{binding.RelativePath} not found");
+                Debug.LogWarning("binding.RelativePath is null");
                 return null;
             }
-            var renderer = transform.GetComponent<SkinnedMeshRenderer>();
+            var found = root.transform.Find(binding.RelativePath);
+            if (found == null)
+            {
+                var name = binding.RelativePath.Split('/').Last();
+                found = root.GetComponentsInChildren<Transform>().Where(x => x.name == name).First();
+                if (found == null)
+                {
+                    Debug.LogWarning($"{binding.RelativePath} not found");
+                    return null;
+                }
+                else
+                {
+                    Debug.LogWarning($"fall back '{binding.RelativePath}' => '{found.RelativePathFrom(root)}'");
+                }
+            }
+            var renderer = found.GetComponent<SkinnedMeshRenderer>();
             if (renderer == null)
             {
                 return null;


### PR DESCRIPTION
* Validation for BlendShapeClip.Values
  * target renderer not found => find same name renderer in hierarchy , and use first
* Validation for BlendShapeClip.MaterialValues

#551 #555

* VrmFirstPerson の Inspector に Validation 表示。reset button

#554

![validation](https://user-images.githubusercontent.com/68057/93169523-3832dd00-f760-11ea-8aee-3a5bb054d773.jpg)

If you ignore the warning, the export is possible and no error occurs, but the corresponding BlendShape is skipped.
