### PR TITLE
Fix/exporter for dict

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF/Serialization/StringKeyDictionarySerialization.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/Serialization/StringKeyDictionarySerialization.cs
@@ -42,7 +42,11 @@ public static $0 $2(ListTreeNode<JsonValue> parsed)
 
         public override string CreateSerializationCondition(string argName, JsonSchemaAttribute t)
         {
-            return $"{argName}!=null&&{argName}.Count>0";
+            // return $"{argName}!=null&&{argName}.Count>0";
+
+            // this check is only /extensions/VRM/materialProperties/*
+            // should export empty dictionary.
+            return $"{argName}!=null";
         }
 
         public override void GenerateSerializer(StreamWriter writer, string callName)

--- a/Assets/UniGLTF/package.json
+++ b/Assets/UniGLTF/package.json
@@ -11,6 +11,6 @@
     "name": "VRM Consortium"
   },
   "dependencies": {
-    "com.vrmc.vrmshaders": "0.63.1"
+    "com.vrmc.vrmshaders": "0.63.2"
   }
 }

--- a/Assets/VRM/Editor/VRMSerializerGenerator.cs
+++ b/Assets/VRM/Editor/VRMSerializerGenerator.cs
@@ -16,7 +16,7 @@ namespace VRM
             get
             {
                 return Path.Combine(UnityEngine.Application.dataPath,
-                "VRM/UniVRM/Scripts/Format/VRMSerializer.g.cs");
+                "VRM/Runtime/Format/VRMSerializer.g.cs");
             }
         }
 

--- a/Assets/VRM/Runtime/Format/VRMSerializer.g.cs
+++ b/Assets/VRM/Runtime/Format/VRMSerializer.g.cs
@@ -935,27 +935,27 @@ public static void Serialize_vrm_materialProperties_ITEM(JsonFormatter f, glTF_V
         f.Value(value.renderQueue);
     }
 
-    if(value.floatProperties!=null&&value.floatProperties.Count>0){
+    if(value.floatProperties!=null){
         f.Key("floatProperties");                
         Serialize_vrm_materialProperties__floatProperties(f, value.floatProperties);
     }
 
-    if(value.vectorProperties!=null&&value.vectorProperties.Count>0){
+    if(value.vectorProperties!=null){
         f.Key("vectorProperties");                
         Serialize_vrm_materialProperties__vectorProperties(f, value.vectorProperties);
     }
 
-    if(value.textureProperties!=null&&value.textureProperties.Count>0){
+    if(value.textureProperties!=null){
         f.Key("textureProperties");                
         Serialize_vrm_materialProperties__textureProperties(f, value.textureProperties);
     }
 
-    if(value.keywordMap!=null&&value.keywordMap.Count>0){
+    if(value.keywordMap!=null){
         f.Key("keywordMap");                
         Serialize_vrm_materialProperties__keywordMap(f, value.keywordMap);
     }
 
-    if(value.tagMap!=null&&value.tagMap.Count>0){
+    if(value.tagMap!=null){
         f.Key("tagMap");                
         Serialize_vrm_materialProperties__tagMap(f, value.tagMap);
     }

--- a/Assets/VRM/Runtime/Format/VRMVersion.cs
+++ b/Assets/VRM/Runtime/Format/VRMVersion.cs
@@ -5,7 +5,7 @@ namespace VRM
     {
         public const int MAJOR = 0;
         public const int MINOR = 63;
-        public const int PATCH = 1;
-        public const string VERSION = "0.63.1";
+        public const int PATCH = 2;
+        public const string VERSION = "0.63.2";
     }
 }

--- a/Assets/VRM/package.json
+++ b/Assets/VRM/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.vrmc.univrm",
-  "version": "0.63.1",
+  "version": "0.63.2",
   "displayName": "VRM",
   "description": "VRM importer",
   "unity": "2018.4",
@@ -14,7 +14,7 @@
     "name": "VRM Consortium"
   },
   "dependencies": {
-    "com.vrmc.vrmshaders": "0.63.1",
+    "com.vrmc.vrmshaders": "0.63.2",
     "com.vrmc.unigltf": "2.0.0"
   }
 }

--- a/Assets/VRMShaders/package.json
+++ b/Assets/VRMShaders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.vrmc.vrmshaders",
-  "version": "0.63.1",
+  "version": "0.63.2",
   "displayName": "VRM Shaders",
   "description": "VRM Shaders",
   "unity": "2018.4",


### PR DESCRIPTION
#654

`v0.62.0` 以前のローダーがディクショナリ(json object)が存在することを期待しているので、空でも出力する必要がある。


Since the loader of v0.62.0 or earlier expects the dictionary (json object) to exist, it needs to output even if it is empty.