### PR TITLE
Fix VRM 0.x to VRM1.x migration errors.

### DIFF
--- a/Assets/VRM10/Runtime/Migration/Migration.cs
+++ b/Assets/VRM10/Runtime/Migration/Migration.cs
@@ -177,11 +177,19 @@ namespace UniVRM10
 
                     case "allowedUserName":
                         {
-                            var allowdUserType = kv.Value.GetString();
-                            switch (allowdUserType)
+                            var allowedUserType = kv.Value.GetString();
+                            switch (allowedUserType)
                             {
-                                case "Everyone": meta.AvatarPermission = UniGLTF.Extensions.VRMC_vrm.AvatarPermissionType.everyone; break;
-                                default: throw new NotImplementedException($"allowedUser: {allowdUserType}");
+                                case "OnlyAuthor":
+                                    meta.AvatarPermission = UniGLTF.Extensions.VRMC_vrm.AvatarPermissionType.onlyAuthor;
+                                    break;
+                                case "ExplicitlyLicensedPerson":
+                                    meta.AvatarPermission = UniGLTF.Extensions.VRMC_vrm.AvatarPermissionType.explicitlyLicensedPerson;
+                                    break;
+                                case "Everyone":
+                                    meta.AvatarPermission = UniGLTF.Extensions.VRMC_vrm.AvatarPermissionType.everyone;
+                                    break;
+                                default: throw new NotImplementedException($"allowedUser: {allowedUserType}");
                             }
                         }
                         break;
@@ -445,7 +453,7 @@ namespace UniVRM10
             {
                 var meshIndex = x["mesh"].GetInt32();
                 var morphTargetIndex = x["index"].GetInt32();
-                var weight = x["weight"].GetInt32();
+                var weight = x["weight"].GetSingle();
 
                 var bind = new UniGLTF.Extensions.VRMC_vrm.MorphTargetBind();
 

--- a/Assets/VRM10/Runtime/Migration/Migration.cs
+++ b/Assets/VRM10/Runtime/Migration/Migration.cs
@@ -189,20 +189,27 @@ namespace UniVRM10
                                 case "Everyone":
                                     meta.AvatarPermission = UniGLTF.Extensions.VRMC_vrm.AvatarPermissionType.everyone;
                                     break;
-                                default: throw new NotImplementedException($"allowedUser: {allowedUserType}");
+                                default:
+                                    throw new NotImplementedException($"allowedUser: {allowedUserType}");
                             }
                         }
                         break;
 
-                    case "violentUssageName": meta.AllowExcessivelyViolentUsage = kv.Value.GetString().ToLower() == "allow"; break;
-                    case "sexualUssageName": meta.AllowExcessivelySexualUsage = kv.Value.GetString().ToLower() == "allow"; break;
-                    case "commercialUssageName":
+                    case "violentUssageName": meta.AllowExcessivelyViolentUsage = kv.Value.GetString().ToLower() == "allow"; break; // Typo "Ussage" is VRM 0.x spec.
+                    case "sexualUssageName": meta.AllowExcessivelySexualUsage = kv.Value.GetString().ToLower() == "allow"; break; // Typo "Ussage" is VRM 0.x spec.
+                    case "commercialUssageName": // Typo "Ussage" is VRM 0.x spec.
                         {
-                            var commercialUssageType = kv.Value.GetString();
-                            switch (commercialUssageType)
+                            var commercialUsageType = kv.Value.GetString();
+                            switch (commercialUsageType)
                             {
-                                case "Allow": meta.CommercialUsage = UniGLTF.Extensions.VRMC_vrm.CommercialUsageType.personalProfit; break;
-                                default: meta.CommercialUsage = UniGLTF.Extensions.VRMC_vrm.CommercialUsageType.personalNonProfit; break;
+                                case "Allow":
+                                    meta.CommercialUsage = UniGLTF.Extensions.VRMC_vrm.CommercialUsageType.personalProfit;
+                                    break;
+                                case "Disallow":
+                                    meta.CommercialUsage = UniGLTF.Extensions.VRMC_vrm.CommercialUsageType.personalNonProfit;
+                                    break;
+                                default:
+                                    throw new NotImplementedException($"{key}: {commercialUsageType}");
                             }
                         }
                         break;

--- a/Assets/VRM10/Runtime/Migration/Migration.cs
+++ b/Assets/VRM10/Runtime/Migration/Migration.cs
@@ -177,8 +177,8 @@ namespace UniVRM10
 
                     case "allowedUserName":
                         {
-                            var allowedUserType = kv.Value.GetString();
-                            switch (allowedUserType)
+                            var allowedUserName = kv.Value.GetString();
+                            switch (allowedUserName)
                             {
                                 case "OnlyAuthor":
                                     meta.AvatarPermission = UniGLTF.Extensions.VRMC_vrm.AvatarPermissionType.onlyAuthor;
@@ -190,17 +190,49 @@ namespace UniVRM10
                                     meta.AvatarPermission = UniGLTF.Extensions.VRMC_vrm.AvatarPermissionType.everyone;
                                     break;
                                 default:
-                                    throw new NotImplementedException($"allowedUser: {allowedUserType}");
+                                    throw new NotImplementedException($"{key}: {allowedUserName}");
                             }
                         }
                         break;
 
