### PR TITLE
生成シリアライザをデフォルトにする

### DIFF
--- a/Assets/VRM/UniGLTF/Editor/Serialization/SerializerGenerator.cs
+++ b/Assets/VRM/UniGLTF/Editor/Serialization/SerializerGenerator.cs
@@ -59,6 +59,9 @@ namespace UniGLTF
                 {"gltf/accessors[]/max", "if(value.max!=null && value.max.Length>0)"},
                 {"gltf/accessors[]/min", "if(value.min!=null && value.min.Length>0)"},
                 {"gltf/accessors[]/sparse", "if(value.sparse!=null && value.sparse.count>0)"},
+                {"gltf/accessors[]/bufferView", "if(value.bufferView>=0)"},
+                {"gltf/accessors[]/byteOffset", "if(value.bufferView>=0)"},
+
                 {"gltf/images", "if(value.images!=null && value.images.Count>0)" },
 
                 {"gltf/meshes", "if(value.meshes!=null && value.meshes.Count>0)" },

--- a/Assets/VRM/UniGLTF/Editor/Serialization/SerializerGenerator.cs
+++ b/Assets/VRM/UniGLTF/Editor/Serialization/SerializerGenerator.cs
@@ -44,13 +44,13 @@ namespace UniGLTF
             Stream m_s;
             StreamWriter m_w;
 
