### PR TITLE
テクスチャサンプラ適用処理を ITextureLoader が持つ

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
@@ -163,8 +163,7 @@ namespace UniGLTF
                 var textureType = TextureIO.GetglTFTextureType(gltf, m_textureIndex);
                 var colorSpace = TextureIO.GetColorSpace(textureType);
                 var isLinear = colorSpace == RenderTextureReadWrite.Linear;
-                yield return m_textureLoader.ProcessOnMainThread(isLinear);
-                TextureSamplerUtil.SetSampler(Texture, gltf.GetSamplerFromTextureIndex(m_textureIndex));
+                yield return m_textureLoader.ProcessOnMainThread(isLinear, gltf.GetSamplerFromTextureIndex(m_textureIndex));
             }
         }
         #endregion

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureLoader.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureLoader.cs
@@ -25,8 +25,9 @@ namespace UniGLTF
         /// Call from unity main thread
         /// </summary>
         /// <param name="isLinear"></param>
+        /// <param name="sampler"></param>
         /// <returns></returns>
-        IEnumerator ProcessOnMainThread(bool isLinear);
+        IEnumerator ProcessOnMainThread(bool isLinear, glTFTextureSampler sampler);
     }
 
 #if UNITY_EDITOR
@@ -53,7 +54,7 @@ namespace UniGLTF
         {
         }
 
-        public IEnumerator ProcessOnMainThread(bool isLinear)
+        public IEnumerator ProcessOnMainThread(bool isLinear, glTFTextureSampler sampler)
         {
             //
             // texture from assets
@@ -90,6 +91,12 @@ namespace UniGLTF
 
                 importer.SaveAndReimport();
             }
+            
+            if (sampler != null)
+            {
+                TextureSamplerUtil.SetSampler(Texture, sampler);
+            }
+            
             yield break;
         }
     }
@@ -140,7 +147,7 @@ namespace UniGLTF
             m_imageBytes = ToArray(segments);
         }
 
-        public IEnumerator ProcessOnMainThread(bool isLinear)
+        public IEnumerator ProcessOnMainThread(bool isLinear, glTFTextureSampler sampler)
         {
             //
             // texture from image(png etc) bytes
@@ -150,6 +157,10 @@ namespace UniGLTF
             if (m_imageBytes != null)
             {
                 Texture.LoadImage(m_imageBytes);
+            }
+            if (sampler != null)
+            {
+                TextureSamplerUtil.SetSampler(Texture, sampler);
             }
             yield break;
         }
@@ -274,7 +285,7 @@ namespace UniGLTF
             }
         }
 
-        public IEnumerator ProcessOnMainThread(bool isLinear)
+        public IEnumerator ProcessOnMainThread(bool isLinear, glTFTextureSampler sampler)
         {
             // tmp file
             var tmp = Path.GetTempFileName();
@@ -327,6 +338,10 @@ namespace UniGLTF
 #else
 #error Unsupported Unity version
 #endif
+            }
+            if (sampler != null)
+            {
+                TextureSamplerUtil.SetSampler(Texture, sampler);
             }
         }
     }


### PR DESCRIPTION
`ITextureLoader` はテクスチャを実際に Unity Object に変換する処理を担当する。
ここで、テクスチャサンプラはテクスチャの属性のひとつなので `ITextureLoader` で処理するのが望ましい。
しかし現状は `ITextureLoader` の外で処理されているため `ITextureLoader` でテクスチャサンプラに独自の処理を
入れることができない。

したがって `ITextureLoader` のインタフェースを変更し、これを達成する。