### PR TITLE
Fix/unintended null reference after exporting

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
@@ -392,7 +392,10 @@ namespace UniGLTF
             {
                 if (tmpParent != null)
                 {
-                    tmpParent.transform.GetChild(0).SetParent(null);
+                    var child = tmpParent.transform.GetChild(0);
+                    child.SetParent(null);
+                    Copy = child.gameObject;
+
                     if (Application.isPlaying)
                     {
                         GameObject.Destroy(tmpParent);


### PR DESCRIPTION
Fixes an issue where `gltfExporter.Copy` becomes null after calling `gltfExporter.Export()` when exporting a root-only object.