### PR TITLE
Fix ExpressionPreset conversion problem in migration.

### DIFF
--- a/Assets/VRM10/Runtime/IO/VrmExpressionAdapter.cs
+++ b/Assets/VRM10/Runtime/IO/VrmExpressionAdapter.cs
@@ -9,7 +9,7 @@ namespace UniVRM10
     {
         public static VrmLib.Expression FromGltf(this UniGLTF.Extensions.VRMC_vrm.Expression x, List<VrmLib.Node> nodes, List<VrmLib.Material> materials)
         {
-            var expression = new VrmLib.Expression((VrmLib.ExpressionPreset)x.Preset,
+            var expression = new VrmLib.Expression(x.Preset.ToVrmFormat(),
                 x.Name,
                 x.IsBinary.HasValue && x.IsBinary.Value)
             {
@@ -109,7 +109,7 @@ namespace UniVRM10
         {
             var g = new UniGLTF.Extensions.VRMC_vrm.Expression
             {
-                Preset = (UniGLTF.Extensions.VRMC_vrm.ExpressionPreset)x.Preset,
+                Preset = x.Preset.ToGltfFormat(),
                 Name = x.Name,
                 IsBinary = x.IsBinary,
                 OverrideBlink = EnumUtil.Cast<UniGLTF.Extensions.VRMC_vrm.ExpressionOverrideType>(x.OverrideBlink),
@@ -145,5 +145,79 @@ namespace UniVRM10
         //     }
         //     return blendShape;
         // }
+
+        private static UniGLTF.Extensions.VRMC_vrm.ExpressionPreset ToGltfFormat(this VrmLib.ExpressionPreset preset)
+        {
+            switch (preset)
+            {
+                case ExpressionPreset.Custom:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.custom;
+                case ExpressionPreset.Aa:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.aa;
+                case ExpressionPreset.Ih:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ih;
+                case ExpressionPreset.Ou:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ou;
+                case ExpressionPreset.Ee:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ee;
+                case ExpressionPreset.Oh:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.oh;
+                case ExpressionPreset.Blink:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blink;
+                case ExpressionPreset.Joy:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.happy;
+                case ExpressionPreset.Angry:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.angry;
+                case ExpressionPreset.Sorrow:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.sad;
+                case ExpressionPreset.Fun:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.relaxed;
+                case ExpressionPreset.LookUp:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookUp;
+                case ExpressionPreset.LookDown:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookDown;
+                case ExpressionPreset.LookLeft:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookLeft;
+                case ExpressionPreset.LookRight:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookRight;
+                case ExpressionPreset.BlinkLeft:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blinkLeft;
+                case ExpressionPreset.BlinkRight:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blinkRight;
+                case ExpressionPreset.Neutral:
+                    return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.neutral;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(preset), preset, null);
+            }
+        }
+
+        private static VrmLib.ExpressionPreset ToVrmFormat(this UniGLTF.Extensions.VRMC_vrm.ExpressionPreset preset)
+        {
+            switch (preset)
+            {
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.custom: return ExpressionPreset.Custom;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.aa: return ExpressionPreset.Aa;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ih: return ExpressionPreset.Ih;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ou: return ExpressionPreset.Ou;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ee: return ExpressionPreset.Ee;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.oh: return ExpressionPreset.Oh;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blink: return ExpressionPreset.Blink;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.happy: return ExpressionPreset.Joy;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.angry: return ExpressionPreset.Angry;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.sad: return ExpressionPreset.Sorrow;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.relaxed: return ExpressionPreset.Fun;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookUp: return ExpressionPreset.LookUp;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.surprised:
+                    throw new NotImplementedException();
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookDown: return ExpressionPreset.LookDown;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookLeft: return ExpressionPreset.LookLeft;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookRight: return ExpressionPreset.LookRight;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blinkLeft: return ExpressionPreset.BlinkLeft;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blinkRight: return ExpressionPreset.BlinkRight;
+                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.neutral: return ExpressionPreset.Neutral;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(preset), preset, null);
+            }
+        }
     }
 }

--- a/Assets/VRM10/Tests/SerializationTests.cs
+++ b/Assets/VRM10/Tests/SerializationTests.cs
@@ -238,28 +238,57 @@ namespace UniVRM10
                 data.OverrideBlink = UniGLTF.Extensions.VRMC_vrm.ExpressionOverrideType.block;
 
                 var json = Serialize(data, UniGLTF.Extensions.VRMC_vrm.GltfSerializer.Serialize_Expressions_ITEM);
-                Assert.AreEqual($"{{{q}preset{q}:{q}custom{q},{q}ignoreBlink{q}:true}}", json);
+                Assert.AreEqual($"{{{q}preset{q}:{q}custom{q},{q}overrideBlink{q}:{q}block{q},{q}overrideLookAt{q}:{q}none{q},{q}overrideMouth{q}:{q}none{q}}}", json);
             }
 
             {
                 var expression = new VrmLib.Expression(VrmLib.ExpressionPreset.Blink, "blink", true)
                 {
-                    OverrideBlink = VrmLib.ExpressionOverrideType.Block,
+                    OverrideBlink = VrmLib.ExpressionOverrideType.None,
                     OverrideLookAt = VrmLib.ExpressionOverrideType.Block,
-                    OverrideMouth = VrmLib.ExpressionOverrideType.Block,
+                    OverrideMouth = VrmLib.ExpressionOverrideType.Blend,
                 };
 
                 // export
                 var gltf = UniVRM10.ExpressionAdapter.ToGltf(expression, new List<VrmLib.Node>(), new List<VrmLib.Material>());
-                Assert.AreEqual(true, gltf.OverrideBlink);
-                Assert.AreEqual(true, gltf.OverrideLookAt);
-                Assert.AreEqual(true, gltf.OverrideMouth);
+                Assert.AreEqual(UniGLTF.Extensions.VRMC_vrm.ExpressionOverrideType.none, gltf.OverrideBlink);
+                Assert.AreEqual(UniGLTF.Extensions.VRMC_vrm.ExpressionOverrideType.block, gltf.OverrideLookAt);
+                Assert.AreEqual(UniGLTF.Extensions.VRMC_vrm.ExpressionOverrideType.blend, gltf.OverrideMouth);
 
                 // import
                 var imported = UniVRM10.ExpressionAdapter.FromGltf(gltf, new List<VrmLib.Node>(), new List<VrmLib.Material>());
-                Assert.AreEqual(true, imported.OverrideBlink);
-                Assert.AreEqual(true, imported.OverrideLookAt);
-                Assert.AreEqual(true, imported.OverrideMouth);
+                Assert.AreEqual(VrmLib.ExpressionOverrideType.None, imported.OverrideBlink);
+                Assert.AreEqual(VrmLib.ExpressionOverrideType.Block, imported.OverrideLookAt);
+                Assert.AreEqual(VrmLib.ExpressionOverrideType.Blend, imported.OverrideMouth);
+            }
+
+            {
+                // export
+                foreach (var preset in Enum.GetValues(typeof(VrmLib.ExpressionPreset)) as VrmLib.ExpressionPreset[])
+                {
+                    var expression = new VrmLib.Expression(preset, "", false);
+                    
+                    // expect no exception
+                    var gltf = ExpressionAdapter.ToGltf(
+                        expression, 
+                        new List<VrmLib.Node>(),
+                        new List<VrmLib.Material>());
+                }
+                
+                // import 
+                foreach (var preset in Enum.GetValues(typeof(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset)) as UniGLTF.Extensions.VRMC_vrm.ExpressionPreset[])
+                {
+                    var gltf = new UniGLTF.Extensions.VRMC_vrm.Expression
+                    {
+                        Preset = preset,
+                    };
+
+                    // expect no exception
+                    ExpressionAdapter.FromGltf(
+                        gltf,
+                        new List<VrmLib.Node>(),
+                        new List<VrmLib.Material>());
+                }
             }
         }
     }


### PR DESCRIPTION
Fix ExpressionPreset conversion problem in migration, and add UnitTests.

but the UnitTest is still failed.

Please fix this.

https://github.com/Santarh/UniVRM/blob/d9a8278df907189f93968b125d161bce0982191c/Assets/VRM10/Runtime/IO/VrmExpressionAdapter.cs#L211