### PR TITLE
fix warning CS0649

### DIFF
--- a/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs
+++ b/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs
@@ -16,7 +16,7 @@ namespace VRM
         [SerializeField]
         public string m_comment;
 
-        [SerializeField] [Header("Gizmo")] private bool m_drawGizmo;
+        [SerializeField] [Header("Gizmo")] private bool m_drawGizmo = default;
 
         [SerializeField] private Color m_gizmoColor = Color.yellow;
 


### PR DESCRIPTION
warning CS0649: Field 'XXX' is never assigned to, and will always have its default value false