-            static Dictionary<string, string> s_snipets = new Dictionary<string, string>
+            static Dictionary<string, string> s_snippets = new Dictionary<string, string>
             {
                 {"gltf/animations", "if(value.animations!=null && value.animations.Count>0)" },
                 {"gltf/cameras", "if(value.cameras!=null && value.cameras.Count>0)" },
                 {"gltf/buffers", "if(value.buffers!=null && value.buffers.Count>0)" },
                 {"gltf/bufferViews", "if(value.bufferViews!=null && value.bufferViews.Count>0)" },
-                {"gltf/bufferViews[]/byteStride", "if(false)" },
+                {"gltf/bufferViews[]/byteStride", "" },
                 {"gltf/bufferViews[]/target", "if(value.target!=0)" },
                 {"gltf/animations[]/channels", "if(value.channels!=null && value.channels.Count>0)" },
                 {"gltf/animations[]/channels[]/target", "if(value!=null)" },
@@ -276,7 +276,7 @@ namespace UniGLTF {
                         {
 
                         }
-                        else if(fi.FieldType == typeof(glTF_KHR_materials_unlit))
+                        else if (fi.FieldType == typeof(glTF_KHR_materials_unlit))
                         {
 
                         }
@@ -287,20 +287,27 @@ namespace UniGLTF {
 
                         var snipet = fi.FieldType.IsClass ? "if(value." + fi.Name + "!=null)" : "";
                         var value = default(string);
-                        if (s_snipets.TryGetValue(path + "/" + fi.Name, out value))
+                        if (s_snippets.TryGetValue(path + "/" + fi.Name, out value))
                         {
                             snipet = value;
                         }
 
-                        m_w.Write(@"
+                        if (value == "")
+                        {
+                            // found, but empty
+                        }
+                        else
+                        {
+                            m_w.Write(@"
         $1
         {
             f.Key(""$0""); f.GenSerialize(value.$0);
         }
 "
-.Replace("$0", fi.Name)
-.Replace("$1", snipet)
-);
+    .Replace("$0", fi.Name)
+    .Replace("$1", snipet)
+    );
+                        }
                     }
 
                     m_w.Write(@"

--- a/Assets/VRM/UniGLTF/Editor/Serialization/SerializerGenerator.cs
+++ b/Assets/VRM/UniGLTF/Editor/Serialization/SerializerGenerator.cs
@@ -80,7 +80,7 @@ namespace UniGLTF
                 {"gltf/meshes[]/primitives[]/extras", "if(value.extras!=null && value.extras.targetNames!=null && value.extras.targetNames.Count>0)"},
                 {"gltf/meshes[]/weights", "if(value.weights!=null && value.weights.Length>0)" },
                 {"gltf/materials", "if(value.materials!=null && value.materials.Count>0)" },
-                {"gltf/materials[]/alphaCutoff", "if(!string.IsNullOrEmpty(value.alphaMode))" },
+                {"gltf/materials[]/alphaCutoff", "if(value.alphaMode == \"MASK\")" },
                 {"gltf/nodes", "if(value.nodes!=null && value.nodes.Count>0)" },
                 {"gltf/nodes[]/camera", "if(value.camera!=-1)"},
                 {"gltf/nodes[]/mesh", "if(value.mesh!=-1)"},

--- a/Assets/VRM/UniGLTF/Editor/Tests/UniGLTFTests.cs
+++ b/Assets/VRM/UniGLTF/Editor/Tests/UniGLTFTests.cs
@@ -666,10 +666,7 @@ namespace UniGLTF
 
                 // import new version
                 {
-                    var context = new ImporterContext
-                    {
-                        SerializerType = SerializerTypes.UniJSON
-                    };
+                    var context = new ImporterContext();
                     context.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
                     //Debug.LogFormat("{0}", context.Json);
                     context.Load();

--- a/Assets/VRM/UniGLTF/Scripts/Format/SerializerTypes.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/SerializerTypes.cs
@@ -2,8 +2,8 @@
 {
     public enum SerializerTypes
     {
+        Generated, // generated, No AOT Problem
         JsonSerializable, // manual, Obsolete
-        UniJSON, // reflection
-        Generated, // generated, experimental for mobile
+        UniJSON, // reflection, Obsolete
     }
 }

--- a/Assets/VRM/UniGLTF/Scripts/Format/glTF.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTF.cs
@@ -427,10 +427,10 @@ namespace UniGLTF
 
         void Traverse(ListTreeNode<JsonValue> node, JsonFormatter f, Utf8String parentKey)
         {
-            if(node.IsMap())
+            if (node.IsMap())
             {
                 f.BeginMap();
-                foreach(var kv in node.ObjectItems())
+                foreach (var kv in node.ObjectItems())
                 {
                     if (parentKey == s_extensions)
                     {
@@ -444,10 +444,10 @@ namespace UniGLTF
                 }
                 f.EndMap();
             }
-            else if(node.IsArray())
+            else if (node.IsArray())
             {
                 f.BeginList();
-                foreach(var x in node.ArrayItems())
+                foreach (var x in node.ArrayItems())
                 {
                     Traverse(x, f, default(Utf8String));
                 }
@@ -468,11 +468,12 @@ namespace UniGLTF
             return f.ToString();
         }
 
-        public byte[] ToGlbBytes(SerializerTypes serializer = SerializerTypes.UniJSON)
+        public byte[] ToGlbBytes(SerializerTypes serializer = SerializerTypes.Generated)
         {
             string json;
             if (serializer == SerializerTypes.UniJSON)
             {
+                // Obsolete
                 var c = new JsonSchemaValidationContext(this)
                 {
                     EnableDiagnosisForNotRequiredFields = true,
@@ -485,7 +486,7 @@ namespace UniGLTF
                 f.GenSerialize(this);
                 json = f.ToString().ParseAsJson().ToString("  ");
             }
-            else if(serializer == SerializerTypes.JsonSerializable)
+            else if (serializer == SerializerTypes.JsonSerializable)
             {
                 // Obsolete
                 json = ToJson();

--- a/Assets/VRM/UniGLTF/Scripts/IO/FormatterExtensionsGltf.g.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/FormatterExtensionsGltf.g.cs
@@ -572,7 +572,7 @@ namespace UniGLTF {
             f.Key("alphaMode"); f.GenSerialize(value.alphaMode);
         }
 
-        if(!string.IsNullOrEmpty(value.alphaMode))
+        if(value.alphaMode == "MASK")
         {
             f.Key("alphaCutoff"); f.GenSerialize(value.alphaCutoff);
         }

--- a/Assets/VRM/UniGLTF/Scripts/IO/FormatterExtensionsGltf.g.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/FormatterExtensionsGltf.g.cs
@@ -246,12 +246,12 @@ namespace UniGLTF {
     {
         f.BeginMap(0); // dummy
 
-        
+        if(value.bufferView>=0)
         {
             f.Key("bufferView"); f.GenSerialize(value.bufferView);
         }
 
-        
+        if(value.bufferView>=0)
         {
             f.Key("byteOffset"); f.GenSerialize(value.byteOffset);
         }

--- a/Assets/VRM/UniGLTF/Scripts/IO/FormatterExtensionsGltf.g.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/FormatterExtensionsGltf.g.cs
@@ -212,11 +212,6 @@ namespace UniGLTF {
             f.Key("byteLength"); f.GenSerialize(value.byteLength);
         }
 
-        if(false)
-        {
-            f.Key("byteStride"); f.GenSerialize(value.byteStride);
-        }
-
         if(value.target!=0)
         {
             f.Key("target"); f.GenSerialize(value.target);

--- a/Assets/VRM/UniGLTF/Scripts/IO/GltfDeserializer.g.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/GltfDeserializer.g.cs
@@ -655,9 +655,85 @@ public static glTFMaterialBaseColorTextureInfo Deserialize_gltf_materials__pbrMe
             continue;
         }
 
+        if(key=="extensions"){
+            value.extensions = Deserialize_gltf_materials__pbrMetallicRoughness_baseColorTexture_extensions(kv.Value);
+            continue;
+        }
+
     }
     return value;
 }
+
+public static glTFTextureInfo_extensions Deserialize_gltf_materials__pbrMetallicRoughness_baseColorTexture_extensions(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTFTextureInfo_extensions();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="KHR_texture_transform"){
+            value.KHR_texture_transform = Deserialize_gltf_materials__pbrMetallicRoughness_baseColorTexture_extensions_KHR_texture_transform(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static glTF_KHR_texture_transform Deserialize_gltf_materials__pbrMetallicRoughness_baseColorTexture_extensions_KHR_texture_transform(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTF_KHR_texture_transform();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="offset"){
+            value.offset = Deserialize_gltf_materials__pbrMetallicRoughness_baseColorTexture_extensions_KHR_texture_transform_offset(kv.Value);
+            continue;
+        }
+
+        if(key=="rotation"){
+            value.rotation = kv.Value.GetSingle();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.scale = Deserialize_gltf_materials__pbrMetallicRoughness_baseColorTexture_extensions_KHR_texture_transform_scale(kv.Value);
+            continue;
+        }
+
+        if(key=="texCoord"){
+            value.texCoord = kv.Value.GetInt32();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static Single[] Deserialize_gltf_materials__pbrMetallicRoughness_baseColorTexture_extensions_KHR_texture_transform_offset(ListTreeNode<JsonValue> parsed)
+{
+    var value = new Single[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Single[] Deserialize_gltf_materials__pbrMetallicRoughness_baseColorTexture_extensions_KHR_texture_transform_scale(ListTreeNode<JsonValue> parsed)
+{
+    var value = new Single[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
 
 public static Single[] Deserialize_gltf_materials__pbrMetallicRoughness_baseColorFactor(ListTreeNode<JsonValue> parsed)
 {
@@ -688,9 +764,85 @@ public static glTFMaterialMetallicRoughnessTextureInfo Deserialize_gltf_material
             continue;
         }
 
+        if(key=="extensions"){
+            value.extensions = Deserialize_gltf_materials__pbrMetallicRoughness_metallicRoughnessTexture_extensions(kv.Value);
+            continue;
+        }
+
     }
     return value;
 }
+
+public static glTFTextureInfo_extensions Deserialize_gltf_materials__pbrMetallicRoughness_metallicRoughnessTexture_extensions(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTFTextureInfo_extensions();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="KHR_texture_transform"){
+            value.KHR_texture_transform = Deserialize_gltf_materials__pbrMetallicRoughness_metallicRoughnessTexture_extensions_KHR_texture_transform(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static glTF_KHR_texture_transform Deserialize_gltf_materials__pbrMetallicRoughness_metallicRoughnessTexture_extensions_KHR_texture_transform(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTF_KHR_texture_transform();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="offset"){
+            value.offset = Deserialize_gltf_materials__pbrMetallicRoughness_metallicRoughnessTexture_extensions_KHR_texture_transform_offset(kv.Value);
+            continue;
+        }
+
+        if(key=="rotation"){
+            value.rotation = kv.Value.GetSingle();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.scale = Deserialize_gltf_materials__pbrMetallicRoughness_metallicRoughnessTexture_extensions_KHR_texture_transform_scale(kv.Value);
+            continue;
+        }
+
+        if(key=="texCoord"){
+            value.texCoord = kv.Value.GetInt32();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static Single[] Deserialize_gltf_materials__pbrMetallicRoughness_metallicRoughnessTexture_extensions_KHR_texture_transform_offset(ListTreeNode<JsonValue> parsed)
+{
+    var value = new Single[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Single[] Deserialize_gltf_materials__pbrMetallicRoughness_metallicRoughnessTexture_extensions_KHR_texture_transform_scale(ListTreeNode<JsonValue> parsed)
+{
+    var value = new Single[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
 
 public static glTFMaterialNormalTextureInfo Deserialize_gltf_materials__normalTexture(ListTreeNode<JsonValue> parsed)
 {
@@ -715,9 +867,85 @@ public static glTFMaterialNormalTextureInfo Deserialize_gltf_materials__normalTe
             continue;
         }
 
+        if(key=="extensions"){
+            value.extensions = Deserialize_gltf_materials__normalTexture_extensions(kv.Value);
+            continue;
+        }
+
     }
     return value;
 }
+
+public static glTFTextureInfo_extensions Deserialize_gltf_materials__normalTexture_extensions(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTFTextureInfo_extensions();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="KHR_texture_transform"){
+            value.KHR_texture_transform = Deserialize_gltf_materials__normalTexture_extensions_KHR_texture_transform(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static glTF_KHR_texture_transform Deserialize_gltf_materials__normalTexture_extensions_KHR_texture_transform(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTF_KHR_texture_transform();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="offset"){
+            value.offset = Deserialize_gltf_materials__normalTexture_extensions_KHR_texture_transform_offset(kv.Value);
+            continue;
+        }
+
+        if(key=="rotation"){
+            value.rotation = kv.Value.GetSingle();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.scale = Deserialize_gltf_materials__normalTexture_extensions_KHR_texture_transform_scale(kv.Value);
+            continue;
+        }
+
+        if(key=="texCoord"){
+            value.texCoord = kv.Value.GetInt32();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static Single[] Deserialize_gltf_materials__normalTexture_extensions_KHR_texture_transform_offset(ListTreeNode<JsonValue> parsed)
+{
+    var value = new Single[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Single[] Deserialize_gltf_materials__normalTexture_extensions_KHR_texture_transform_scale(ListTreeNode<JsonValue> parsed)
+{
+    var value = new Single[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
 
 public static glTFMaterialOcclusionTextureInfo Deserialize_gltf_materials__occlusionTexture(ListTreeNode<JsonValue> parsed)
 {
@@ -742,9 +970,85 @@ public static glTFMaterialOcclusionTextureInfo Deserialize_gltf_materials__occlu
             continue;
         }
 
+        if(key=="extensions"){
+            value.extensions = Deserialize_gltf_materials__occlusionTexture_extensions(kv.Value);
+            continue;
+        }
+
     }
     return value;
 }
+
+public static glTFTextureInfo_extensions Deserialize_gltf_materials__occlusionTexture_extensions(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTFTextureInfo_extensions();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="KHR_texture_transform"){
+            value.KHR_texture_transform = Deserialize_gltf_materials__occlusionTexture_extensions_KHR_texture_transform(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static glTF_KHR_texture_transform Deserialize_gltf_materials__occlusionTexture_extensions_KHR_texture_transform(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTF_KHR_texture_transform();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="offset"){
+            value.offset = Deserialize_gltf_materials__occlusionTexture_extensions_KHR_texture_transform_offset(kv.Value);
+            continue;
+        }
+
+        if(key=="rotation"){
+            value.rotation = kv.Value.GetSingle();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.scale = Deserialize_gltf_materials__occlusionTexture_extensions_KHR_texture_transform_scale(kv.Value);
+            continue;
+        }
+
+        if(key=="texCoord"){
+            value.texCoord = kv.Value.GetInt32();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static Single[] Deserialize_gltf_materials__occlusionTexture_extensions_KHR_texture_transform_offset(ListTreeNode<JsonValue> parsed)
+{
+    var value = new Single[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Single[] Deserialize_gltf_materials__occlusionTexture_extensions_KHR_texture_transform_scale(ListTreeNode<JsonValue> parsed)
+{
+    var value = new Single[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
 
 public static glTFMaterialEmissiveTextureInfo Deserialize_gltf_materials__emissiveTexture(ListTreeNode<JsonValue> parsed)
 {
@@ -764,9 +1068,85 @@ public static glTFMaterialEmissiveTextureInfo Deserialize_gltf_materials__emissi
             continue;
         }
 
+        if(key=="extensions"){
+            value.extensions = Deserialize_gltf_materials__emissiveTexture_extensions(kv.Value);
+            continue;
+        }
+
     }
     return value;
 }
+
+public static glTFTextureInfo_extensions Deserialize_gltf_materials__emissiveTexture_extensions(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTFTextureInfo_extensions();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="KHR_texture_transform"){
+            value.KHR_texture_transform = Deserialize_gltf_materials__emissiveTexture_extensions_KHR_texture_transform(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static glTF_KHR_texture_transform Deserialize_gltf_materials__emissiveTexture_extensions_KHR_texture_transform(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTF_KHR_texture_transform();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="offset"){
+            value.offset = Deserialize_gltf_materials__emissiveTexture_extensions_KHR_texture_transform_offset(kv.Value);
+            continue;
+        }
+
+        if(key=="rotation"){
+            value.rotation = kv.Value.GetSingle();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.scale = Deserialize_gltf_materials__emissiveTexture_extensions_KHR_texture_transform_scale(kv.Value);
+            continue;
+        }
+
+        if(key=="texCoord"){
+            value.texCoord = kv.Value.GetInt32();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static Single[] Deserialize_gltf_materials__emissiveTexture_extensions_KHR_texture_transform_offset(ListTreeNode<JsonValue> parsed)
+{
+    var value = new Single[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Single[] Deserialize_gltf_materials__emissiveTexture_extensions_KHR_texture_transform_scale(ListTreeNode<JsonValue> parsed)
+{
+    var value = new Single[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
 
 public static Single[] Deserialize_gltf_materials__emissiveFactor(ListTreeNode<JsonValue> parsed)
 {
@@ -837,6 +1217,11 @@ public static glTFMesh Deserialize_gltf_meshes_LIST(ListTreeNode<JsonValue> pars
 
         if(key=="weights"){
             value.weights = Deserialize_gltf_meshes__weights(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.extras = Deserialize_gltf_meshes__extras(kv.Value);
             continue;
         }
 
@@ -1032,6 +1417,32 @@ public static Single[] Deserialize_gltf_meshes__weights(ListTreeNode<JsonValue> 
 	return value;
 } 
 
+public static glTFMesh_extras Deserialize_gltf_meshes__extras(ListTreeNode<JsonValue> parsed)
+{
+    var value = new glTFMesh_extras();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="targetNames"){
+            value.targetNames = Deserialize_gltf_meshes__extras_targetNames(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<System.String> Deserialize_gltf_meshes__extras_targetNames(ListTreeNode<JsonValue> parsed)
+{
+    var value = new List<String>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(x.GetString());
+    }
+	return value;
+}
 public static List<UniGLTF.glTFNode> Deserialize_gltf_nodes(ListTreeNode<JsonValue> parsed)
 {
     var value = new List<glTFNode>();

--- a/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
@@ -271,7 +271,7 @@ namespace UniGLTF
             }
         }
 
-        private SerializerTypes _serializerType = SerializerTypes.UniJSON;
+        private SerializerTypes _serializerType = SerializerTypes.Generated;
         public SerializerTypes SerializerType { get { return _serializerType; } set { _serializerType = value; } }
 
         public virtual void ParseJson(string json, IStorage storage)
@@ -281,6 +281,7 @@ namespace UniGLTF
 
             if (_serializerType == SerializerTypes.UniJSON)
             {
+                // Obsolete
                 Json.ParseAsJson().Deserialize(ref GLTF);
             }
             else if (_serializerType == SerializerTypes.Generated)

--- a/Assets/VRM/UniVRM/Editor/Format/VRMEditorExporter.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMEditorExporter.cs
@@ -231,7 +231,7 @@ namespace VRM
                 // vrm.extensions.VRM.meta.contactInformation = settings.ContactInformation;
                 // vrm.extensions.VRM.meta.reference = settings.Reference;
 
-                var bytes = vrm.ToGlbBytes(settings.UseExperimentalExporter ? SerializerTypes.Generated : SerializerTypes.UniJSON);
+                var bytes = vrm.ToGlbBytes();
                 File.WriteAllBytes(path, bytes);
                 Debug.LogFormat("Export elapsed {0}", sw.Elapsed);
             }

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExportSettings.cs
@@ -19,12 +19,6 @@ namespace VRM
         public bool PoseFreeze = true;
 
         /// <summary>
-        /// エクスポート時に新しいJsonSerializerを使う
-        /// </summary>
-        [Tooltip("Use new JSON serializer")]
-        public bool UseExperimentalExporter = false;
-
-        /// <summary>
         /// BlendShapeのシリアライズにSparseAccessorを使う
         /// </summary>
         [Tooltip("Use sparse accessor for blendshape. This may reduce vrm size")]

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExportSettingsEditor.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExportSettingsEditor.cs
@@ -86,7 +86,6 @@ namespace VRM
 
         CheckBoxProp m_forceTPose;
         CheckBoxProp m_poseFreeze;
-        CheckBoxProp m_useExcperimentalExporter;
         CheckBoxProp m_useSparseAccessor;
         CheckBoxProp m_onlyBlendShapePosition;
         CheckBoxProp m_reduceBlendShape;
@@ -137,7 +136,6 @@ namespace VRM
         {
             m_forceTPose = new CheckBoxProp(serializedObject.FindProperty(nameof(ForceTPose)), Options.FORCE_T_POSE);
             m_poseFreeze = new CheckBoxProp(serializedObject.FindProperty(nameof(PoseFreeze)), Options.NORMALIZE);
-            m_useExcperimentalExporter = new CheckBoxProp(serializedObject.FindProperty(nameof(UseExperimentalExporter)), Options.USE_GENERATED_SERIALIZER);
             m_useSparseAccessor = new CheckBoxProp(serializedObject.FindProperty(nameof(UseSparseAccessor)), Options.BLENDSHAPE_USE_SPARSE);
             m_onlyBlendShapePosition = new CheckBoxProp(serializedObject.FindProperty(nameof(OnlyBlendshapePosition)), Options.BLENDSHAPE_EXCLUDE_NORMAL_AND_TANGENT);
             m_reduceBlendShape = new CheckBoxProp(serializedObject.FindProperty(nameof(ReduceBlendshape)), Options.BLENDSHAPE_ONLY_CLIP_USE);
@@ -151,7 +149,6 @@ namespace VRM
             serializedObject.Update();
             m_forceTPose.Draw();
             m_poseFreeze.Draw();
-            m_useExcperimentalExporter.Draw();
             m_useSparseAccessor.Draw();
             m_onlyBlendShapePosition.Draw();
             m_reduceBlendShape.Draw();


### PR DESCRIPTION
#553
#490

https://github.com/KhronosGroup/glTF-Validator/blob/1be41dd1acdfe21ee9e577577bc2183e6861345a/ISSUES.md

* `BUFFER_VIEW_TARGET_OVERRIDE`
* `ACCESSOR_MAX_MISMATCH`

は、validator の方に 修正が要ると思う。

https://github.com/KhronosGroup/glTF-Sample-Models

に該当するサンプルを送って修正依頼を試みる。
(違うタイプの sparse しかサンプルが無い )

* Microsoft 3D Viewer
* Three.js
* babylon.js

での動作を確認した。
