### PR TITLE
同名メッシュが100以上あるときにも対応

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
@@ -333,19 +333,23 @@ namespace UniGLTF
             {
                 if (string.IsNullOrEmpty(mesh.name))
                 {
-                    mesh.name = Guid.NewGuid().ToString();
+                    mesh.name = "mesh_" + Guid.NewGuid().ToString("N");
+                    used.Add(mesh.name);
                 }
-                var lname = mesh.name.ToLower();
-                if (used.Contains(lname))
+                else
                 {
-                    // rename
-                    var uname = MakeUniqueName(lname, used);
-                    Debug.LogWarning($"same name: {lname} => {uname}");
-                    mesh.name = uname;
-                    lname = uname;
-                }
+                    var lname = mesh.name.ToLower();
+                    if (used.Contains(lname))
+                    {
+                        // rename
+                        var uname = lname + "_" + Guid.NewGuid().ToString("N");
+                        Debug.LogWarning($"same name: {lname} => {uname}");
+                        mesh.name = uname;
+                        lname = uname;
+                    }
 
-                used.Add(lname);
+                    used.Add(lname);
+                }
             }
         }
 

--- a/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
@@ -312,20 +312,6 @@ namespace UniGLTF
             }
         }
 
-        static string MakeUniqueName(string name, HashSet<string> used)
-        {
-            for (var i = 0; i < 100; ++i)
-            {
-                name = $"{name}_{i}";
-                if (!used.Contains(name))
-                {
-                    return name;
-                }
-            }
-
-            throw new Exception("hobo arienai");
-        }
-
         void FixUnique()
         {
             var used = new HashSet<string>();


### PR DESCRIPTION
UniVRM 0.59 から入っているメッシュの同名修正：ImporterContext.FixUnique(), MakeUniqueName() ですが、割と古い VRMモデルや GLBなどの背景モデルでは同名メッシュが 100個を超えることもあるので、エラーが出て、ロードができないことがあるようです。

![FixUnique_support_over100_hierarchy](https://user-images.githubusercontent.com/8603961/97108304-fc504780-170f-11eb-8bb4-211931aa8afb.jpg)
(※髪の毛やスカート、装飾など、メッシュが結合されてないモデルもある)

(例) vrm
https://3d.nicovideo.jp/works/td41774

(UniVRM 0.59 以降で同名が大量にあるときのロード)
![FixUnique_support_over100_original](https://user-images.githubusercontent.com/8603961/97108297-f5293980-170f-11eb-8042-f586aed9071d.jpg)

　
なので試しに、ImporterContext.MakeUniqueName() 内のループ回数の代わりに GUID にしてみたら、上手くロードできるようになりました。

(GUIDにした修正版)
![FixUnique_support_over100_edited](https://user-images.githubusercontent.com/8603961/97108300-f9eded80-170f-11eb-9315-2edf0b9dcfa1.jpg)

ただ、GUID にする場合、MakeUniqueName() でループを回す必要性は無くなるので、FixUnique() の中にまとめてみました。
実質、MakeUniqueName() が不要になってしまいましたが、念のため、削除などのご判断はお任せします(笑)。

　
バグレポでも良かったんですが、コードの方がわかりやすい気がしたので、修正の参考にでもして下さい。