### PR TITLE
BoneWeightの無いBlendShapeは正規化必用

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
@@ -22,6 +22,16 @@ namespace UniGLTF
         public bool IsRendererActive;
         public bool Skinned;
 
+        public bool HasNormal => Mesh != null && Mesh.normals != null && Mesh.normals.Length == Mesh.vertexCount;
+        public bool HasUV => Mesh != null && Mesh.uv != null && Mesh.uv.Length == Mesh.vertexCount;
+
+        public bool HasVertexColor => Mesh.colors != null && Mesh.colors.Length == Mesh.vertexCount
+            && VertexColor == VertexColorState.ExistsAndIsUsed
+            || VertexColor == VertexColorState.ExistsAndMixed // Export する
+            ;
+
+        public bool HasSkinning => Mesh.boneWeights != null && Mesh.boneWeights.Length == Mesh.vertexCount;
+
         /// <summary>
         /// Mesh に頂点カラーが含まれているか。
         /// 含まれている場合にマテリアルは Unlit.VColorMultiply になっているか？

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExportMeshes.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExportMeshes.cs
@@ -79,25 +79,22 @@ namespace VRM
             // float4 x 3
             // vertices
             sb.Append($"(Pos");
-            if (info.Mesh.normals != null && info.Mesh.normals.Length == info.Mesh.vertexCount)
+            if (info.HasNormal)
             {
                 sb.Append("+Nom");
                 info.ExportVertexSize += 4 * 3;
             }
-            if (info.Mesh.uv != null && info.Mesh.uv.Length == info.Mesh.vertexCount)
+            if (info.HasUV)
             {
                 sb.Append("+UV");
                 info.ExportVertexSize += 4 * 2;
             }
-            if (info.Mesh.colors != null && info.Mesh.colors.Length == info.Mesh.vertexCount
-            && info.VertexColor == UniGLTF.MeshExportInfo.VertexColorState.ExistsAndIsUsed
-            || info.VertexColor == UniGLTF.MeshExportInfo.VertexColorState.ExistsAndMixed // Export する
-            )
+            if (info.HasVertexColor)
             {
                 sb.Append("+Col");
                 info.ExportVertexSize += 4 * 4;
             }
-            if (info.Mesh.boneWeights != null && info.Mesh.boneWeights.Length == info.Mesh.vertexCount)
+            if (info.HasSkinning)
             {
                 // short, float x 4 weights
                 sb.Append("+Skin");
@@ -143,6 +140,12 @@ namespace VRM
                     sb.Insert(0, "[remove vcolor]");
                     break;
             }
+            if (info.ExportBlendShapeCount > 0 && !info.HasSkinning)
+            {
+                sb.Insert(0, "[morph without skin]");
+            }
+
+            // total bytes
             sb.Insert(0, $"{info.ExportByteSize:#,0} Bytes = ");
             info.Summary = sb.ToString();
         }

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExporterVaildator.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExporterVaildator.cs
@@ -84,7 +84,7 @@ namespace VRM
         /// <param name="ExportRoot"></param>
         /// <param name="m_settings"></param>
         /// <returns></returns>
-        public bool RootAndHumanoidCheck(GameObject ExportRoot, VRMExportSettings m_settings)
+        public bool RootAndHumanoidCheck(GameObject ExportRoot, VRMExportSettings m_settings, IReadOnlyList<UniGLTF.MeshExportInfo> info)
         {
             //
             // root
@@ -107,25 +107,31 @@ namespace VRM
                 return false;
             }
 
-            if (HasRotationOrScale(ExportRoot))
+            if (HasRotationOrScale(ExportRoot) || info.Any(x => x.ExportBlendShapeCount > 0 && !x.HasSkinning))
             {
+                // 正規化必用
                 if (m_settings.PoseFreeze)
                 {
-                    EditorGUILayout.HelpBox("Root OK", MessageType.Info);
+                    // する
+                    EditorGUILayout.HelpBox("PoseFreeze checked. OK", MessageType.Info);
                 }
                 else
                 {
+                    // しない
                     Validation.Warning(Msg(VRMExporterWizardMessages.ROTATION_OR_SCALEING_INCLUDED_IN_NODE)).DrawGUI();
                 }
             }
             else
             {
+                // 不要
                 if (m_settings.PoseFreeze)
                 {
+                    // する
                     Validation.Warning(Msg(VRMExporterWizardMessages.IS_POSE_FREEZE_DONE)).DrawGUI();
                 }
                 else
                 {
+                    // しない
                     EditorGUILayout.HelpBox("Root OK", MessageType.Info);
                 }
             }

--- a/Assets/VRM/UniVRM/Editor/Format/VRMExporterWizardMessages.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMExporterWizardMessages.cs
@@ -21,8 +21,8 @@ namespace VRM
         [LangMsg(Languages.en, "Prefab Asset cannot be exported. Prefab Asset has different behaviour with Scene GameObject. Please put the prefab into the scene")]
         PREFAB_CANNOT_EXPORT,
 
-        [LangMsg(Languages.ja, "回転・拡大縮小を持つノードが含まれています。正規化が必用です。Setting の PoseFreeze を有効にしてください")]
-        [LangMsg(Languages.en, " Normalization is required. There are nodes (child GameObject) where rotation and scaling are not default. Please enable PoseFreeze")]
+        [LangMsg(Languages.ja, "回転・拡大縮小もしくはWeightの無いBlendShapeが含まれています。正規化が必用です。Setting の PoseFreeze を有効にしてください")]
+        [LangMsg(Languages.en, " Normalization is required. There are nodes (child GameObject) where rotation and scaling or blendshape without bone weight are not default. Please enable PoseFreeze")]
         ROTATION_OR_SCALEING_INCLUDED_IN_NODE,
 
         [LangMsg(Languages.ja, "正規化済みです。Setting の PoseFreeze は不要です")]


### PR DESCRIPTION
Unity は BoneWeight の無い BlendShape を SkinnedMeshRenderer で扱う。 GLTF が理解できるように正規化で BoneWeight を付与する