-                    case "violentUssageName": meta.AllowExcessivelyViolentUsage = kv.Value.GetString().ToLower() == "allow"; break; // Typo "Ussage" is VRM 0.x spec.
-                    case "sexualUssageName": meta.AllowExcessivelySexualUsage = kv.Value.GetString().ToLower() == "allow"; break; // Typo "Ussage" is VRM 0.x spec.
+                    case "violentUssageName": // Typo "Ussage" is VRM 0.x spec.
+                        {
+                            var violentUsageName = kv.Value.GetString();
+                            switch (violentUsageName)
+                            {
+                                case "allow":
+                                    meta.AllowExcessivelyViolentUsage = true;
+                                    break;
+                                case "disallow":
+                                    meta.AllowExcessivelyViolentUsage = false;
+                                    break;
+                                default:
+                                    throw new NotImplementedException($"{key}: {violentUsageName}");
+                            }
+                        }
+                        break;
+                    
+                    case "sexualUssageName": // Typo "Ussage" is VRM 0.x spec.
+                        {
+                            var sexualUsageName = kv.Value.GetString();
+                            switch (sexualUsageName)
+                            {
+                                case "Allow":
+                                    meta.AllowExcessivelySexualUsage = true;
+                                    break;
+                                case "Disallow":
+                                    meta.AllowExcessivelySexualUsage = false;
+                                    break;
+                                default:
+                                    throw new NotImplementedException($"{key}: {sexualUsageName}");
+                            }
+                        }
+                        break;
+                    
                     case "commercialUssageName": // Typo "Ussage" is VRM 0.x spec.
                         {
-                            var commercialUsageType = kv.Value.GetString();
-                            switch (commercialUsageType)
+                            var commercialUsageName = kv.Value.GetString();
+                            switch (commercialUsageName)
                             {
                                 case "Allow":
                                     meta.CommercialUsage = UniGLTF.Extensions.VRMC_vrm.CommercialUsageType.personalProfit;
@@ -209,7 +241,7 @@ namespace UniVRM10
                                     meta.CommercialUsage = UniGLTF.Extensions.VRMC_vrm.CommercialUsageType.personalNonProfit;
                                     break;
                                 default:
-                                    throw new NotImplementedException($"{key}: {commercialUsageType}");
+                                    throw new NotImplementedException($"{key}: {commercialUsageName}");
                             }
                         }
                         break;

--- a/Assets/VRM10/Runtime/UnityBuilder/MeshLoader.cs
+++ b/Assets/VRM10/Runtime/UnityBuilder/MeshLoader.cs
@@ -46,29 +46,12 @@ namespace UniVRM10
             }
 
             mesh.subMeshCount = src.Submeshes.Count;
-
-#if UNITY_2019
-            var triangles = src.IndexBuffer.GetAsIntArray();
-            mesh.triangles = triangles;
-            var flags = MeshUpdateFlags.DontRecalculateBounds | MeshUpdateFlags.DontResetBoneBounds;
-            for (int i = 0; i < src.Submeshes.Count; ++i)
-            {
-                var submesh = src.Submeshes[i];
-                mesh.SetSubMesh(i, new SubMeshDescriptor
-                {
-                    indexStart = submesh.Offset,
-                    indexCount = submesh.DrawCount,
-                },
-                flags);                
-            }
-#else
             var triangles = src.IndexBuffer.GetAsIntList();
             for (int i = 0; i < src.Submeshes.Count; ++i)
             {
                 var submesh = src.Submeshes[i];
                 mesh.SetTriangles(triangles.GetRange(submesh.Offset, submesh.DrawCount), i);
             }
-#endif
 
             foreach (var morphTarget in src.MorphTargets)
             {
@@ -78,10 +61,10 @@ namespace UniVRM10
                     : new Vector3[mesh.vertexCount] // dummy
                     ;
                 mesh.AddBlendShapeFrame(morphTarget.Name, 100.0f, positions, null, null);
-
-                mesh.RecalculateBounds();
-                mesh.RecalculateTangents();
             }
+
+            mesh.RecalculateBounds();
+            mesh.RecalculateTangents();
         }
     }
 }


### PR DESCRIPTION
Fix migration erros.

- Complete `VRMC_vrm.meta.avatarPermission` variant.
- Complete `VRMC_vrm.meta.allowExcessivelyViolentUsage` variant.
- Complete `VRMC_vrm.meta.allowExcessivelySexualUsage` variant.
- Complete `VRMC_vrm.meta.commercialUsage` variant.
- Invalid mesh load function in Unity 2019.