### PR TITLE
gltf の読み書きで反転軸を指定できるようにする

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF.Editor.asmdef
+++ b/Assets/UniGLTF/Editor/UniGLTF.Editor.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "UniGLTF.Editor",
     "references": [
-        "UniGLTF"
+        "UniGLTF",
+        "MeshUtility.Editor"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [

--- a/Assets/UniGLTF/Editor/UniGLTF/ImporterMenu.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ImporterMenu.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿#if false
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -51,3 +52,4 @@ namespace UniGLTF
         }
     }
 }
+#endif

--- a/Assets/UniGLTF/Editor/UniGLTF/ImporterMenu.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ImporterMenu.cs
@@ -21,8 +21,10 @@ namespace UniGLTF
                 //
                 // load into scene
                 //
-                var context = new ImporterContext();
-                context.Load(path);
+                var parser = new GltfParser();
+                parser.ParsePath(path);
+                var context = new ImporterContext(parser);
+                context.Load();
                 context.ShowMeshes();
                 Selection.activeGameObject = context.Root;
             }

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter.meta
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 552c42899d5f1664b8fba3faef53f3eb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
@@ -76,19 +76,19 @@ namespace UniGLTF
             }
         }
 
-        public void ExtractTextures()
-        {
-            // extract textures to files
-            this.ExtractTextures(TextureDirName);
-            // reimport
-            AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate);
-        }
+        // public void ExtractTextures()
+        // {
+        //     // extract textures to files
+        //     this.ExtractTextures(TextureDirName);
+        //     // reimport
+        //     AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate);
+        // }
 
-        public void ExtractMaterials()
-        {
-            this.ExtractAssets<UnityEngine.Material>(MaterialDirName, ".mat");
-            AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate);
-        }
+        // public void ExtractMaterials()
+        // {
+        //     this.ExtractAssets<UnityEngine.Material>(MaterialDirName, ".mat");
+        //     AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate);
+        // }
 
         public void ExtractMaterialsAndTextures()
         {
@@ -99,10 +99,10 @@ namespace UniGLTF
             });
         }
 
-        public Dictionary<string, T> GetExternalUnityObjects<T>() where T : UnityEngine.Object
-        {
-            return this.GetExternalObjectMap().Where(x => x.Key.type == typeof(T)).ToDictionary(x => x.Key.name, x => (T)x.Value);
-        }
+        // public Dictionary<string, T> GetExternalUnityObjects<T>() where T : UnityEngine.Object
+        // {
+        //     return this.GetExternalObjectMap().Where(x => x.Key.type == typeof(T)).ToDictionary(x => x.Key.name, x => (T)x.Value);
+        // }
 
         public void SetExternalUnityObject<T>(UnityEditor.AssetImporter.SourceAssetIdentifier sourceAssetIdentifier, T obj) where T : UnityEngine.Object
         {

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
@@ -26,7 +26,7 @@ namespace UniGLTF
 
                 // Build Unity Model
                 var context = new ImporterContext(parser, GetExternalObjectMap()
-                .Select(kv => new KeyValuePair<string, UnityEngine.Object>(kv.Key.name, kv.Value)));
+                .Select(kv => (kv.Key.name, kv.Value)));
                 context.Load();
                 context.ShowMeshes();
 

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
@@ -11,6 +11,9 @@ namespace UniGLTF
     [ScriptedImporter(1, "glb")]
     public class GltfScriptedImporter : ScriptedImporter
     {
+        [SerializeField]
+        Axises m_reverseAxis;
+
         const string TextureDirName = "Textures";
         const string MaterialDirName = "Materials";
 
@@ -25,8 +28,11 @@ namespace UniGLTF
                 parser.ParsePath(ctx.assetPath);
 
                 // Build Unity Model
-                var context = new ImporterContext(parser, GetExternalObjectMap()
-                .Select(kv => (kv.Key.name, kv.Value)));
+                var externalObjectMap = GetExternalObjectMap()
+                .Select(kv => (kv.Key.name, kv.Value))
+                ;
+                var context = new ImporterContext(parser, externalObjectMap);
+                context.InvertAxis = m_reverseAxis;
                 context.Load();
                 context.ShowMeshes();
 

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
@@ -25,28 +25,25 @@ namespace UniGLTF
                 parser.ParsePath(ctx.assetPath);
 
                 // Build Unity Model
-                var context = new ImporterContext(parser);
+                var context = new ImporterContext(parser, GetExternalObjectMap()
+                .Select(kv => new KeyValuePair<string, UnityEngine.Object>(kv.Key.name, kv.Value)));
                 context.Load();
                 context.ShowMeshes();
 
                 // Texture
                 var externalTextures = this.GetExternalUnityObjects<UnityEngine.Texture2D>();
-                foreach (var texture in context.Textures)
+                foreach (var info in context.TextureFactory.Textures)
                 {
-                    if (texture == null)
+                    if (!info.UseExternal)
                     {
-                        throw new Exception();
-                    }
-
-                    if (!externalTextures.ContainsValue(texture))
-                    {
+                        var texture = info.Texture;
                         ctx.AddObjectToAsset(texture.name, texture);
                     }
                 }
 
                 // Material
                 var externalMaterials = this.GetExternalUnityObjects<UnityEngine.Material>();
-                foreach (var material in context.Materials)
+                foreach (var material in context.MaterialFactory.Materials)
                 {
                     if (material == null)
                     {

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
@@ -39,7 +39,11 @@ namespace UniGLTF
                 // Texture
                 foreach (var info in context.TextureFactory.Textures)
                 {
-                    if (!info.UseExternal)
+                    if (!info.IsUsed)
+                    {
+                        continue;
+                    }
+                    if (!info.IsExternal)
                     {
                         var texture = info.Texture;
                         ctx.AddObjectToAsset(texture.name, texture);

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
@@ -12,7 +12,7 @@ namespace UniGLTF
     public class GltfScriptedImporter : ScriptedImporter
     {
         [SerializeField]
-        Axises m_reverseAxis;
+        Axises m_reverseAxis = default;
 
         const string TextureDirName = "Textures";
         const string MaterialDirName = "Materials";

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
@@ -31,7 +31,6 @@ namespace UniGLTF
                 context.ShowMeshes();
 
                 // Texture
-                var externalTextures = this.GetExternalUnityObjects<UnityEngine.Texture2D>();
                 foreach (var info in context.TextureFactory.Textures)
                 {
                     if (!info.UseExternal)
@@ -42,16 +41,11 @@ namespace UniGLTF
                 }
 
                 // Material
-                var externalMaterials = this.GetExternalUnityObjects<UnityEngine.Material>();
-                foreach (var material in context.MaterialFactory.Materials)
+                foreach (var info in context.MaterialFactory.Materials)
                 {
-                    if (material == null)
+                    if (!info.UseExternal)
                     {
-                        throw new Exception();
-                    }
-
-                    if (!externalMaterials.ContainsValue(material))
-                    {
+                        var material = info.Asset;
                         ctx.AddObjectToAsset(material.name, material);
                     }
                 }
@@ -88,8 +82,11 @@ namespace UniGLTF
 
         public void ExtractMaterialsAndTextures()
         {
-            this.ExtractTextures(TextureDirName, () => { this.ExtractAssets<UnityEngine.Material>(MaterialDirName, ".mat"); });
-            AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate);
+            this.ExtractTextures(TextureDirName, () =>
+            {
+                this.ExtractAssets<UnityEngine.Material>(MaterialDirName, ".mat");
+                AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate);
+            });
         }
 
         public Dictionary<string, T> GetExternalUnityObjects<T>() where T : UnityEngine.Object

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
@@ -66,6 +66,12 @@ namespace UniGLTF
                     ctx.AddObjectToAsset(mesh.name, mesh);
                 }
 
+                // Animation
+                foreach (var clip in context.AnimationClips)
+                {
+                    ctx.AddObjectToAsset(clip.name, clip);
+                }
+
                 // Root
                 ctx.AddObjectToAsset(context.Root.name, context.Root);
                 ctx.SetMainObject(context.Root);

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
@@ -82,20 +82,6 @@ namespace UniGLTF
             }
         }
 
-        // public void ExtractTextures()
-        // {
-        //     // extract textures to files
-        //     this.ExtractTextures(TextureDirName);
-        //     // reimport
-        //     AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate);
-        // }
-
-        // public void ExtractMaterials()
-        // {
-        //     this.ExtractAssets<UnityEngine.Material>(MaterialDirName, ".mat");
-        //     AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate);
-        // }
-
         public void ExtractMaterialsAndTextures()
         {
             this.ExtractTextures(TextureDirName, () =>
@@ -104,11 +90,6 @@ namespace UniGLTF
                 AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate);
             });
         }
-
-        // public Dictionary<string, T> GetExternalUnityObjects<T>() where T : UnityEngine.Object
-        // {
-        //     return this.GetExternalObjectMap().Where(x => x.Key.type == typeof(T)).ToDictionary(x => x.Key.name, x => (T)x.Value);
-        // }
 
         public void SetExternalUnityObject<T>(UnityEditor.AssetImporter.SourceAssetIdentifier sourceAssetIdentifier, T obj) where T : UnityEngine.Object
         {

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs.meta
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d4faa0a7a13c9c1489b5eed3a9575a01
+guid: aecd2106718f2444db3ca21345da2cef
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs
@@ -48,8 +48,8 @@ namespace UniGLTF
             }
         }
 
-        static bool s_foldMaterials = true;
-        static bool s_foldTextures = true;
+        static bool s_foldMaterials;
+        static bool s_foldTextures;
 
         static void OnGUIMaterial(GltfScriptedImporter importer, GltfParser parser)
         {
@@ -65,7 +65,7 @@ namespace UniGLTF
                 DrawRemapGUI<UnityEngine.Material>(importer, parser.GLTF.materials.Select(x => x.name));
             }
 
-            s_foldTextures = EditorGUILayout.Foldout(s_foldMaterials, "Remapped Textures");
+            s_foldTextures = EditorGUILayout.Foldout(s_foldTextures, "Remapped Textures");
             if (s_foldTextures)
             {
                 DrawRemapGUI<UnityEngine.Texture2D>(importer, parser.EnumerateTextures().Select(x => x.Name));

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs
@@ -85,10 +85,14 @@ namespace UniGLTF
                 {
                     throw new System.ArgumentNullException();
                 }
+
                 EditorGUILayout.BeginHorizontal();
                 EditorGUILayout.PrefixLabel(name);
-                if (map.TryGetValue(name, out T value))
+                map.TryGetValue(name, out T value);
+                if (map.Any() && value == null)
                 {
+                    var a = 0;
+                    // Debug.Log($"{name}: {value}");
                 }
                 var asset = EditorGUILayout.ObjectField(value, typeof(T), true) as T;
                 if (asset != value)

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs
@@ -19,19 +19,15 @@ namespace UniGLTF
 
             EditorGUILayout.BeginHorizontal();
             EditorGUILayout.PrefixLabel("Materials And Textures");
-            GUI.enabled = !(importer.GetExternalUnityObjects<UnityEngine.Material>().Any()
-                && importer.GetExternalUnityObjects<UnityEngine.Texture2D>().Any());
             if (GUILayout.Button("Extract"))
             {
                 importer.ExtractMaterialsAndTextures();
             }
-            GUI.enabled = !GUI.enabled;
             if (GUILayout.Button("Clear"))
             {
                 importer.ClearExternalObjects<UnityEngine.Material>();
                 importer.ClearExternalObjects<UnityEngine.Texture2D>();
             }
-            GUI.enabled = true;
             EditorGUILayout.EndHorizontal();
 
             // ObjectMap

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs
@@ -1,11 +1,9 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using UnityEditor;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEngine;
 
-namespace UniVRM10
+namespace UniGLTF
 {
     [CustomEditor(typeof(GltfScriptedImporter))]
     public class GltfScriptedImporterEditorGUI : ScriptedImporterEditor
@@ -43,7 +41,7 @@ namespace UniVRM10
             base.OnInspectorGUI();
         }
 
-        private void DrawRemapGUI<T>(string title, GltfScriptedImporter importer) where T: UnityEngine.Object
+        private void DrawRemapGUI<T>(string title, GltfScriptedImporter importer) where T : UnityEngine.Object
         {
             EditorGUILayout.Foldout(_isOpen, title);
             EditorGUI.indentLevel++;
@@ -53,7 +51,7 @@ namespace UniVRM10
                 EditorGUILayout.BeginHorizontal();
                 EditorGUILayout.PrefixLabel(obj.Key.name);
                 var asset = EditorGUILayout.ObjectField(obj.Value, obj.Key.type, true) as T;
-                if(asset != obj.Value)
+                if (asset != obj.Value)
                 {
                     importer.SetExternalUnityObject(obj.Key, asset);
                 }

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs
@@ -22,6 +22,7 @@ namespace UniGLTF
         enum Tabs
         {
             Model,
+            Animation,
             Materials,
         }
         static Tabs s_currentTab;
@@ -29,10 +30,16 @@ namespace UniGLTF
         public override void OnInspectorGUI()
         {
             s_currentTab = MeshUtility.TabBar.OnGUI(s_currentTab);
+            GUILayout.Space(10);
+
             switch (s_currentTab)
             {
                 case Tabs.Model:
                     base.OnInspectorGUI();
+                    break;
+
+                case Tabs.Animation:
+                    OnGUIAnimation(m_importer, m_parser);
                     break;
 
                 case Tabs.Materials:
@@ -102,6 +109,14 @@ namespace UniGLTF
                 EditorGUILayout.EndHorizontal();
             }
             EditorGUI.indentLevel--;
+        }
+
+        static void OnGUIAnimation(GltfScriptedImporter importer, GltfParser parser)
+        {
+            foreach (var a in parser.GLTF.animations)
+            {
+                GUILayout.Label(a.name);
+            }
         }
     }
 }

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs.meta
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterEditorGUI.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5f9566aa8f690614f872fc63691397e9
+guid: 706590752e82d004e99da97aff535f67
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterExtension.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterExtension.cs
@@ -1,0 +1,242 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor.Experimental.AssetImporters;
+using UnityEditor;
+using System;
+using UnityEngine;
+using System.Text.RegularExpressions;
+
+namespace UniGLTF
+{
+    public static class ScriptedImporterExtension
+    {
+        public static void ClearExternalObjects<T>(this ScriptedImporter importer) where T : UnityEngine.Object
+        {
+            foreach (var extarnalObject in importer.GetExternalObjectMap().Where(x => x.Key.type == typeof(T)))
+            {
+                importer.RemoveRemap(extarnalObject.Key);
+            }
+
+            AssetDatabase.WriteImportSettingsIfDirty(importer.assetPath);
+            AssetDatabase.ImportAsset(importer.assetPath, ImportAssetOptions.ForceUpdate);
+        }
+
+        public static void ClearExtarnalObjects(this ScriptedImporter importer)
+        {
+            foreach (var extarnalObject in importer.GetExternalObjectMap())
+            {
+                importer.RemoveRemap(extarnalObject.Key);
+            }
+
+            AssetDatabase.WriteImportSettingsIfDirty(importer.assetPath);
+            AssetDatabase.ImportAsset(importer.assetPath, ImportAssetOptions.ForceUpdate);
+        }
+
+        private static T GetSubAsset<T>(this ScriptedImporter importer, string assetPath) where T : UnityEngine.Object
+        {
+            return importer.GetSubAssets<T>(assetPath)
+                .FirstOrDefault();
+        }
+
+        public static IEnumerable<T> GetSubAssets<T>(this ScriptedImporter importer, string assetPath) where T : UnityEngine.Object
+        {
+            return AssetDatabase
+                .LoadAllAssetsAtPath(assetPath)
+                .Where(x => AssetDatabase.IsSubAsset(x))
+                .Where(x => x is T)
+                .Select(x => x as T);
+        }
+
+        private static void ExtractFromAsset(UnityEngine.Object subAsset, string destinationPath, bool isForceUpdate)
+        {
+            string assetPath = AssetDatabase.GetAssetPath(subAsset);
+
+            var clone = UnityEngine.Object.Instantiate(subAsset);
+            AssetDatabase.CreateAsset(clone, destinationPath);
+
+            var assetImporter = AssetImporter.GetAtPath(assetPath);
+            assetImporter.AddRemap(new AssetImporter.SourceAssetIdentifier(subAsset), clone);
+
+            if (isForceUpdate)
+            {
+                AssetDatabase.WriteImportSettingsIfDirty(assetPath);
+                AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate);
+            }
+        }
+
+        public static void ExtractAssets<T>(this ScriptedImporter importer, string dirName, string extension) where T : UnityEngine.Object
+        {
+            if (string.IsNullOrEmpty(importer.assetPath))
+                return;
+
+            var subAssets = importer.GetSubAssets<T>(importer.assetPath);
+
+            var path = string.Format("{0}/{1}.{2}",
+                Path.GetDirectoryName(importer.assetPath),
+                Path.GetFileNameWithoutExtension(importer.assetPath),
+                dirName
+                );
+
+            var info = importer.SafeCreateDirectory(path);
+
+            foreach (var asset in subAssets)
+            {
+                ExtractFromAsset(asset, string.Format("{0}/{1}{2}", path, asset.name, extension), false);
+            }
+        }
+
+        struct TextureInfo
+        {
+            public string Path;
+            public bool sRGB;
+            public bool IsNormalMap;
+        }
+
+        class TextureExtractor
+        {
+            GltfParser m_parser;
+
+            public glTF GLTF => m_parser.GLTF;
+
+            public readonly List<TextureInfo> Textures = new List<TextureInfo>();
+            UnityEngine.Texture2D[] m_subAssets;
+            string m_path;
+
+            public TextureExtractor(ScriptedImporter importer)
+            {
+                // parse GLTF
+                m_parser = new GltfParser();
+                m_parser.ParsePath(importer.assetPath);
+
+                m_path = $"{Path.GetDirectoryName(importer.assetPath)}/{Path.GetFileNameWithoutExtension(importer.assetPath)}.Textures";
+                m_subAssets = importer.GetSubAssets<UnityEngine.Texture2D>(importer.assetPath).ToArray();
+            }
+
+            static Regex s_mimeTypeReg = new Regex("image/(?<mime>.*)$");
+
+            public void Extract(int? index, string prop = default)
+            {
+                if (!index.HasValue)
+                {
+                    return;
+                }
+
+                var gltfTexture = GLTF.textures[index.Value];
+                var gltfImage = GLTF.images[gltfTexture.source];
+                var mimeType = s_mimeTypeReg.Match(gltfImage.mimeType);
+                var ext = "";
+                switch (mimeType.Groups["mime"].Value)
+                {
+                    case "jpeg":
+                        ext = ".jpg";
+                        break;
+
+                    case "png":
+                        ext = ".png";
+                        break;
+
+                    default:
+                        throw new NotImplementedException();
+
+                }
+
+                var assetName = gltfImage.name;
+                string targetPath = default;
+                switch (prop)
+                {
+                    case GetTextureParam.NORMAL_PROP:
+                    case GetTextureParam.METALLIC_GLOSS_PROP:
+                    case GetTextureParam.OCCLUSION_PROP:
+                        // File.WriteAllBytes(targetPath, subAsset.EncodeToPNG());
+                        throw new NotImplementedException();
+
+                    default:
+                        {
+                            var name = "";
+                            var bytes = GLTF.GetImageBytes(m_parser.Storage, gltfTexture.source, out name);
+                            targetPath = string.Format("{0}/{1}{2}",
+                                m_path,
+                                assetName,
+                                ext
+                                );
+                            File.WriteAllBytes(targetPath, bytes.ToArray());
+                        }
+                        break;
+                }
+
+                AssetDatabase.ImportAsset(targetPath);
+
+                var subAsset = m_subAssets.FirstOrDefault(x => x.name == assetName);
+                Textures.Add(new TextureInfo
+                {
+                    Path = targetPath,
+                    sRGB = true,
+                });
+            }
+        }
+
+        public static void ExtractTextures(this ScriptedImporter importer, string dirName, Action onCompleted = null)
+        {
+            if (string.IsNullOrEmpty(importer.assetPath))
+            {
+                return;
+            }
+
+            var path = string.Format("{0}/{1}.{2}",
+                Path.GetDirectoryName(importer.assetPath),
+                Path.GetFileNameWithoutExtension(importer.assetPath),
+                dirName
+                );
+            importer.SafeCreateDirectory(path);
+
+            // Reload Model
+            var extractor = new TextureExtractor(importer);
+
+            foreach (var material in extractor.GLTF.materials)
+            {
+                // standard or unlit
+                extractor.Extract(material.pbrMetallicRoughness?.baseColorTexture?.index);
+                if (!glTF_KHR_materials_unlit.IsEnable(material))
+                {
+                    // standard
+                }
+            }
+
+            EditorApplication.delayCall += () =>
+            {
+                foreach (var extracted in extractor.Textures)
+                {
+                    // TextureImporter
+                    var targetTextureImporter = AssetImporter.GetAtPath(extracted.Path) as TextureImporter;
+                    targetTextureImporter.sRGBTexture = extracted.sRGB;
+                    if (extracted.IsNormalMap)
+                    {
+                        targetTextureImporter.textureType = TextureImporterType.NormalMap;
+                    }
+                    targetTextureImporter.SaveAndReimport();
+
+                    // remap
+                    var externalObject = AssetDatabase.LoadAssetAtPath<UnityEngine.Texture2D>(extracted.Path);
+                    importer.AddRemap(new AssetImporter.SourceAssetIdentifier(typeof(UnityEngine.Texture2D), externalObject.name), externalObject);
+                }
+
+                AssetDatabase.ImportAsset(importer.assetPath, ImportAssetOptions.ForceUpdate);
+
+                if (onCompleted != null)
+                {
+                    onCompleted();
+                }
+            };
+        }
+
+        public static DirectoryInfo SafeCreateDirectory(this ScriptedImporter importer, string path)
+        {
+            if (Directory.Exists(path))
+            {
+                return null;
+            }
+            return Directory.CreateDirectory(path);
+        }
+    }
+}

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterExtension.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterExtension.cs
@@ -131,6 +131,7 @@ namespace UniGLTF
                 {
                     Path = targetPath,
                     sRGB = true,
+                    IsNormalMap = param.TextureType == GetTextureParam.NORMAL_PROP,
                 });
             }
         }

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterExtension.cs.meta
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c57d58453713684bb3888c33177ed78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniGLTF/Editor/UniGLTF/gltfAssetPostprocessor.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/gltfAssetPostprocessor.cs
@@ -44,8 +44,9 @@ namespace UniGLTF
                 return;
             }
 
-            var context = new ImporterContext();
-            context.Parse(src);
+            var parser = new GltfParser();
+            parser.ParsePath(src);
+            var context = new ImporterContext(parser);
 
             // Extract textures to assets folder
             context.ExtractImages(prefabPath);

--- a/Assets/UniGLTF/Editor/UniGLTF/gltfAssetPostprocessor.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/gltfAssetPostprocessor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if false
+using System;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -85,3 +86,4 @@ namespace UniGLTF
         }
     }
 }
+#endif

--- a/Assets/UniGLTF/Runtime/Extensions/UnityExtensions.cs
+++ b/Assets/UniGLTF/Runtime/Extensions/UnityExtensions.cs
@@ -45,9 +45,19 @@ namespace UniGLTF
             return new Vector4(v.x, v.y, -v.z, v.w);
         }
 
+        public static Vector4 ReverseX(this Vector4 v)
+        {
+            return new Vector4(-v.x, v.y, v.z, v.w);
+        }
+
         public static Vector3 ReverseZ(this Vector3 v)
         {
             return new Vector3(v.x, v.y, -v.z);
+        }
+
+        public static Vector3 ReverseX(this Vector3 v)
+        {
+            return new Vector3(-v.x, v.y, v.z);
         }
 
         [Obsolete]
@@ -67,6 +77,14 @@ namespace UniGLTF
             Vector3 axis;
             q.ToAngleAxis(out angle, out axis);
             return Quaternion.AngleAxis(-angle, ReverseZ(axis));
+        }
+
+        public static Quaternion ReverseX(this Quaternion q)
+        {
+            float angle;
+            Vector3 axis;
+            q.ToAngleAxis(out angle, out axis);
+            return Quaternion.AngleAxis(-angle, ReverseX(axis));
         }
 
         public static Matrix4x4 Matrix4x4FromColumns(Vector4 c0, Vector4 c1, Vector4 c2, Vector4 c3)
@@ -97,6 +115,12 @@ namespace UniGLTF
         public static Matrix4x4 ReverseZ(this Matrix4x4 m)
         {
             m.SetTRS(m.ExtractPosition().ReverseZ(), m.ExtractRotation().ReverseZ(), m.ExtractScale());
+            return m;
+        }
+
+        public static Matrix4x4 ReverseX(this Matrix4x4 m)
+        {
+            m.SetTRS(m.ExtractPosition().ReverseX(), m.ExtractRotation().ReverseX(), m.ExtractScale());
             return m;
         }
 

--- a/Assets/UniGLTF/Runtime/Extensions/glTFExtensions.cs
+++ b/Assets/UniGLTF/Runtime/Extensions/glTFExtensions.cs
@@ -325,7 +325,8 @@ namespace UniGLTF
             var bufferCount = vertexAccessor.count * vertexAccessor.TypeCount;
 
             float[] result = null;
-            if(vertexAccessor.bufferView != -1){
+            if (vertexAccessor.bufferView != -1)
+            {
                 var attrib = new float[vertexAccessor.count * vertexAccessor.TypeCount];
                 var view = self.bufferViews[vertexAccessor.bufferView];
                 var segment = self.buffers[view.buffer].GetBytes();
@@ -333,8 +334,9 @@ namespace UniGLTF
                 bytes.MarshalCopyTo(attrib);
                 result = attrib;
             }
-            else{
-                result =  new float[bufferCount];
+            else
+            {
+                result = new float[bufferCount];
             }
 
             var sparse = vertexAccessor.sparse;
@@ -354,28 +356,15 @@ namespace UniGLTF
             return result;
         }
 
-        public static ArraySegment<Byte> GetImageBytes(this glTF self, IStorage storage, int imageIndex, out string textureName)
+        public static ArraySegment<Byte> GetImageBytes(this glTF self, IStorage storage, int imageIndex)
         {
             var image = self.images[imageIndex];
             if (string.IsNullOrEmpty(image.uri))
             {
-                //
-                // use buffer view (GLB)
-                //
-                //m_imageBytes = ToArray(byteSegment);
-                textureName = !string.IsNullOrEmpty(image.name) ? image.name : string.Format("{0:00}#GLB", imageIndex);
                 return self.GetViewBytes(image.bufferView);
             }
             else
             {
-                if (image.uri.FastStartsWith("data:"))
-                {
-                    textureName = !string.IsNullOrEmpty(image.name) ? image.name : string.Format("{0:00}#Base64Embedded", imageIndex);
-                }
-                else
-                {
-                    textureName = !string.IsNullOrEmpty(image.name) ? image.name : Path.GetFileNameWithoutExtension(image.uri);
-                }
                 return storage.Get(image.uri);
             }
         }
@@ -441,7 +430,7 @@ namespace UniGLTF
             // remove unused extenions
             var json = f.ToString().ParseAsJson().ToString("  ");
             self.RemoveUnusedExtensions(json);
-            
+
             return Glb.Create(json, self.buffers[0].GetBytes()).ToBytes();
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/glTF.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/glTF.cs
@@ -67,16 +67,6 @@ namespace UniGLTF
         [JsonSchema(MinItems = 1, ExplicitIgnorableItemLength = 0)]
         public List<glTFImage> images = new List<glTFImage>();
 
-        public int GetImageIndexFromTextureIndex(int textureIndex)
-        {
-            return textures[textureIndex].source;
-        }
-
-        public glTFImage GetImageFromTextureIndex(int textureIndex)
-        {
-            return images[GetImageIndexFromTextureIndex(textureIndex)];
-        }
-
         public glTFTextureSampler GetSamplerFromTextureIndex(int textureIndex)
         {
             var samplerIndex = textures[textureIndex].sampler;

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/glTF.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/glTF.cs
@@ -172,12 +172,5 @@ namespace UniGLTF
                 && animations.SequenceEqual(other.animations)
                 ;
         }
-
-        public string ImageNameFromTextureIndex(int index)
-        {
-            var gltfTexture = textures[index];
-            var glTFImage = images[gltfTexture.source];
-            return glTFImage.name;
-        }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/glTF.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/glTF.cs
@@ -182,5 +182,12 @@ namespace UniGLTF
                 && animations.SequenceEqual(other.animations)
                 ;
         }
+
+        public string ImageNameFromTextureIndex(int index)
+        {
+            var gltfTexture = textures[index];
+            var glTFImage = images[gltfTexture.source];
+            return glTFImage.name;
+        }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/AltTask/Awaitable.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/AltTask/Awaitable.cs
@@ -78,6 +78,10 @@ namespace UniGLTF.AltTask
 
         public Awaitable(Task task)
         {
+            if (task.IsFaulted)
+            {
+                throw task.Exception;
+            }
             _task = task;
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/AltTask/Awaitable.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/AltTask/Awaitable.cs
@@ -78,14 +78,16 @@ namespace UniGLTF.AltTask
 
         public Awaitable(Task task)
         {
-            if (task.IsFaulted)
-            {
-                throw task.Exception;
-            }
             _task = task;
+            if (_task.Exception != null)
+            {
+                throw _task.Exception;
+            }
         }
 
         public bool IsCompleted => _task.IsCompleted;
+
+        public Exception Exception => _task.Exception;
 
         public IAwaiter GetAwaiter()
         {
@@ -130,6 +132,10 @@ namespace UniGLTF.AltTask
 
         public void GetResult()
         {
+            if (m_task.Exception != null)
+            {
+                throw m_task.Exception;
+            }
         }
 
         public void OnCompleted(Action continuation)

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/AltTask/GenericAwaitable.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/AltTask/GenericAwaitable.cs
@@ -70,11 +70,15 @@ namespace UniGLTF.AltTask
         public Awaitable(Task<T> task)
         {
             _task = task;
+            if (_task.Exception != null)
+            {
+                throw _task.Exception;
+            }
         }
-
 
         public bool IsCompleted => _task.IsCompleted;
         public T Result => _task.Result;
+        public Exception Exception => _task.Exception;
 
         public IAwaiter<T> GetAwaiter()
         {
@@ -110,6 +114,10 @@ namespace UniGLTF.AltTask
 
         public T GetResult()
         {
+            if (m_task.Exception != null)
+            {
+                throw m_task.Exception;
+            }
             return m_task.Result;
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/AltTask/NextFrameAwaitable.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/AltTask/NextFrameAwaitable.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace UniGLTF.AltTask
 {
-    public static class LoopAwaitable
+    public static class NextFrameAwaitable
     {
         // TODO
         // loop スレッド使わないようにしたい

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/AltTask/NextFrameAwaitable.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/AltTask/NextFrameAwaitable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: db36517c11c455e4b94d9cbb8c1cc3ff
+guid: 81795a4f6e605d74787f604354a8565f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/AnimationImporterUtil.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/AnimationImporterUtil.cs
@@ -64,7 +64,7 @@ namespace UniGLTF
 
         }
 
-        public delegate float[] ReverseZ(float[] current, float[] last);
+        public delegate float[] ReverseFunc(float[] current, float[] last);
         public static void SetAnimationCurve(
             AnimationClip targetClip,
             string relativePath,
@@ -73,7 +73,7 @@ namespace UniGLTF
             float[] output,
             string interpolation,
             Type curveType,
-            ReverseZ reverse)
+            ReverseFunc reverse)
         {
             var tangentMode = GetTangentMode(interpolation);
 
@@ -164,18 +164,18 @@ namespace UniGLTF
 
         private static string RelativePathFrom(List<glTFNode> nodes, glTFNode root, glTFNode target, List<string> path)
         {
-            if(path.Count == 0) path.Add(target.name);
+            if (path.Count == 0) path.Add(target.name);
 
             var targetIndex = nodes.IndexOf(target);
             foreach (var parent in nodes)
             {
-                if(parent.children == null || parent.children.Length == 0) continue;
+                if (parent.children == null || parent.children.Length == 0) continue;
 
-                foreach(var child in parent.children)
+                foreach (var child in parent.children)
                 {
-                    if(child != targetIndex) continue;
+                    if (child != targetIndex) continue;
 
-                    if(parent == root) return string.Join("/", path);
+                    if (parent == root) return string.Join("/", path);
 
                     path.Insert(0, parent.name);
                     return RelativePathFrom(nodes, root, parent, path);
@@ -185,7 +185,7 @@ namespace UniGLTF
             return string.Join("/", path);
         }
 
-        public static AnimationClip ConvertAnimationClip(glTF gltf, glTFAnimation animation, glTFNode root = null)
+        public static AnimationClip ConvertAnimationClip(glTF gltf, glTFAnimation animation, AxisInverter inverter, glTFNode root = null)
         {
             var clip = new AnimationClip();
             clip.ClearCurves();
@@ -215,7 +215,7 @@ namespace UniGLTF
                                 (values, last) =>
                                 {
                                     Vector3 temp = new Vector3(values[0], values[1], values[2]);
-                                    return temp.ReverseZ().ToArray();
+                                    return inverter.InvertVector3(temp).ToArray();
                                 }
                                 );
                         }
@@ -239,7 +239,7 @@ namespace UniGLTF
                                 {
                                     Quaternion currentQuaternion = new Quaternion(values[0], values[1], values[2], values[3]);
                                     Quaternion lastQuaternion = new Quaternion(last[0], last[1], last[2], last[3]);
-                                    return AnimationImporterUtil.GetShortest(lastQuaternion, currentQuaternion.ReverseZ()).ToArray();
+                                    return AnimationImporterUtil.GetShortest(lastQuaternion, inverter.InvertQuaternion(currentQuaternion)).ToArray();
                                 }
                             );
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/Axises.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/Axises.cs
@@ -1,0 +1,35 @@
+using System;
+using UnityEngine;
+
+namespace UniGLTF
+{
+    public enum Axises
+    {
+        Z,
+        X,
+    }
+
+    public struct AxisInverter
+    {
+        public Func<Vector3, Vector3> InvertVector3;
+        public Func<Vector4, Vector4> InvertVector4;
+        public Func<Quaternion, Quaternion> InvertQuaternion;
+        public Func<Matrix4x4, Matrix4x4> InvertMat4;
+
+        public static AxisInverter ReverseZ => new AxisInverter
+        {
+            InvertVector3 = x => x.ReverseZ(),
+            InvertVector4 = x => x.ReverseZ(),
+            InvertQuaternion = x => x.ReverseZ(),
+            InvertMat4 = x => x.ReverseZ(),
+        };
+
+        public static AxisInverter ReverseX => new AxisInverter
+        {
+            InvertVector3 = x => x.ReverseX(),
+            InvertVector4 = x => x.ReverseX(),
+            InvertQuaternion = x => x.ReverseX(),
+            InvertMat4 = x => x.ReverseX(),
+        };
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/Axises.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/Axises.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b3b7b9629a4da242bacf52f5ca0fd80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
@@ -165,6 +165,7 @@ namespace UniGLTF
 
             FixMeshNameUnique();
             FixImageNameUnique();
+            FixMaterialNameUnique();
             FixNodeName();
 
             // parepare byte buffer
@@ -235,6 +236,19 @@ namespace UniGLTF
                         lower = uname;
                     }
                     used.Add(lower);
+                }
+            }
+        }
+
+        public void FixMaterialNameUnique()
+        {
+            foreach (var material in GLTF.materials)
+            {
+                var originalName = material.name;
+                int j = 2;
+                while (GLTF.materials.Any(x => x != material && x.name == material.name))
+                {
+                    material.name = string.Format("{0}({1})", originalName, j++);
                 }
             }
         }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
@@ -163,7 +163,8 @@ namespace UniGLTF
             // Version Compatibility
             RestoreOlderVersionValues();
 
-            FixUnique();
+            FixMeshNameUnique();
+            FixImageNameUnique();
             FixNodeName();
 
             // parepare byte buffer
@@ -174,29 +175,66 @@ namespace UniGLTF
             }
         }
 
-        void FixUnique()
+        void FixMeshNameUnique()
         {
             var used = new HashSet<string>();
             foreach (var mesh in GLTF.meshes)
             {
                 if (string.IsNullOrEmpty(mesh.name))
                 {
+                    // empty
                     mesh.name = "mesh_" + Guid.NewGuid().ToString("N");
+                    Debug.LogWarning($"no name: => {mesh.name}");
                     used.Add(mesh.name);
                 }
                 else
                 {
-                    var lname = mesh.name.ToLower();
-                    if (used.Contains(lname))
+                    var lower = mesh.name.ToLower();
+                    if (used.Contains(lower))
                     {
                         // rename
-                        var uname = lname + "_" + Guid.NewGuid().ToString("N");
-                        Debug.LogWarning($"same name: {lname} => {uname}");
+                        var uname = lower + "_" + Guid.NewGuid().ToString("N");
+                        Debug.LogWarning($"same name: {lower} => {uname}");
                         mesh.name = uname;
-                        lname = uname;
+                        lower = uname;
                     }
+                    used.Add(lower);
+                }
+            }
+        }
 
-                    used.Add(lname);
+        void FixImageNameUnique()
+        {
+            var used = new HashSet<string>();
+            for (int i = 0; i < GLTF.images.Count; ++i)
+            {
+                var image = GLTF.images[i];
+                if (string.IsNullOrEmpty(image.name))
+                {
+                    var newName = $"image_{i}";
+                    if (!used.Add(newName))
+                    {
+                        newName = "image_" + Guid.NewGuid().ToString("N");
+                        if (!used.Add(newName))
+                        {
+                            throw new Exception();
+                        }
+                    }
+                    image.name = newName;
+                    // Debug.LogWarning($"no name: => {image.name}");
+                }
+                else
+                {
+                    var lower = image.name.ToLower();
+                    if (used.Contains(lower))
+                    {
+                        // rename
+                        var uname = lower + "_" + Guid.NewGuid().ToString("N");
+                        Debug.LogWarning($"same name: {lower} => {uname}");
+                        image.name = uname;
+                        lower = uname;
+                    }
+                    used.Add(lower);
                 }
             }
         }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UniJSON;
+using UnityEngine;
+
+namespace UniGLTF
+{
+    public class GltfParser
+    {
+        /// <summary>
+        /// JSON source
+        /// </summary>
+        public String Json;
+
+        /// <summary>
+        /// GLTF parsed from JSON
+        /// </summary>
+        public glTF GLTF;
+
+        /// <summary>
+        /// URI access
+        /// </summary>
+        public IStorage Storage;
+
+        public static bool IsGeneratedUniGLTFAndOlderThan(string generatorVersion, int major, int minor)
+        {
+            if (string.IsNullOrEmpty(generatorVersion)) return false;
+            if (generatorVersion == "UniGLTF") return true;
+            if (!generatorVersion.FastStartsWith("UniGLTF-")) return false;
+
+            try
+            {
+                var splitted = generatorVersion.Substring(8).Split('.');
+                var generatorMajor = int.Parse(splitted[0]);
+                var generatorMinor = int.Parse(splitted[1]);
+
+                if (generatorMajor < major)
+                {
+                    return true;
+                }
+                else if (generatorMajor > major)
+                {
+                    return false;
+                }
+                else
+                {
+                    if (generatorMinor >= minor)
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarningFormat("{0}: {1}", generatorVersion, ex);
+                return false;
+            }
+        }
+
+        public bool IsGeneratedUniGLTFAndOlder(int major, int minor)
+        {
+            if (GLTF == null) return false;
+            if (GLTF.asset == null) return false;
+            return IsGeneratedUniGLTFAndOlderThan(GLTF.asset.generator, major, minor);
+        }
+
+        #region Parse
+        public void ParsePath(string path)
+        {
+            Parse(path, File.ReadAllBytes(path));
+        }
+
+        /// <summary>
+        /// Parse gltf json or Parse json chunk of glb
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="bytes"></param>
+        public virtual void Parse(string path, Byte[] bytes)
+        {
+            var ext = Path.GetExtension(path).ToLower();
+            switch (ext)
+            {
+                case ".gltf":
+                    ParseJson(Encoding.UTF8.GetString(bytes), new FileSystemStorage(Path.GetDirectoryName(path)));
+                    break;
+
+                case ".zip":
+                    {
+                        var zipArchive = Zip.ZipArchiveStorage.Parse(bytes);
+                        var gltf = zipArchive.Entries.FirstOrDefault(x => x.FileName.ToLower().EndsWith(".gltf"));
+                        if (gltf == null)
+                        {
+                            throw new Exception("no gltf in archive");
+                        }
+                        var jsonBytes = zipArchive.Extract(gltf);
+                        var json = Encoding.UTF8.GetString(jsonBytes);
+                        ParseJson(json, zipArchive);
+                    }
+                    break;
+
+                default:
+                    ParseGlb(bytes);
+                    break;
+            }
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="bytes"></param>
+        public void ParseGlb(Byte[] bytes)
+        {
+            var chunks = glbImporter.ParseGlbChunks(bytes);
+
+            if (chunks.Count != 2)
+            {
+                throw new Exception("unknown chunk count: " + chunks.Count);
+            }
+
+            if (chunks[0].ChunkType != GlbChunkType.JSON)
+            {
+                throw new Exception("chunk 0 is not JSON");
+            }
+
+            if (chunks[1].ChunkType != GlbChunkType.BIN)
+            {
+                throw new Exception("chunk 1 is not BIN");
+            }
+
+            try
+            {
+                var jsonBytes = chunks[0].Bytes;
+                ParseJson(Encoding.UTF8.GetString(jsonBytes.Array, jsonBytes.Offset, jsonBytes.Count),
+                    new SimpleStorage(chunks[1].Bytes));
+            }
+            catch (StackOverflowException ex)
+            {
+                throw new Exception("[UniVRM Import Error] json parsing failed, nesting is too deep.\n" + ex);
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        public virtual void ParseJson(string json, IStorage storage)
+        {
+            Json = json;
+            Storage = storage;
+            GLTF = GltfDeserializer.Deserialize(json.ParseAsJson());
+            if (GLTF.asset.version != "2.0")
+            {
+                throw new UniGLTFException("unknown gltf version {0}", GLTF.asset.version);
+            }
+
+            // Version Compatibility
+            RestoreOlderVersionValues();
+
+            FixUnique();
+            FixNodeName();
+
+            // parepare byte buffer
+            //GLTF.baseDir = System.IO.Path.GetDirectoryName(Path);
+            foreach (var buffer in GLTF.buffers)
+            {
+                buffer.OpenStorage(storage);
+            }
+        }
+
+        void FixUnique()
+        {
+            var used = new HashSet<string>();
+            foreach (var mesh in GLTF.meshes)
+            {
+                if (string.IsNullOrEmpty(mesh.name))
+                {
+                    mesh.name = "mesh_" + Guid.NewGuid().ToString("N");
+                    used.Add(mesh.name);
+                }
+                else
+                {
+                    var lname = mesh.name.ToLower();
+                    if (used.Contains(lname))
+                    {
+                        // rename
+                        var uname = lname + "_" + Guid.NewGuid().ToString("N");
+                        Debug.LogWarning($"same name: {lname} => {uname}");
+                        mesh.name = uname;
+                        lname = uname;
+                    }
+
+                    used.Add(lname);
+                }
+            }
+        }
+
+        /// <summary>
+        /// rename empty name to $"{index}"
+        /// </summary>
+        void FixNodeName()
+        {
+            for (var i = 0; i < GLTF.nodes.Count; ++i)
+            {
+                var node = GLTF.nodes[i];
+                if (string.IsNullOrWhiteSpace(node.name))
+                {
+                    node.name = $"{i}";
+                }
+            }
+        }
+
+        void RestoreOlderVersionValues()
+        {
+            var parsed = UniJSON.JsonParser.Parse(Json);
+            for (int i = 0; i < GLTF.images.Count; ++i)
+            {
+                if (string.IsNullOrEmpty(GLTF.images[i].name))
+                {
+                    try
+                    {
+                        var extraName = parsed["images"][i]["extra"]["name"].Value.GetString();
+                        if (!string.IsNullOrEmpty(extraName))
+                        {
+                            //Debug.LogFormat("restore texturename: {0}", extraName);
+                            GLTF.images[i].name = extraName;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // do nothing
+                    }
+                }
+            }
+        }
+        #endregion
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
@@ -292,5 +292,15 @@ namespace UniGLTF
             }
         }
         #endregion
+
+        public IEnumerable<GetTextureParam> EnumerateTextures()
+        {
+            for (int i = 0; i < GLTF.textures.Count; ++i)
+            {
+                yield return GetTextureParam.Create(GLTF, i);
+            }
+
+            // TODO: converted textures
+        }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
@@ -204,12 +204,32 @@ namespace UniGLTF
             }
         }
 
+        void RenameImageFromTexture(int i)
+        {
+            foreach (var texture in GLTF.textures)
+            {
+                if (texture.source == i)
+                {
+                    if (!string.IsNullOrEmpty(texture.name))
+                    {
+                        GLTF.images[i].name = texture.name;
+                        return;
+                    }
+                }
+            }
+        }
+
         void FixImageNameUnique()
         {
             var used = new HashSet<string>();
             for (int i = 0; i < GLTF.images.Count; ++i)
             {
                 var image = GLTF.images[i];
+                if (string.IsNullOrEmpty(image.name))
+                {
+                    RenameImageFromTexture(i);
+                }
+
                 if (string.IsNullOrEmpty(image.name))
                 {
                     var newName = $"image_{i}";

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae3083233546b58449904dca65e76005
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -45,7 +45,7 @@ namespace UniGLTF
         {
             m_parser = parser;
             m_textureFactory = new TextureFactory(GLTF, Storage, externalObjectMap);
-            m_materialFactory = new MaterialFactory(GLTF, Storage);
+            m_materialFactory = new MaterialFactory(GLTF, Storage, externalObjectMap);
         }
 
         #region Source

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -37,9 +37,11 @@ namespace UniGLTF
 
         MaterialFactory m_materialFactory;
         public MaterialFactory MaterialFactory => m_materialFactory;
+        public IEnumerable<Material> Materials => m_materialFactory.Materials;
 
         TextureFactory m_textureFactory;
         public TextureFactory TextureFactory => m_textureFactory;
+        public IEnumerable<Texture2D> Textures => m_textureFactory.Textures;
 
         public ImporterContext(GltfParser parser)
         {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -57,9 +57,6 @@ namespace UniGLTF
         #endregion
 
         #region Load. Build unity objects
-
-        public bool EnableLoadBalancing;
-
         public virtual async Awaitable LoadAsync(Func<string, IDisposable> MeasureTime = null)
         {
             if (MeasureTime == null)
@@ -145,16 +142,7 @@ namespace UniGLTF
         {
             using (MeasureTime("BuildMesh"))
             {
-                MeshWithMaterials meshWithMaterials;
-                if (EnableLoadBalancing)
-                {
-                    meshWithMaterials = await MeshImporter.BuildMeshAsync(MaterialFactory, x);
-                }
-                else
-                {
-                    meshWithMaterials = MeshImporter.BuildMesh(MaterialFactory, x);
-                }
-
+                var meshWithMaterials = await MeshImporter.BuildMeshAsync(MaterialFactory, x);
                 var mesh = meshWithMaterials.Mesh;
 
                 // mesh name

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -391,30 +391,29 @@ namespace UniGLTF
             // https://answers.unity.com/questions/647615/how-to-update-import-settings-for-newly-created-as.html
             //
             int created = 0;
-            //for (int i = 0; i < GLTF.textures.Count; ++i)
-            for (int i = 0; i < GLTF.images.Count; ++i)
+            for (int i = 0; i < GLTF.textures.Count; ++i)
             {
                 folder.EnsureFolder();
 
-                //var x = GLTF.textures[i];
-                var image = GLTF.images[i];
-                var src = Storage.GetPath(image.uri);
+                var gltfTexture = GLTF.textures[i];
+                var gltfImage = GLTF.images[gltfTexture.source];
+                var src = Storage.GetPath(gltfImage.uri);
                 if (UnityPath.FromFullpath(src).IsUnderAssetsFolder)
                 {
                     // asset is exists.
                 }
                 else
                 {
-                    string textureName;
-                    var byteSegment = GLTF.GetImageBytes(Storage, i, out textureName);
+                    var byteSegment = GLTF.GetImageBytes(Storage, gltfTexture.source);
+                    var textureName = gltfTexture.name;
 
                     // path
-                    var dst = folder.Child(textureName + image.GetExt());
+                    var dst = folder.Child(textureName + gltfImage.GetExt());
                     File.WriteAllBytes(dst.FullPath, byteSegment.ToArray());
                     dst.ImportAsset();
 
                     // make relative path from PrefabParentDir
-                    image.uri = dst.Value.Substring(prefabParentDir.Value.Length + 1);
+                    gltfImage.uri = dst.Value.Substring(prefabParentDir.Value.Length + 1);
                     ++created;
                 }
             }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -98,6 +98,15 @@ namespace UniGLTF
                 throw new UniGLTFNotSupportedException("draco is not supported");
             }
 
+            // create textures
+            for (int i = 0; i < GLTF.materials.Count; ++i)
+            {
+                foreach (var param in MaterialFactory.EnumerateGetTextureparam(i))
+                {
+                    await m_textureFactory.GetTextureAsync(GLTF, param);
+                }
+            }
+
             await m_materialFactory.LoadMaterialsAsync(m_textureFactory.GetTextureAsync);
 
             // meshes

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -41,7 +41,7 @@ namespace UniGLTF
         TextureFactory m_textureFactory;
         public TextureFactory TextureFactory => m_textureFactory;
 
-        public ImporterContext(GltfParser parser, IEnumerable<KeyValuePair<string, UnityEngine.Object>> externalObjectMap = null)
+        public ImporterContext(GltfParser parser, IEnumerable<(string, UnityEngine.Object)> externalObjectMap = null)
         {
             m_parser = parser;
             m_textureFactory = new TextureFactory(GLTF, Storage, externalObjectMap);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -98,16 +98,16 @@ namespace UniGLTF
                 throw new UniGLTFNotSupportedException("draco is not supported");
             }
 
-            using (MeasureTime("LoadTextures"))
-            {
-                for (int i = 0; i < GLTF.materials.Count; ++i)
-                {
-                    foreach (var param in MaterialFactory.EnumerateGetTextureparam(i))
-                    {
-                        await m_textureFactory.GetTextureAsync(GLTF, param);
-                    }
-                }
-            }
+            // using (MeasureTime("LoadTextures"))
+            // {
+            //     for (int i = 0; i < GLTF.materials.Count; ++i)
+            //     {
+            //         foreach (var param in MaterialFactory.EnumerateGetTextureparam(i))
+            //         {
+            //             await m_textureFactory.GetTextureAsync(GLTF, param);
+            //         }
+            //     }
+            // }
 
             using (MeasureTime("LoadMaterials"))
             {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -37,16 +37,14 @@ namespace UniGLTF
 
         MaterialFactory m_materialFactory;
         public MaterialFactory MaterialFactory => m_materialFactory;
-        public IEnumerable<Material> Materials => m_materialFactory.Materials;
 
         TextureFactory m_textureFactory;
         public TextureFactory TextureFactory => m_textureFactory;
-        public IEnumerable<Texture2D> Textures => m_textureFactory.Textures;
 
-        public ImporterContext(GltfParser parser)
+        public ImporterContext(GltfParser parser, IEnumerable<KeyValuePair<string, UnityEngine.Object>> externalObjectMap = null)
         {
             m_parser = parser;
-            m_textureFactory = new TextureFactory(GLTF, Storage);
+            m_textureFactory = new TextureFactory(GLTF, Storage, externalObjectMap);
             m_materialFactory = new MaterialFactory(GLTF, Storage);
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -98,7 +98,6 @@ namespace UniGLTF
                 throw new UniGLTFNotSupportedException("draco is not supported");
             }
 
-            // create textures
             using (MeasureTime("LoadTextures"))
             {
                 for (int i = 0; i < GLTF.materials.Count; ++i)
@@ -115,7 +114,6 @@ namespace UniGLTF
                 await m_materialFactory.LoadMaterialsAsync(m_textureFactory.GetTextureAsync);
             }
 
-            // meshes
             var meshImporter = new MeshImporter();
             for (int i = 0; i < GLTF.meshes.Count; ++i)
             {
@@ -135,7 +133,7 @@ namespace UniGLTF
                     Nodes.Add(NodeImporter.ImportNode(GLTF.nodes[i], i).transform);
                 }
             }
-            await LoopAwaitable.Create();
+            await NextFrameAwaitable.Create();
 
             using (MeasureTime("BuildHierarchy"))
             {
@@ -160,7 +158,7 @@ namespace UniGLTF
                     t.SetParent(Root.transform, false);
                 }
             }
-            await LoopAwaitable.Create();
+            await NextFrameAwaitable.Create();
 
             using (MeasureTime("AnimationImporter"))
             {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -99,15 +99,21 @@ namespace UniGLTF
             }
 
             // create textures
-            for (int i = 0; i < GLTF.materials.Count; ++i)
+            using (MeasureTime("LoadTextures"))
             {
-                foreach (var param in MaterialFactory.EnumerateGetTextureparam(i))
+                for (int i = 0; i < GLTF.materials.Count; ++i)
                 {
-                    await m_textureFactory.GetTextureAsync(GLTF, param);
+                    foreach (var param in MaterialFactory.EnumerateGetTextureparam(i))
+                    {
+                        await m_textureFactory.GetTextureAsync(GLTF, param);
+                    }
                 }
             }
 
-            await m_materialFactory.LoadMaterialsAsync(m_textureFactory.GetTextureAsync);
+            using (MeasureTime("LoadMaterials"))
+            {
+                await m_materialFactory.LoadMaterialsAsync(m_textureFactory.GetTextureAsync);
+            }
 
             // meshes
             var meshImporter = new MeshImporter();

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -3,8 +3,6 @@ using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
 using System.IO;
-using System.Text;
-using UniJSON;
 using UniGLTF.AltTask;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -43,247 +41,19 @@ namespace UniGLTF
         TextureFactory m_textureFactory;
         public TextureFactory TextureFactory => m_textureFactory;
 
-        public ImporterContext()
+        public ImporterContext(GltfParser parser)
         {
-        }
-        #region Source
-
-        /// <summary>
-        /// JSON source
-        /// </summary>
-        public String Json;
-
-        /// <summary>
-        /// GLTF parsed from JSON
-        /// </summary>
-        public glTF GLTF; // parsed
-
-        public static bool IsGeneratedUniGLTFAndOlderThan(string generatorVersion, int major, int minor)
-        {
-            if (string.IsNullOrEmpty(generatorVersion)) return false;
-            if (generatorVersion == "UniGLTF") return true;
-            if (!generatorVersion.FastStartsWith("UniGLTF-")) return false;
-
-            try
-            {
-                var splitted = generatorVersion.Substring(8).Split('.');
-                var generatorMajor = int.Parse(splitted[0]);
-                var generatorMinor = int.Parse(splitted[1]);
-
-                if (generatorMajor < major)
-                {
-                    return true;
-                }
-                else if (generatorMajor > major)
-                {
-                    return false;
-                }
-                else
-                {
-                    if (generatorMinor >= minor)
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        return true;
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.LogWarningFormat("{0}: {1}", generatorVersion, ex);
-                return false;
-            }
-        }
-
-        public bool IsGeneratedUniGLTFAndOlder(int major, int minor)
-        {
-            if (GLTF == null) return false;
-            if (GLTF.asset == null) return false;
-            return IsGeneratedUniGLTFAndOlderThan(GLTF.asset.generator, major, minor);
-        }
-
-        /// <summary>
-        /// URI access
-        /// </summary>
-        public IStorage Storage;
-        #endregion
-
-        #region Parse
-        public void Parse(string path)
-        {
-            Parse(path, File.ReadAllBytes(path));
-        }
-
-        /// <summary>
-        /// Parse gltf json or Parse json chunk of glb
-        /// </summary>
-        /// <param name="path"></param>
-        /// <param name="bytes"></param>
-        public virtual void Parse(string path, Byte[] bytes)
-        {
-            var ext = Path.GetExtension(path).ToLower();
-            switch (ext)
-            {
-                case ".gltf":
-                    ParseJson(Encoding.UTF8.GetString(bytes), new FileSystemStorage(Path.GetDirectoryName(path)));
-                    break;
-
-                case ".zip":
-                    {
-                        var zipArchive = Zip.ZipArchiveStorage.Parse(bytes);
-                        var gltf = zipArchive.Entries.FirstOrDefault(x => x.FileName.ToLower().EndsWith(".gltf"));
-                        if (gltf == null)
-                        {
-                            throw new Exception("no gltf in archive");
-                        }
-                        var jsonBytes = zipArchive.Extract(gltf);
-                        var json = Encoding.UTF8.GetString(jsonBytes);
-                        ParseJson(json, zipArchive);
-                    }
-                    break;
-
-                case ".glb":
-                    ParseGlb(bytes);
-                    break;
-
-                default:
-                    throw new NotImplementedException();
-            }
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="bytes"></param>
-        public void ParseGlb(Byte[] bytes)
-        {
-            var chunks = glbImporter.ParseGlbChunks(bytes);
-
-            if (chunks.Count != 2)
-            {
-                throw new Exception("unknown chunk count: " + chunks.Count);
-            }
-
-            if (chunks[0].ChunkType != GlbChunkType.JSON)
-            {
-                throw new Exception("chunk 0 is not JSON");
-            }
-
-            if (chunks[1].ChunkType != GlbChunkType.BIN)
-            {
-                throw new Exception("chunk 1 is not BIN");
-            }
-
-            try
-            {
-                var jsonBytes = chunks[0].Bytes;
-                ParseJson(Encoding.UTF8.GetString(jsonBytes.Array, jsonBytes.Offset, jsonBytes.Count),
-                    new SimpleStorage(chunks[1].Bytes));
-            }
-            catch (StackOverflowException ex)
-            {
-                throw new Exception("[UniVRM Import Error] json parsing failed, nesting is too deep.\n" + ex);
-            }
-            catch
-            {
-                throw;
-            }
-        }
-
-        public virtual void ParseJson(string json, IStorage storage)
-        {
-            Json = json;
-            Storage = storage;
-            GLTF = GltfDeserializer.Deserialize(json.ParseAsJson());
-            if (GLTF.asset.version != "2.0")
-            {
-                throw new UniGLTFException("unknown gltf version {0}", GLTF.asset.version);
-            }
-
+            m_parser = parser;
             m_textureFactory = new TextureFactory(GLTF, Storage);
             m_materialFactory = new MaterialFactory(GLTF, Storage);
-
-            // Version Compatibility
-            RestoreOlderVersionValues();
-
-            FixUnique();
-            FixNodeName();
-
-            // parepare byte buffer
-            //GLTF.baseDir = System.IO.Path.GetDirectoryName(Path);
-            foreach (var buffer in GLTF.buffers)
-            {
-                buffer.OpenStorage(storage);
-            }
         }
 
-        void FixUnique()
-        {
-            var used = new HashSet<string>();
-            foreach (var mesh in GLTF.meshes)
-            {
-                if (string.IsNullOrEmpty(mesh.name))
-                {
-                    mesh.name = "mesh_" + Guid.NewGuid().ToString("N");
-                    used.Add(mesh.name);
-                }
-                else
-                {
-                    var lname = mesh.name.ToLower();
-                    if (used.Contains(lname))
-                    {
-                        // rename
-                        var uname = lname + "_" + Guid.NewGuid().ToString("N");
-                        Debug.LogWarning($"same name: {lname} => {uname}");
-                        mesh.name = uname;
-                        lname = uname;
-                    }
-
-                    used.Add(lname);
-                }
-            }
-        }
-
-        /// <summary>
-        /// rename empty name to $"{index}"
-        /// </summary>
-        void FixNodeName()
-        {
-            for (var i = 0; i < GLTF.nodes.Count; ++i)
-            {
-                var node = GLTF.nodes[i];
-                if (string.IsNullOrWhiteSpace(node.name))
-                {
-                    node.name = $"{i}";
-                }
-            }
-        }
-
-        void RestoreOlderVersionValues()
-        {
-            var parsed = UniJSON.JsonParser.Parse(Json);
-            for (int i = 0; i < GLTF.images.Count; ++i)
-            {
-                if (string.IsNullOrEmpty(GLTF.images[i].name))
-                {
-                    try
-                    {
-                        var extraName = parsed["images"][i]["extra"]["name"].Value.GetString();
-                        if (!string.IsNullOrEmpty(extraName))
-                        {
-                            //Debug.LogFormat("restore texturename: {0}", extraName);
-                            GLTF.images[i].name = extraName;
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        // do nothing
-                    }
-                }
-            }
-        }
+        #region Source
+        GltfParser m_parser;
+        public GltfParser Parser => m_parser;
+        public String Json => m_parser.Json;
+        public glTF GLTF => m_parser.GLTF;
+        public IStorage Storage => m_parser.Storage;
         #endregion
 
         #region Load. Build unity objects

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
@@ -6,29 +6,6 @@ namespace UniGLTF
 {
     public static class ImporterContextExtensions
     {
-        // /// <summary>
-        // /// ReadAllBytes, Parse, Create GameObject
-        // /// </summary>
-        // /// <param name="path">allbytes</param>
-        // public static void Load(this ImporterContext self, string path)
-        // {
-        //     var bytes = File.ReadAllBytes(path);
-        //     self.Load(path, bytes);
-        // }
-
-        // /// <summary>
-        // /// Parse, Create GameObject
-        // /// </summary>
-        // /// <param name="path">gltf or glb path</param>
-        // /// <param name="bytes">allbytes</param>
-        // public static void Load(this ImporterContext self, string path, byte[] bytes)
-        // {
-        //     var parser = new GltfParser();
-        //     parser.Parse(path, bytes);
-        //     self.Load(parser);
-        //     self.Root.name = Path.GetFileNameWithoutExtension(path);
-        // }
-
         /// <summary>
         /// Build unity objects from parsed gltf
         /// </summary>

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using UniGLTF.AltTask;
+using UnityEngine;
 
 namespace UniGLTF
 {
@@ -32,9 +33,10 @@ namespace UniGLTF
         /// </summary>
         public static void Load(this ImporterContext self)
         {
+            var meassureTime = new ImporterContextSpeedLog();
             using (var queue = TaskQueue.Create())
             {
-                var task = self.LoadAsync();
+                var task = self.LoadAsync(meassureTime.MeasureTime);
 
                 // 中断された await を消化する
                 while (!task.IsCompleted)
@@ -43,6 +45,10 @@ namespace UniGLTF
                     queue.ExecuteOneCallback();
                 }
             }
+
+#if VRM_DEVELOP
+            Debug.Log(meassureTime.GetSpeedLog());
+#endif
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
@@ -6,27 +6,28 @@ namespace UniGLTF
 {
     public static class ImporterContextExtensions
     {
-        /// <summary>
-        /// ReadAllBytes, Parse, Create GameObject
-        /// </summary>
-        /// <param name="path">allbytes</param>
-        public static void Load(this ImporterContext self, string path)
-        {
-            var bytes = File.ReadAllBytes(path);
-            self.Load(path, bytes);
-        }
+        // /// <summary>
+        // /// ReadAllBytes, Parse, Create GameObject
+        // /// </summary>
+        // /// <param name="path">allbytes</param>
+        // public static void Load(this ImporterContext self, string path)
+        // {
+        //     var bytes = File.ReadAllBytes(path);
+        //     self.Load(path, bytes);
+        // }
 
-        /// <summary>
-        /// Parse, Create GameObject
-        /// </summary>
-        /// <param name="path">gltf or glb path</param>
-        /// <param name="bytes">allbytes</param>
-        public static void Load(this ImporterContext self, string path, byte[] bytes)
-        {
-            self.Parse(path, bytes);
-            self.Load();
-            self.Root.name = Path.GetFileNameWithoutExtension(path);
-        }
+        // /// <summary>
+        // /// Parse, Create GameObject
+        // /// </summary>
+        // /// <param name="path">gltf or glb path</param>
+        // /// <param name="bytes">allbytes</param>
+        // public static void Load(this ImporterContext self, string path, byte[] bytes)
+        // {
+        //     var parser = new GltfParser();
+        //     parser.Parse(path, bytes);
+        //     self.Load(parser);
+        //     self.Root.name = Path.GetFileNameWithoutExtension(path);
+        // }
 
         /// <summary>
         /// Build unity objects from parsed gltf

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextSpeedLog.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextSpeedLog.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace UniGLTF
+{
+    public class ImporterContextSpeedLog
+    {
+        public struct KeyElapsed
+        {
+            public string Key;
+            public TimeSpan Elapsed;
+            public KeyElapsed(string key, TimeSpan elapsed)
+            {
+                Key = key;
+                Elapsed = elapsed;
+            }
+        }
+
+        public struct MeasureScope : IDisposable
+        {
+            Action m_onDispose;
+            public MeasureScope(Action onDispose)
+            {
+                m_onDispose = onDispose;
+            }
+            public void Dispose()
+            {
+                m_onDispose();
+            }
+        }
+
+        public List<KeyElapsed> m_speedReports = new List<KeyElapsed>();
+
+        public IDisposable MeasureTime(string key)
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            return new MeasureScope(() =>
+            {
+                m_speedReports.Add(new KeyElapsed(key, sw.Elapsed));
+            });
+        }
+
+        public string GetSpeedLog()
+        {
+            var total = TimeSpan.Zero;
+
+            var sb = new StringBuilder();
+            sb.AppendLine("【SpeedLog】");
+            foreach (var kv in m_speedReports)
+            {
+                sb.AppendLine(string.Format("{0}: {1}ms", kv.Key, (int)kv.Elapsed.TotalMilliseconds));
+                total += kv.Elapsed;
+            }
+            sb.AppendLine(string.Format("total: {0}ms", (int)total.TotalMilliseconds));
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextSpeedLog.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextSpeedLog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e99bb16028e30ce4b972caecca5343b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/MaterialFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/MaterialFactory.cs
@@ -108,12 +108,11 @@ namespace UniGLTF
                 if (TryGetExternal(i, out Material material))
                 {
                     m_materials.Add(new MaterialLoadInfo(material, true));
+                    continue;
                 }
-                else
-                {
-                    material = await CreateMaterialAsync(m_gltf, i, getTexture);
-                    m_materials.Add(new MaterialLoadInfo(material, false));
-                }
+
+                material = await CreateMaterialAsync(m_gltf, i, getTexture);
+                m_materials.Add(new MaterialLoadInfo(material, false));
             }
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/MaterialFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/MaterialFactory.cs
@@ -16,7 +16,7 @@ namespace UniGLTF
             m_storage = storage;
         }
 
-        public delegate Awaitable<Material> CreateMaterialAsyncFunc(glTF glTF, int i, GetTextureAsyncFunc getTexture);
+        public delegate Awaitable<Material> CreateMaterialAsyncFunc(glTF gltf, int i, GetTextureAsyncFunc getTexture);
         CreateMaterialAsyncFunc m_createMaterialAsync;
         public CreateMaterialAsyncFunc CreateMaterialAsync
         {
@@ -78,6 +78,13 @@ namespace UniGLTF
             }
             else
             {
+                // 先に m_gltf.textures を作成
+                for (int i = 0; i < m_gltf.textures.Count; ++i)
+                {
+                    await getTexture(GetTextureParam.Create(i));
+                }
+                // 後に material を作成。
+                // 必用に応じてテクスチャを変換。
                 for (int i = 0; i < m_gltf.materials.Count; ++i)
                 {
                     var material = await CreateMaterialAsync(m_gltf, i, getTexture);
@@ -125,7 +132,6 @@ namespace UniGLTF
 
         public static Awaitable<Material> DefaultCreateMaterialAsync(glTF gltf, int i, GetTextureAsyncFunc getTexture)
         {
-
             if (i < 0 || i >= gltf.materials.Count)
             {
                 UnityEngine.Debug.LogWarning("glTFMaterial is empty");

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/MaterialFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/MaterialFactory.cs
@@ -96,6 +96,11 @@ namespace UniGLTF
             return m_materials[index].Asset;
         }
 
+        /// <summary>
+        /// テクスチャ生成
+        /// </summary>
+        /// <param name="getTexture"></param>
+        /// <returns></returns>
         public async Awaitable LoadMaterialsAsync(GetTextureAsyncFunc getTexture)
         {
             if (m_gltf.materials == null || m_gltf.materials.Count == 0)

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/MaterialFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/MaterialFactory.cs
@@ -93,7 +93,6 @@ namespace UniGLTF
             return m_materials[index].Asset;
         }
 
-
         public async Awaitable LoadMaterialsAsync(GetTextureAsyncFunc getTexture)
         {
             if (m_gltf.materials == null || m_gltf.materials.Count == 0)
@@ -104,14 +103,6 @@ namespace UniGLTF
                 return;
             }
 
-            // 先に m_gltf.textures を作成
-            for (int i = 0; i < m_gltf.textures.Count; ++i)
-            {
-                await getTexture(m_gltf, GetTextureParam.Create(m_gltf, i));
-            }
-
-            // 後に material を作成。
-            // 必用に応じてテクスチャを変換。
             for (int i = 0; i < m_gltf.materials.Count; ++i)
             {
                 if (TryGetExternal(i, out Material material))
@@ -196,6 +187,23 @@ namespace UniGLTF
             };
             var task = DefaultCreateMaterialAsync(gltf, i, null);
             return task.Result;
+        }
+
+        public IEnumerable<GetTextureParam> EnumerateGetTextureparam(int i)
+        {
+            var m = m_gltf.materials[i];
+
+            // color texture
+            var colorIndex = m.pbrMetallicRoughness?.baseColorTexture?.index;
+            if (colorIndex.HasValue)
+            {
+                yield return GetTextureParam.Create(m_gltf, i);
+            }
+
+            if (!glTF_KHR_materials_unlit.IsEnable(m))
+            {
+                // PBR
+            }
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/MaterialFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/MaterialFactory.cs
@@ -13,10 +13,13 @@ namespace UniGLTF
         Dictionary<string, Material> m_externalMap;
         public bool TryGetExternal(int index, out Material external)
         {
-            var gltfMaterial = m_gltf.materials[index];
-            if (m_externalMap.TryGetValue(gltfMaterial.name, out external))
+            if (m_externalMap != null)
             {
-                return true;
+                var gltfMaterial = m_gltf.materials[index];
+                if (m_externalMap.TryGetValue(gltfMaterial.name, out external))
+                {
+                    return true;
+                }
             }
 
             external = default;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/PBRMaterialItem.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/PBRMaterialItem.cs
@@ -43,6 +43,28 @@ namespace UniGLTF
             Transparent
         }
 
+        public static GetTextureParam BaseColorTexture(glTF gltf, glTFMaterial src)
+        {
+            return GetTextureParam.Create(gltf, src.pbrMetallicRoughness.baseColorTexture.index);
+        }
+
+        public static GetTextureParam MetallicRoughnessTexture(glTF gltf, glTFMaterial src)
+        {
+            return GetTextureParam.CreateMetallic(gltf,
+                            src.pbrMetallicRoughness.metallicRoughnessTexture.index,
+                            src.pbrMetallicRoughness.metallicFactor);
+        }
+
+        public static GetTextureParam OcclusionTexture(glTF gltf, glTFMaterial src)
+        {
+            return GetTextureParam.CreateOcclusion(gltf, src.occlusionTexture.index);
+        }
+
+        public static GetTextureParam NormalTexture(glTF gltf, glTFMaterial src)
+        {
+            return GetTextureParam.CreateNormal(gltf, src.normalTexture.index);
+        }
+
         public static async Awaitable<Material> CreateAsync(glTF gltf, int i, GetTextureAsyncFunc getTexture)
         {
             if (getTexture == null)
@@ -66,7 +88,7 @@ namespace UniGLTF
 
                     if (src.pbrMetallicRoughness.baseColorTexture != null && src.pbrMetallicRoughness.baseColorTexture.index != -1)
                     {
-                        material.mainTexture = await getTexture(gltf, GetTextureParam.Create(gltf, src.pbrMetallicRoughness.baseColorTexture.index));
+                        material.mainTexture = await getTexture(gltf, BaseColorTexture(gltf, src));
 
                         // Texture Offset and Scale
                         MaterialFactory.SetTextureOffsetAndScale(material, src.pbrMetallicRoughness.baseColorTexture, "_MainTex");
@@ -76,9 +98,7 @@ namespace UniGLTF
                     {
                         material.EnableKeyword("_METALLICGLOSSMAP");
 
-                        var texture = await getTexture(gltf, GetTextureParam.CreateMetallic(gltf,
-                            src.pbrMetallicRoughness.metallicRoughnessTexture.index,
-                            src.pbrMetallicRoughness.metallicFactor));
+                        var texture = await getTexture(gltf, MetallicRoughnessTexture(gltf, src));
                         if (texture != null)
                         {
                             material.SetTexture(GetTextureParam.METALLIC_GLOSS_PROP, texture);
@@ -101,7 +121,7 @@ namespace UniGLTF
                 if (src.normalTexture != null && src.normalTexture.index != -1)
                 {
                     material.EnableKeyword("_NORMALMAP");
-                    var texture = await getTexture(gltf, GetTextureParam.CreateNormal(gltf, src.normalTexture.index));
+                    var texture = await getTexture(gltf, NormalTexture(gltf, src));
                     if (texture != null)
                     {
                         material.SetTexture(GetTextureParam.NORMAL_PROP, texture);
@@ -114,7 +134,7 @@ namespace UniGLTF
 
                 if (src.occlusionTexture != null && src.occlusionTexture.index != -1)
                 {
-                    var texture = await getTexture(gltf, GetTextureParam.CreateOcclusion(gltf, src.occlusionTexture.index));
+                    var texture = await getTexture(gltf, OcclusionTexture(gltf, src));
                     if (texture != null)
                     {
                         material.SetTexture(GetTextureParam.OCCLUSION_PROP, texture);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/PBRMaterialItem.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/PBRMaterialItem.cs
@@ -43,12 +43,13 @@ namespace UniGLTF
             Transparent
         }
 
-        public static async Awaitable<Material> CreateAsync(int i, glTFMaterial src, GetTextureAsyncFunc getTexture)
+        public static async Awaitable<Material> CreateAsync(glTF gltf, int i, GetTextureAsyncFunc getTexture)
         {
             if (getTexture == null)
             {
-                getTexture = _ => Awaitable.FromResult<Texture2D>(null);
+                getTexture = (_x, _y) => Awaitable.FromResult<Texture2D>(null);
             }
+            var src = gltf.materials[i];
 
             var material = MaterialFactory.CreateMaterial(i, src, ShaderName);
 
@@ -65,7 +66,7 @@ namespace UniGLTF
 
                     if (src.pbrMetallicRoughness.baseColorTexture != null && src.pbrMetallicRoughness.baseColorTexture.index != -1)
                     {
-                        material.mainTexture = await getTexture(GetTextureParam.Create(src.pbrMetallicRoughness.baseColorTexture.index));
+                        material.mainTexture = await getTexture(gltf, GetTextureParam.Create(gltf, src.pbrMetallicRoughness.baseColorTexture.index));
 
                         // Texture Offset and Scale
                         MaterialFactory.SetTextureOffsetAndScale(material, src.pbrMetallicRoughness.baseColorTexture, "_MainTex");
@@ -75,7 +76,7 @@ namespace UniGLTF
                     {
                         material.EnableKeyword("_METALLICGLOSSMAP");
 
-                        var texture = await getTexture(GetTextureParam.CreateMetallic(
+                        var texture = await getTexture(gltf, GetTextureParam.CreateMetallic(gltf,
                             src.pbrMetallicRoughness.metallicRoughnessTexture.index,
                             src.pbrMetallicRoughness.metallicFactor));
                         if (texture != null)
@@ -100,7 +101,7 @@ namespace UniGLTF
                 if (src.normalTexture != null && src.normalTexture.index != -1)
                 {
                     material.EnableKeyword("_NORMALMAP");
-                    var texture = await getTexture(GetTextureParam.CreateNormal(src.normalTexture.index));
+                    var texture = await getTexture(gltf, GetTextureParam.CreateNormal(gltf, src.normalTexture.index));
                     if (texture != null)
                     {
                         material.SetTexture(GetTextureParam.NORMAL_PROP, texture);
@@ -113,7 +114,7 @@ namespace UniGLTF
 
                 if (src.occlusionTexture != null && src.occlusionTexture.index != -1)
                 {
-                    var texture = await getTexture(GetTextureParam.CreateOcclusion(src.occlusionTexture.index));
+                    var texture = await getTexture(gltf, GetTextureParam.CreateOcclusion(gltf, src.occlusionTexture.index));
                     if (texture != null)
                     {
                         material.SetTexture(GetTextureParam.OCCLUSION_PROP, texture);
@@ -137,7 +138,7 @@ namespace UniGLTF
 
                     if (src.emissiveTexture != null && src.emissiveTexture.index != -1)
                     {
-                        var texture = await getTexture(GetTextureParam.Create(src.emissiveTexture.index));
+                        var texture = await getTexture(gltf, GetTextureParam.Create(gltf, src.emissiveTexture.index));
                         if (texture != null)
                         {
                             material.SetTexture("_EmissionMap", texture);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/UnlitMaterialItem.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/UnlitMaterialItem.cs
@@ -11,7 +11,7 @@ namespace UniGLTF
         {
             if (getTexture == null)
             {
-                getTexture = _ => Awaitable.FromResult<Texture2D>(null);
+                getTexture = _ => Awaitable.FromResult<Texture2D>(default);
             }
 
             var material = MaterialFactory.CreateMaterial(i, src, ShaderName);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/UnlitMaterialItem.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialLoader/UnlitMaterialItem.cs
@@ -7,19 +7,20 @@ namespace UniGLTF
     {
         public const string ShaderName = "UniGLTF/UniUnlit";
 
-        public static async Awaitable<Material> CreateAsync(int i, glTFMaterial src, GetTextureAsyncFunc getTexture, bool hasVertexColor)
+        public static async Awaitable<Material> CreateAsync(glTF gltf, int i, GetTextureAsyncFunc getTexture, bool hasVertexColor)
         {
             if (getTexture == null)
             {
-                getTexture = _ => Awaitable.FromResult<Texture2D>(default);
+                getTexture = (_x, _y) => Awaitable.FromResult<Texture2D>(default);
             }
 
+            var src = gltf.materials[i];
             var material = MaterialFactory.CreateMaterial(i, src, ShaderName);
 
             // texture
             if (src.pbrMetallicRoughness.baseColorTexture != null)
             {
-                material.mainTexture = await getTexture(GetTextureParam.Create(src.pbrMetallicRoughness.baseColorTexture.index));
+                material.mainTexture = await getTexture(gltf, GetTextureParam.Create(gltf, src.pbrMetallicRoughness.baseColorTexture.index));
 
                 // Texture Offset and Scale
                 MaterialFactory.SetTextureOffsetAndScale(material, src.pbrMetallicRoughness.baseColorTexture, "_MainTex");

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshImporter.cs
@@ -627,33 +627,6 @@ namespace UniGLTF
             }
         }
 
-        public static MeshWithMaterials BuildMesh(MaterialFactory ctx, MeshImporter.MeshContext meshContext)
-        {
-            var (mesh, recalculateTangents) = _BuildMesh(meshContext);
-
-            if (recalculateTangents)
-            {
-                mesh.RecalculateTangents();
-            }
-
-            // 先にすべてのマテリアルを作成済みなのでテクスチャーは生成済み。Resultを使ってよい
-            var result = new MeshWithMaterials
-            {
-                Mesh = mesh,
-                Materials = meshContext.MaterialIndices.Select(x => ctx.GetMaterial(x)).ToArray()
-            };
-
-            if (meshContext.BlendShapes.Count > 0)
-            {
-                var emptyVertices = new Vector3[mesh.vertexCount];
-                foreach (var blendShape in meshContext.BlendShapes)
-                {
-                    BuildBlendShape(mesh, meshContext, blendShape, emptyVertices);
-                }
-            }
-            return result;
-        }
-
         public static async Awaitable<MeshWithMaterials> BuildMeshAsync(MaterialFactory ctx, MeshImporter.MeshContext meshContext)
         {
             var (mesh, recalculateTangents) = _BuildMesh(meshContext);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshImporter.cs
@@ -154,7 +154,7 @@ namespace UniGLTF
                         {
                             throw new Exception("different length");
                         }
-                        if (ctx.IsGeneratedUniGLTFAndOlder(1, 16))
+                        if (ctx.Parser.IsGeneratedUniGLTFAndOlder(1, 16))
                         {
 #pragma warning disable 0612
                             // backward compatibility
@@ -317,7 +317,7 @@ namespace UniGLTF
                     // uv
                     if (prim.attributes.TEXCOORD_0 != -1)
                     {
-                        if (ctx.IsGeneratedUniGLTFAndOlder(1, 16))
+                        if (ctx.Parser.IsGeneratedUniGLTFAndOlder(1, 16))
                         {
 #pragma warning disable 0612
                             // backward compatibility

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshImporter.cs
@@ -8,8 +8,6 @@ using UnityEngine;
 
 namespace UniGLTF
 {
-
-
     public class MeshImporter
     {
         const float FRAME_WEIGHT = 100.0f;
@@ -109,7 +107,7 @@ namespace UniGLTF
             /// <param name="ctx"></param>
             /// <param name="gltfMesh"></param>
             /// <returns></returns>
-            public void ImportMeshIndependentVertexBuffer(ImporterContext ctx, glTFMesh gltfMesh)
+            public void ImportMeshIndependentVertexBuffer(ImporterContext ctx, glTFMesh gltfMesh, AxisInverter inverter)
             {
                 foreach (var prim in gltfMesh.primitives)
                 {
@@ -119,7 +117,7 @@ namespace UniGLTF
                     // position は必ずある
                     var positions = ctx.GLTF.GetArrayFromAccessor<Vector3>(prim.attributes.POSITION);
                     var fillLength = m_positions.Count;
-                    m_positions.AddRange(positions.Select(x => x.ReverseZ()));
+                    m_positions.AddRange(positions.Select(inverter.InvertVector3));
 
                     // normal
                     if (prim.attributes.NORMAL != -1)
@@ -130,7 +128,7 @@ namespace UniGLTF
                             throw new Exception("different length");
                         }
                         FillZero(m_normals, fillLength);
-                        m_normals.AddRange(normals.Select(x => x.ReverseZ()));
+                        m_normals.AddRange(normals.Select(inverter.InvertVector3));
                     }
 
 #if false
@@ -142,7 +140,7 @@ namespace UniGLTF
                             throw new Exception("different length");
                         }
                         FillZero(tangetns, fillLength);
-                        tangents.AddRange(.Select(x => x.ReverseZ()));
+                        tangents.AddRange(.Select(inverter.InvertVector4));
                     }
 #endif
 
@@ -242,7 +240,7 @@ namespace UniGLTF
                                     throw new Exception("different length");
                                 }
                                 FillZero(blendShape.Positions, fillLength);
-                                blendShape.Positions.AddRange(array.Select(x => x.ReverseZ()).ToArray());
+                                blendShape.Positions.AddRange(array.Select(inverter.InvertVector3).ToArray());
                             }
                             if (primTarget.NORMAL != -1)
                             {
@@ -252,7 +250,7 @@ namespace UniGLTF
                                     throw new Exception("different length");
                                 }
                                 FillZero(blendShape.Normals, fillLength);
-                                blendShape.Normals.AddRange(array.Select(x => x.ReverseZ()).ToArray());
+                                blendShape.Normals.AddRange(array.Select(inverter.InvertVector3).ToArray());
                             }
                             if (primTarget.TANGENT != -1)
                             {
@@ -262,7 +260,7 @@ namespace UniGLTF
                                     throw new Exception("different length");
                                 }
                                 FillZero(blendShape.Tangents, fillLength);
-                                blendShape.Tangents.AddRange(array.Select(x => x.ReverseZ()).ToArray());
+                                blendShape.Tangents.AddRange(array.Select(inverter.InvertVector3).ToArray());
                             }
                             m_blendShapes.Add(blendShape);
                         }
@@ -293,24 +291,24 @@ namespace UniGLTF
             /// <param name="ctx"></param>
             /// <param name="gltfMesh"></param>
             /// <returns></returns>
-            public void ImportMeshSharingVertexBuffer(ImporterContext ctx, glTFMesh gltfMesh)
+            public void ImportMeshSharingVertexBuffer(ImporterContext ctx, glTFMesh gltfMesh, AxisInverter inverter)
             {
                 {
                     //  同じVertexBufferを共有しているので先頭のモノを使う
                     var prim = gltfMesh.primitives.First();
-                    m_positions.AddRange(ctx.GLTF.GetArrayFromAccessor<Vector3>(prim.attributes.POSITION).SelectInplace(x => x.ReverseZ()));
+                    m_positions.AddRange(ctx.GLTF.GetArrayFromAccessor<Vector3>(prim.attributes.POSITION).SelectInplace(inverter.InvertVector3));
 
                     // normal
                     if (prim.attributes.NORMAL != -1)
                     {
-                        m_normals.AddRange(ctx.GLTF.GetArrayFromAccessor<Vector3>(prim.attributes.NORMAL).SelectInplace(x => x.ReverseZ()));
+                        m_normals.AddRange(ctx.GLTF.GetArrayFromAccessor<Vector3>(prim.attributes.NORMAL).SelectInplace(inverter.InvertVector3));
                     }
 
 #if false
                     // tangent
                     if (prim.attributes.TANGENT != -1)
                     {
-                        tangents.AddRange(ctx.GLTF.GetArrayFromAccessor<Vector4>(prim.attributes.TANGENT).SelectInplace(x => x.ReverseZ()));
+                        tangents.AddRange(ctx.GLTF.GetArrayFromAccessor<Vector4>(prim.attributes.TANGENT).SelectInplace(inverter.InvertVector4));
                     }
 #endif
 
@@ -403,17 +401,17 @@ namespace UniGLTF
                             if (primTarget.POSITION != -1)
                             {
                                 blendShape.Positions.Assign(
-                                    ctx.GLTF.GetArrayFromAccessor<Vector3>(primTarget.POSITION), x => x.ReverseZ());
+                                    ctx.GLTF.GetArrayFromAccessor<Vector3>(primTarget.POSITION), inverter.InvertVector3);
                             }
                             if (primTarget.NORMAL != -1)
                             {
                                 blendShape.Normals.Assign(
-                                    ctx.GLTF.GetArrayFromAccessor<Vector3>(primTarget.NORMAL), x => x.ReverseZ());
+                                    ctx.GLTF.GetArrayFromAccessor<Vector3>(primTarget.NORMAL), inverter.InvertVector3);
                             }
                             if (primTarget.TANGENT != -1)
                             {
                                 blendShape.Tangents.Assign(
-                                    ctx.GLTF.GetArrayFromAccessor<Vector3>(primTarget.TANGENT), x => x.ReverseZ());
+                                    ctx.GLTF.GetArrayFromAccessor<Vector3>(primTarget.TANGENT), inverter.InvertVector3);
                             }
                         }
                     }
@@ -509,18 +507,18 @@ namespace UniGLTF
             return sharedAttributes;
         }
 
-        public MeshContext ReadMesh(ImporterContext ctx, int meshIndex)
+        public MeshContext ReadMesh(ImporterContext ctx, int meshIndex, AxisInverter inverter)
         {
             var gltfMesh = ctx.GLTF.meshes[meshIndex];
 
             var meshContext = new MeshContext(gltfMesh.name, meshIndex);
             if (HasSharedVertexBuffer(gltfMesh))
             {
-                meshContext.ImportMeshSharingVertexBuffer(ctx, gltfMesh);
+                meshContext.ImportMeshSharingVertexBuffer(ctx, gltfMesh, inverter);
             }
             else
             {
-                meshContext.ImportMeshIndependentVertexBuffer(ctx, gltfMesh);
+                meshContext.ImportMeshIndependentVertexBuffer(ctx, gltfMesh, inverter);
             }
 
             meshContext.RenameBlendShape(gltfMesh);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshImporter.cs
@@ -631,9 +631,9 @@ namespace UniGLTF
 
             if (recalculateTangents)
             {
-                await LoopAwaitable.Create();
+                await NextFrameAwaitable.Create();
                 mesh.RecalculateTangents();
-                await LoopAwaitable.Create();
+                await NextFrameAwaitable.Create();
             }
 
             // 先にすべてのマテリアルを作成済みなのでテクスチャーは生成済み。Resultを使ってよい
@@ -643,7 +643,7 @@ namespace UniGLTF
                 Materials = meshContext.MaterialIndices.Select(x => ctx.GetMaterial(x)).ToArray()
             };
 
-            await LoopAwaitable.Create();
+            await NextFrameAwaitable.Create();
             if (meshContext.BlendShapes.Count > 0)
             {
                 var emptyVertices = new Vector3[mesh.vertexCount];

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/NodeImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/NodeImporter.cs
@@ -16,7 +16,7 @@ namespace UniGLTF
                 Debug.LogWarningFormat("node {0} contains /. replace _", node.name);
                 nodeName = nodeName.Replace("/", "_");
             }
-            if(string.IsNullOrEmpty(nodeName))
+            if (string.IsNullOrEmpty(nodeName))
             {
                 nodeName = string.Format("nodeIndex_{0}", nodeIndex);
             }
@@ -131,7 +131,7 @@ namespace UniGLTF
         //
         // fix node's coordinate. z-back to z-forward
         //
-        public static void FixCoordinate(ImporterContext context, List<TransformWithSkin> nodes)
+        public static void FixCoordinate(ImporterContext context, List<TransformWithSkin> nodes, AxisInverter inverter)
         {
             var globalTransformMap = nodes.ToDictionary(x => x.Transform, x => new PosRot
             {
@@ -148,13 +148,13 @@ namespace UniGLTF
                 foreach (var transform in t.Traverse())
                 {
                     var g = globalTransformMap[transform];
-                    transform.position = g.Position.ReverseZ();
-                    transform.rotation = g.Rotation.ReverseZ();
+                    transform.position = inverter.InvertVector3(g.Position);
+                    transform.rotation = inverter.InvertQuaternion(g.Rotation);
                 }
             }
         }
 
-        public static void SetupSkinning(ImporterContext context, List<TransformWithSkin> nodes, int i)
+        public static void SetupSkinning(ImporterContext context, List<TransformWithSkin> nodes, int i, AxisInverter inverter)
         {
             var x = nodes[i];
             var skinnedMeshRenderer = x.Transform.GetComponent<SkinnedMeshRenderer>();
@@ -181,7 +181,7 @@ namespace UniGLTF
                             if (skin.inverseBindMatrices != -1)
                             {
                                 var bindPoses = context.GLTF.GetArrayFromAccessor<Matrix4x4>(skin.inverseBindMatrices)
-                                    .Select(y => y.ReverseZ())
+                                    .Select(inverter.InvertMat4)
                                     .ToArray()
                                     ;
                                 mesh.bindposes = bindPoses;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/RootAnimationImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/RootAnimationImporter.cs
@@ -12,7 +12,7 @@ namespace UniGLTF
             if (context.GLTF.animations != null && context.GLTF.animations.Any())
             {
                 var animation = context.Root.AddComponent<Animation>();
-                context.AnimationClips = ImportAnimationClips(context.GLTF);
+                context.AnimationClips = ImportAnimationClips(context.GLTF, context.InvertAxis);
 
                 foreach (var clip in context.AnimationClips)
                 {
@@ -25,7 +25,7 @@ namespace UniGLTF
             }
         }
 
-        private List<AnimationClip> ImportAnimationClips(glTF gltf)
+        private List<AnimationClip> ImportAnimationClips(glTF gltf, Axises invertAxis)
         {
             var animationClips = new List<AnimationClip>();
             for (var i = 0; i < gltf.animations.Count; ++i)
@@ -46,7 +46,23 @@ namespace UniGLTF
                     animation.name = $"animation:{i}";
                 }
 
-                animationClips.Add(AnimationImporterUtil.ConvertAnimationClip(gltf, animation));
+                AxisInverter inverter = default;
+                switch (invertAxis)
+                {
+                    case Axises.X:
+                        inverter = AxisInverter.ReverseX;
+                        break;
+
+                    case Axises.Z:
+                        inverter = AxisInverter.ReverseZ;
+                        break;
+
+                    default:
+                        throw new System.Exception();
+
+                }
+
+                animationClips.Add(AnimationImporterUtil.ConvertAnimationClip(gltf, animation, inverter));
             }
 
             return animationClips;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureConverter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureConverter.cs
@@ -31,22 +31,6 @@ namespace UniGLTF
             return copyTexture;
         }
 
-        public static void AppendTextureExtension(Texture texture, string extension)
-        {
-            if (!texture.name.EndsWith(extension))
-            {
-                texture.name = texture.name + extension;
-            }
-        }
-
-        public static void RemoveTextureExtension(Texture texture, string extension)
-        {
-            if (texture.name.EndsWith(extension))
-            {
-                texture.name = texture.name.Replace(extension, "");
-            }
-        }
-
         struct ColorSpaceScope : IDisposable
         {
             bool m_sRGBWrite;
@@ -194,8 +178,6 @@ namespace UniGLTF
 
     public class MetallicRoughnessConverter : ITextureConverter
     {
-        private const string m_extension = ".metallicRoughness";
-
         private float _smoothnessOrRoughness;
 
         public MetallicRoughnessConverter(float smoothnessOrRoughness)
@@ -206,14 +188,12 @@ namespace UniGLTF
         public Texture2D GetImportTexture(Texture2D texture)
         {
             var converted = TextureConverter.Convert(texture, glTFTextureTypes.Metallic, Import, null);
-            TextureConverter.AppendTextureExtension(converted, m_extension);
             return converted;
         }
 
         public Texture2D GetExportTexture(Texture2D texture)
         {
             var converted = TextureConverter.Convert(texture, glTFTextureTypes.Metallic, Export, null);
-            TextureConverter.RemoveTextureExtension(converted, m_extension);
             return converted;
         }
 
@@ -260,8 +240,6 @@ namespace UniGLTF
 
     public class NormalConverter : ITextureConverter
     {
-        private const string m_extension = ".normal";
-
         private Material m_decoder;
         private Material GetDecoder()
         {
@@ -288,7 +266,6 @@ namespace UniGLTF
         {
             var mat = GetEncoder();
             var converted = TextureConverter.Convert(texture, glTFTextureTypes.Normal, null, mat);
-            TextureConverter.AppendTextureExtension(converted, m_extension);
             return converted;
         }
 
@@ -298,26 +275,22 @@ namespace UniGLTF
         {
             var mat = GetDecoder();
             var converted = TextureConverter.Convert(texture, glTFTextureTypes.Normal, null, mat);
-            TextureConverter.RemoveTextureExtension(converted, m_extension);
             return converted;
         }
     }
 
     public class OcclusionConverter : ITextureConverter
     {
-        private const string m_extension = ".occlusion";
 
         public Texture2D GetImportTexture(Texture2D texture)
         {
             var converted = TextureConverter.Convert(texture, glTFTextureTypes.Occlusion, Import, null);
-            TextureConverter.AppendTextureExtension(converted, m_extension);
             return converted;
         }
 
         public Texture2D GetExportTexture(Texture2D texture)
         {
             var converted = TextureConverter.Convert(texture, glTFTextureTypes.Occlusion, Export, null);
-            TextureConverter.RemoveTextureExtension(converted, m_extension);
             return converted;
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GetTextureParam.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GetTextureParam.cs
@@ -1,4 +1,6 @@
-﻿namespace UniGLTF
+﻿using System;
+
+namespace UniGLTF
 {
     public struct GetTextureParam
     {
@@ -18,7 +20,12 @@
 
         public GetTextureParam(string name, string textureType, float metallicFactor, int i0, int i1, int i2, int i3, int i4, int i5)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException();
+            }
             Name = name;
+
             TextureType = textureType;
             MetallicFactor = metallicFactor;
             Index0 = (ushort)i0;
@@ -29,10 +36,10 @@
             Index5 = (ushort)i5;
         }
 
-        public static GetTextureParam Create(glTF gltf, int index)
+        public static GetTextureParam Create(glTF gltf, int textureIndex)
         {
-            var name = gltf.ImageNameFromTextureIndex(index);
-            return new GetTextureParam(name, default, default, index, default, default, default, default, default);
+            var name = gltf.textures[textureIndex].name;
+            return new GetTextureParam(name, default, default, textureIndex, default, default, default, default, default);
         }
 
         public static GetTextureParam Create(glTF gltf, int index, string prop)
@@ -53,22 +60,22 @@
             }
         }
 
-        public static GetTextureParam CreateNormal(glTF gltf, int index)
+        public static GetTextureParam CreateNormal(glTF gltf, int textureIndex)
         {
-            var name = gltf.ImageNameFromTextureIndex(index);
-            return new GetTextureParam(name, NORMAL_PROP, default, index, default, default, default, default, default);
+            var name = gltf.textures[textureIndex].name;
+            return new GetTextureParam(name, NORMAL_PROP, default, textureIndex, default, default, default, default, default);
         }
 
-        public static GetTextureParam CreateMetallic(glTF gltf, int index, float metallicFactor)
+        public static GetTextureParam CreateMetallic(glTF gltf, int textureIndex, float metallicFactor)
         {
-            var name = gltf.ImageNameFromTextureIndex(index);
-            return new GetTextureParam(name, METALLIC_GLOSS_PROP, metallicFactor, index, default, default, default, default, default);
+            var name = gltf.textures[textureIndex].name;
+            return new GetTextureParam(name, METALLIC_GLOSS_PROP, metallicFactor, textureIndex, default, default, default, default, default);
         }
 
-        public static GetTextureParam CreateOcclusion(glTF gltf, int index)
+        public static GetTextureParam CreateOcclusion(glTF gltf, int textureIndex)
         {
-            var name = gltf.ImageNameFromTextureIndex(index);
-            return new GetTextureParam(name, OCCLUSION_PROP, default, index, default, default, default, default, default);
+            var name = gltf.textures[textureIndex].name;
+            return new GetTextureParam(name, OCCLUSION_PROP, default, textureIndex, default, default, default, default, default);
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GetTextureParam.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GetTextureParam.cs
@@ -8,7 +8,7 @@ namespace UniGLTF
         public const string METALLIC_GLOSS_PROP = "_MetallicGlossMap";
         public const string OCCLUSION_PROP = "_OcclusionMap";
 
-        public string Name;
+        public readonly string Name;
         public readonly string TextureType;
         public readonly float MetallicFactor;
         public readonly ushort? Index0;
@@ -69,13 +69,13 @@ namespace UniGLTF
         public static GetTextureParam CreateMetallic(glTF gltf, int textureIndex, float metallicFactor)
         {
             var name = gltf.textures[textureIndex].name;
-            return new GetTextureParam(name, METALLIC_GLOSS_PROP, metallicFactor, textureIndex, default, default, default, default, default);
+            return new GetTextureParam(name + ".metallicRoughness", METALLIC_GLOSS_PROP, metallicFactor, textureIndex, default, default, default, default, default);
         }
 
         public static GetTextureParam CreateOcclusion(glTF gltf, int textureIndex)
         {
             var name = gltf.textures[textureIndex].name;
-            return new GetTextureParam(name, OCCLUSION_PROP, default, textureIndex, default, default, default, default, default);
+            return new GetTextureParam(name + ".occlusion", OCCLUSION_PROP, default, textureIndex, default, default, default, default, default);
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GetTextureParam.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GetTextureParam.cs
@@ -1,7 +1,4 @@
-﻿using System.Threading.Tasks;
-using UnityEngine;
-
-namespace UniGLTF
+﻿namespace UniGLTF
 {
     public struct GetTextureParam
     {
@@ -9,6 +6,7 @@ namespace UniGLTF
         public const string METALLIC_GLOSS_PROP = "_MetallicGlossMap";
         public const string OCCLUSION_PROP = "_OcclusionMap";
 
+        public string Name;
         public readonly string TextureType;
         public readonly float MetallicFactor;
         public readonly ushort? Index0;
@@ -18,8 +16,9 @@ namespace UniGLTF
         public readonly ushort? Index4;
         public readonly ushort? Index5;
 
-        public GetTextureParam(string textureType, float metallicFactor, int i0, int i1, int i2, int i3, int i4, int i5)
+        public GetTextureParam(string name, string textureType, float metallicFactor, int i0, int i1, int i2, int i3, int i4, int i5)
         {
+            Name = name;
             TextureType = textureType;
             MetallicFactor = metallicFactor;
             Index0 = (ushort)i0;
@@ -30,25 +29,46 @@ namespace UniGLTF
             Index5 = (ushort)i5;
         }
 
-        public static GetTextureParam Create(int index)
+        public static GetTextureParam Create(glTF gltf, int index)
         {
-            return new GetTextureParam(default, default, index, default, default, default, default, default);
+            var name = gltf.ImageNameFromTextureIndex(index);
+            return new GetTextureParam(name, default, default, index, default, default, default, default, default);
         }
 
-        public static GetTextureParam CreateNormal(int index)
+        public static GetTextureParam Create(glTF gltf, int index, string prop)
         {
-            return new GetTextureParam(NORMAL_PROP, default, index, default, default, default, default, default);
+            switch (prop)
+            {
+                case NORMAL_PROP:
+                    return CreateNormal(gltf, index);
+
+                case OCCLUSION_PROP:
+                    return CreateOcclusion(gltf, index);
+
+                case METALLIC_GLOSS_PROP:
+                    return CreateMetallic(gltf, index, 1);
+
+                default:
+                    return Create(gltf, index);
+            }
         }
 
-        public static GetTextureParam CreateMetallic(int index, float metallicFactor)
+        public static GetTextureParam CreateNormal(glTF gltf, int index)
         {
-            return new GetTextureParam(METALLIC_GLOSS_PROP, metallicFactor, index, default, default, default, default, default);
+            var name = gltf.ImageNameFromTextureIndex(index);
+            return new GetTextureParam(name, NORMAL_PROP, default, index, default, default, default, default, default);
         }
 
-        public static GetTextureParam CreateOcclusion(int index)
+        public static GetTextureParam CreateMetallic(glTF gltf, int index, float metallicFactor)
         {
-            return new GetTextureParam(OCCLUSION_PROP, default, index, default, default, default, default, default);
+            var name = gltf.ImageNameFromTextureIndex(index);
+            return new GetTextureParam(name, METALLIC_GLOSS_PROP, metallicFactor, index, default, default, default, default, default);
+        }
+
+        public static GetTextureParam CreateOcclusion(glTF gltf, int index)
+        {
+            var name = gltf.ImageNameFromTextureIndex(index);
+            return new GetTextureParam(name, OCCLUSION_PROP, default, index, default, default, default, default, default);
         }
     }
-
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GltfTextureLoader.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GltfTextureLoader.cs
@@ -26,12 +26,11 @@ namespace UniGLTF
 
         public static async Awaitable<Texture2D> LoadTextureAsync(glTF gltf, IStorage storage, int index)
         {
-            string m_textureName = default;
-
+            string textureName = default;
             var imageBytes = await Awaitable.Run(() =>
             {
                 var imageIndex = gltf.GetImageIndexFromTextureIndex(index);
-                var segments = gltf.GetImageBytes(storage, imageIndex, out m_textureName);
+                var segments = gltf.GetImageBytes(storage, imageIndex, out textureName);
                 return ToArray(segments);
             });
 
@@ -44,7 +43,7 @@ namespace UniGLTF
             var sampler = gltf.GetSamplerFromTextureIndex(index);
 
             var texture = new Texture2D(2, 2, TextureFormat.ARGB32, false, isLinear);
-            texture.name = m_textureName;
+            texture.name = textureName;
             if (imageBytes != null)
             {
                 texture.LoadImage(imageBytes);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GltfTextureLoader.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GltfTextureLoader.cs
@@ -26,7 +26,6 @@ namespace UniGLTF
 
         public static async Awaitable<Texture2D> LoadTextureAsync(glTF gltf, IStorage storage, int textureIndex)
         {
-            string textureName = default;
             var imageBytes = await Awaitable.Run(() =>
             {
                 var imageIndex = gltf.textures[textureIndex].source;
@@ -43,7 +42,7 @@ namespace UniGLTF
             var sampler = gltf.GetSamplerFromTextureIndex(textureIndex);
 
             var texture = new Texture2D(2, 2, TextureFormat.ARGB32, false, isLinear);
-            texture.name = textureName;
+            texture.name = gltf.textures[textureIndex].name;
             if (imageBytes != null)
             {
                 texture.LoadImage(imageBytes);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GltfTextureLoader.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/GltfTextureLoader.cs
@@ -24,23 +24,23 @@ namespace UniGLTF
             }
         }
 
-        public static async Awaitable<Texture2D> LoadTextureAsync(glTF gltf, IStorage storage, int index)
+        public static async Awaitable<Texture2D> LoadTextureAsync(glTF gltf, IStorage storage, int textureIndex)
         {
             string textureName = default;
             var imageBytes = await Awaitable.Run(() =>
             {
-                var imageIndex = gltf.GetImageIndexFromTextureIndex(index);
-                var segments = gltf.GetImageBytes(storage, imageIndex, out textureName);
+                var imageIndex = gltf.textures[textureIndex].source;
+                var segments = gltf.GetImageBytes(storage, imageIndex);
                 return ToArray(segments);
             });
 
             //
             // texture from image(png etc) bytes
             //
-            var textureType = TextureIO.GetglTFTextureType(gltf, index);
+            var textureType = TextureIO.GetglTFTextureType(gltf, textureIndex);
             var colorSpace = TextureIO.GetColorSpace(textureType);
             var isLinear = colorSpace == RenderTextureReadWrite.Linear;
-            var sampler = gltf.GetSamplerFromTextureIndex(index);
+            var sampler = gltf.GetSamplerFromTextureIndex(textureIndex);
 
             var texture = new Texture2D(2, 2, TextureFormat.ARGB32, false, isLinear);
             texture.name = textureName;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
@@ -148,7 +148,6 @@ namespace UniGLTF
                         {
                             var baseTexture = await GetOrCreateBaseTexture(gltf, param.Index0.Value, false);
                             var converted = new NormalConverter().GetImportTexture(baseTexture);
-                            converted.name = $"{converted.name}.{GetTextureParam.NORMAL_PROP}";
                             var info = new TextureLoadInfo(converted, true, false);
                             m_textureCache.Add(param, info);
                             return info.Texture;
@@ -161,7 +160,6 @@ namespace UniGLTF
 
                             var textureAssetPath = AssetDatabase.GetAssetPath(info.Texture);
                             TextureIO.MarkTextureAssetAsNormalMap(textureAssetPath);
-                            info.Texture.name = $"{info.Texture.name}.{GetTextureParam.NORMAL_PROP}";
 #endif
                             return info.Texture;
                         }
@@ -172,7 +170,6 @@ namespace UniGLTF
                         // Bake roughnessFactor values into a texture.
                         var baseTexture = await GetOrCreateBaseTexture(gltf, param.Index0.Value, false);
                         var converted = new MetallicRoughnessConverter(param.MetallicFactor).GetImportTexture(baseTexture);
-                        converted.name = $"{converted.name}.{GetTextureParam.METALLIC_GLOSS_PROP}";
                         var info = new TextureLoadInfo(converted, true, false);
                         m_textureCache.Add(param, info);
                         return info.Texture;
@@ -182,7 +179,6 @@ namespace UniGLTF
                     {
                         var baseTexture = await GetOrCreateBaseTexture(gltf, param.Index0.Value, false);
                         var converted = new OcclusionConverter().GetImportTexture(baseTexture);
-                        converted.name = $"{converted.name}.{GetTextureParam.OCCLUSION_PROP}";
                         var info = new TextureLoadInfo(converted, true, false);
                         m_textureCache.Add(param, info);
                         return info.Texture;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
@@ -21,7 +21,7 @@ namespace UniGLTF
         }
     }
 
-    public delegate Awaitable<Texture2D> GetTextureAsyncFunc(GetTextureParam param);
+    public delegate Awaitable<Texture2D> GetTextureAsyncFunc(glTF gltf, GetTextureParam param);
     public class TextureFactory : IDisposable
     {
         glTF m_gltf;
@@ -48,14 +48,14 @@ namespace UniGLTF
         public UnityPath ImageBaseDir { get; set; }
 
         public TextureFactory(glTF gltf, IStorage storage,
-        IEnumerable<KeyValuePair<string, UnityEngine.Object>> externalMap)
+        IEnumerable<(string, UnityEngine.Object)> externalMap)
         {
             m_gltf = gltf;
             m_storage = storage;
             if (externalMap != null)
             {
                 m_externalMap = externalMap
-                    .Select(kv => (kv.Key, kv.Value as Texture2D))
+                    .Select(kv => (kv.Item1, kv.Item2 as Texture2D))
                     .Where(kv => kv.Item2 != null)
                     .ToDictionary(kv => kv.Item1, kv => kv.Item2);
             }
@@ -99,7 +99,7 @@ namespace UniGLTF
         /// <param name="roughnessFactor">METALLIC_GLOSS_PROPの追加パラメーター</param>
         /// <param name="indices">gltf の texture index</param>
         /// <returns></returns>
-        public async Awaitable<Texture2D> GetTextureAsync(GetTextureParam param)
+        public async Awaitable<Texture2D> GetTextureAsync(glTF gltf, GetTextureParam param)
         {
             if (m_textureCache.TryGetValue(param, out TextureLoadInfo info))
             {
@@ -111,7 +111,7 @@ namespace UniGLTF
             }
 
             {
-                var defaultParam = GetTextureParam.Create(param.Index0.Value);
+                var defaultParam = GetTextureParam.Create(gltf, param.Index0.Value);
                 if (!m_textureCache.TryGetValue(defaultParam, out info))
                 {
                     info = await LoadTextureAsync(param.Index0.Value);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
@@ -1,23 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
 using UniGLTF.AltTask;
-using UnityEditor;
 using UnityEngine;
+using System.Linq;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace UniGLTF
 {
+    public struct TextureLoadInfo
+    {
+        public readonly Texture2D Texture;
+        public readonly bool UseExternal;
+
+        public TextureLoadInfo(Texture2D texture, bool useExternal)
+        {
+            Texture = texture;
+            UseExternal = useExternal;
+        }
+    }
+
     public delegate Awaitable<Texture2D> GetTextureAsyncFunc(GetTextureParam param);
     public class TextureFactory : IDisposable
     {
         glTF m_gltf;
         IStorage m_storage;
+        Dictionary<string, Texture2D> m_externalMap;
 
         public UnityPath ImageBaseDir { get; set; }
 
-        public TextureFactory(glTF gltf, IStorage storage)
+        public TextureFactory(glTF gltf, IStorage storage, IEnumerable<KeyValuePair<string, UnityEngine.Object>> externalMap)
         {
             m_gltf = gltf;
             m_storage = storage;
+            m_externalMap = externalMap
+                .Select(kv => (kv.Key, kv.Value as Texture2D))
+                .Where(kv => kv.Item2 != null)
+                .ToDictionary(kv => kv.Item1, kv => kv.Item2);
         }
 
         public void Dispose()
@@ -32,20 +52,40 @@ namespace UniGLTF
         {
             foreach (var kv in m_textureCache)
             {
-                yield return kv.Value;
+                yield return kv.Value.Texture;
             }
         }
 
-        Dictionary<GetTextureParam, Texture2D> m_textureCache = new Dictionary<GetTextureParam, Texture2D>();
-        public IEnumerable<Texture2D> Textures => m_textureCache.Values;
+        Dictionary<GetTextureParam, TextureLoadInfo> m_textureCache = new Dictionary<GetTextureParam, TextureLoadInfo>();
 
-        public virtual Awaitable<Texture2D> LoadTextureAsync(int index)
+        public IEnumerable<TextureLoadInfo> Textures => m_textureCache.Values;
+
+        public virtual async Awaitable<TextureLoadInfo> LoadTextureAsync(int index)
         {
 #if UNIGLTF_USE_WEBREQUEST_TEXTURELOADER
             return UnityWebRequestTextureLoader.LoadTextureAsync(index);
 #else
-            return GltfTextureLoader.LoadTextureAsync(m_gltf, m_storage, index);
+            var texture = await GltfTextureLoader.LoadTextureAsync(m_gltf, m_storage, index);
+            return new TextureLoadInfo(texture, false);
 #endif
+        }
+
+        public bool TryGetExternal(GetTextureParam param, out Texture2D external)
+        {
+            if (param.Index0.HasValue && m_externalMap != null)
+            {
+                var gltfTexture = m_gltf.textures[param.Index0.Value];
+                m_gltf.GetImageBytes(m_storage, gltfTexture.source, out string textureName);
+
+                if (m_externalMap.TryGetValue(textureName, out external))
+                {
+                    Debug.Log($"use external: {textureName}");
+                    m_textureCache.Add(param, new TextureLoadInfo(external, true));
+                    return external;
+                }
+            }
+            external = default;
+            return false;
         }
 
         /// <summary>
@@ -58,17 +98,21 @@ namespace UniGLTF
         /// <returns></returns>
         public async Awaitable<Texture2D> GetTextureAsync(GetTextureParam param)
         {
-            if (m_textureCache.TryGetValue(param, out Texture2D texture))
+            if (m_textureCache.TryGetValue(param, out TextureLoadInfo info))
             {
-                return texture;
+                return info.Texture;
+            }
+            if (TryGetExternal(param, out Texture2D external))
+            {
+                return external;
             }
 
             {
                 var defaultParam = GetTextureParam.Create(param.Index0.Value);
-                if (!m_textureCache.TryGetValue(defaultParam, out texture))
+                if (!m_textureCache.TryGetValue(defaultParam, out info))
                 {
-                    texture = await LoadTextureAsync(param.Index0.Value);
-                    m_textureCache.Add(defaultParam, texture);
+                    info = await LoadTextureAsync(param.Index0.Value);
+                    m_textureCache.Add(defaultParam, info);
                 }
             }
 
@@ -78,49 +122,52 @@ namespace UniGLTF
                     {
                         if (Application.isPlaying)
                         {
-                            var converted = new NormalConverter().GetImportTexture(texture);
-                            m_textureCache.Add(param, converted);
+                            var converted = new NormalConverter().GetImportTexture(info.Texture);
                             converted.name = $"{converted.name}.{GetTextureParam.NORMAL_PROP}";
-                            return converted;
+                            info = new TextureLoadInfo(converted, false);
+                            m_textureCache.Add(param, info);
+                            return info.Texture;
                         }
                         else
                         {
 #if UNITY_EDITOR
-                            var textureAssetPath = AssetDatabase.GetAssetPath(texture);
+                            var textureAssetPath = AssetDatabase.GetAssetPath(info.Texture);
                             if (!string.IsNullOrEmpty(textureAssetPath))
                             {
                                 TextureIO.MarkTextureAssetAsNormalMap(textureAssetPath);
-                                texture.name = $"{texture.name}.{GetTextureParam.NORMAL_PROP}";
+                                info.Texture.name = $"{info.Texture.name}.{GetTextureParam.NORMAL_PROP}";
                             }
                             else
                             {
-                                Debug.LogWarningFormat("no asset for {0}", texture);
+                                Debug.LogWarningFormat("no asset for {0}", info);
                             }
 #endif
-                            m_textureCache.Add(param, texture);
-                            return texture;
+                            m_textureCache.Add(param, info);
+                            return info.Texture;
                         }
                     }
 
                 case GetTextureParam.METALLIC_GLOSS_PROP:
                     {
                         // Bake roughnessFactor values into a texture.
-                        var converted = new MetallicRoughnessConverter(param.MetallicFactor).GetImportTexture(texture);
+                        var converted = new MetallicRoughnessConverter(param.MetallicFactor).GetImportTexture(info.Texture);
                         converted.name = $"{converted.name}.{GetTextureParam.METALLIC_GLOSS_PROP}";
-                        m_textureCache.Add(param, converted);
-                        return converted;
+                        info = new TextureLoadInfo(converted, false);
+                        m_textureCache.Add(param, info);
+                        return info.Texture;
                     }
 
                 case GetTextureParam.OCCLUSION_PROP:
                     {
-                        var converted = new OcclusionConverter().GetImportTexture(texture);
+                        var converted = new OcclusionConverter().GetImportTexture(info.Texture);
                         converted.name = $"{converted.name}.{GetTextureParam.OCCLUSION_PROP}";
-                        m_textureCache.Add(param, converted);
-                        return converted;
+                        info = new TextureLoadInfo(converted, false);
+                        m_textureCache.Add(param, info);
+                        return info.Texture;
                     }
 
                 default:
-                    return texture;
+                    return info.Texture;
             }
 
             throw new NotImplementedException();

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using UniGLTF.AltTask;
 using UnityEditor;
 using UnityEngine;
@@ -9,7 +8,6 @@ namespace UniGLTF
 {
     public delegate Awaitable<Texture2D> GetTextureAsyncFunc(GetTextureParam param);
     public class TextureFactory : IDisposable
-
     {
         glTF m_gltf;
         IStorage m_storage;
@@ -22,7 +20,6 @@ namespace UniGLTF
             m_storage = storage;
         }
 
-        List<Texture2D> m_textuers = new List<Texture2D>();
         public void Dispose()
         {
             foreach (var x in ObjectsForSubAsset())
@@ -40,6 +37,7 @@ namespace UniGLTF
         }
 
         Dictionary<GetTextureParam, Texture2D> m_textureCache = new Dictionary<GetTextureParam, Texture2D>();
+        public IEnumerable<Texture2D> Textures => m_textureCache.Values;
 
         public virtual Awaitable<Texture2D> LoadTextureAsync(int index)
         {
@@ -82,6 +80,7 @@ namespace UniGLTF
                         {
                             var converted = new NormalConverter().GetImportTexture(texture);
                             m_textureCache.Add(param, converted);
+                            converted.name = $"{converted.name}.{GetTextureParam.NORMAL_PROP}";
                             return converted;
                         }
                         else
@@ -91,6 +90,7 @@ namespace UniGLTF
                             if (!string.IsNullOrEmpty(textureAssetPath))
                             {
                                 TextureIO.MarkTextureAssetAsNormalMap(textureAssetPath);
+                                texture.name = $"{texture.name}.{GetTextureParam.NORMAL_PROP}";
                             }
                             else
                             {
@@ -106,6 +106,7 @@ namespace UniGLTF
                     {
                         // Bake roughnessFactor values into a texture.
                         var converted = new MetallicRoughnessConverter(param.MetallicFactor).GetImportTexture(texture);
+                        converted.name = $"{converted.name}.{GetTextureParam.METALLIC_GLOSS_PROP}";
                         m_textureCache.Add(param, converted);
                         return converted;
                     }
@@ -113,6 +114,7 @@ namespace UniGLTF
                 case GetTextureParam.OCCLUSION_PROP:
                     {
                         var converted = new OcclusionConverter().GetImportTexture(texture);
+                        converted.name = $"{converted.name}.{GetTextureParam.OCCLUSION_PROP}";
                         m_textureCache.Add(param, converted);
                         return converted;
                     }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
@@ -51,11 +51,9 @@ namespace UniGLTF
             if (param.Index0.HasValue && m_externalMap != null)
             {
                 var gltfTexture = m_gltf.textures[param.Index0.Value];
-                m_gltf.GetImageBytes(m_storage, gltfTexture.source, out string textureName);
-
-                if (m_externalMap.TryGetValue(textureName, out external))
+                if (m_externalMap.TryGetValue(gltfTexture.name, out external))
                 {
-                    Debug.Log($"use external: {textureName}");
+                    Debug.Log($"use external: {gltfTexture.name}");
                     m_textureCache.Add(param, new TextureLoadInfo(external, used, true));
                     return external;
                 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/TextureFactory.cs
@@ -131,14 +131,13 @@ namespace UniGLTF
         /// <returns></returns>
         public async Awaitable<Texture2D> GetTextureAsync(glTF gltf, GetTextureParam param)
         {
-            if (TryGetExternal(param, true, out Texture2D external))
-            {
-                return external;
-            }
-
             if (m_textureCache.TryGetValue(param, out TextureLoadInfo cacheInfo))
             {
                 return cacheInfo.Texture;
+            }
+            if (TryGetExternal(param, true, out Texture2D external))
+            {
+                return external;
             }
 
             switch (param.TextureType)

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/UnityWebRequestTextureLoader.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureLoader/UnityWebRequestTextureLoader.cs
@@ -55,8 +55,8 @@ namespace UniGLTF
 
         public IEnumerator ProcessOnMainThread(glTF gltf, IStorage storage, bool isLinear, glTFTextureSampler sampler)
         {
-            var imageIndex = gltf.GetImageIndexFromTextureIndex(m_textureIndex);
-            var bytes = gltf.GetImageBytes(storage, imageIndex, out m_textureName);
+            var gltfTexture = gltf.textures[m_textureIndex];
+            var bytes = gltf.GetImageBytes(storage, gltfTexture.source);
 
             // tmp file
             var tmp = Path.GetTempFileName();

--- a/Assets/UniGLTF/Tests/UniGLTF/UniGLTFTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/UniGLTFTests.cs
@@ -98,7 +98,7 @@ namespace UniGLTF
         public void UniGLTFSimpleSceneTest()
         {
             var go = CreateSimpleScene();
-            var context = new ImporterContext();
+            ImporterContext context = default;
 
             try
             {
@@ -117,9 +117,12 @@ namespace UniGLTF
                     json = gltf.ToJson();
                 }
 
+                // parse
+                var parser = new GltfParser();
+                parser.ParseJson(json, new SimpleStorage(new ArraySegment<byte>()));
+
                 // import
-                context.ParseJson(json, new SimpleStorage(new ArraySegment<byte>()));
-                //Debug.LogFormat("{0}", context.Json);
+                context = new ImporterContext(parser);
                 context.Load();
 
                 AssertAreEqual(go.transform, context.Root.transform);
@@ -128,7 +131,10 @@ namespace UniGLTF
             {
                 //Debug.LogFormat("Destroy, {0}", go.name);
                 GameObject.DestroyImmediate(go);
-                context.EditorDestroyRootAndAssets();
+                if (context != null)
+                {
+                    context.EditorDestroyRootAndAssets();
+                }
             }
         }
 
@@ -191,12 +197,12 @@ namespace UniGLTF
         [Test]
         public void VersionChecker()
         {
-            Assert.False(ImporterContext.IsGeneratedUniGLTFAndOlderThan("hoge", 1, 16));
-            Assert.False(ImporterContext.IsGeneratedUniGLTFAndOlderThan("UniGLTF-1.16", 1, 16));
-            Assert.True(ImporterContext.IsGeneratedUniGLTFAndOlderThan("UniGLTF-1.15", 1, 16));
-            Assert.False(ImporterContext.IsGeneratedUniGLTFAndOlderThan("UniGLTF-11.16", 1, 16));
-            Assert.True(ImporterContext.IsGeneratedUniGLTFAndOlderThan("UniGLTF-0.16", 1, 16));
-            Assert.True(ImporterContext.IsGeneratedUniGLTFAndOlderThan("UniGLTF", 1, 16));
+            Assert.False(GltfParser.IsGeneratedUniGLTFAndOlderThan("hoge", 1, 16));
+            Assert.False(GltfParser.IsGeneratedUniGLTFAndOlderThan("UniGLTF-1.16", 1, 16));
+            Assert.True(GltfParser.IsGeneratedUniGLTFAndOlderThan("UniGLTF-1.15", 1, 16));
+            Assert.False(GltfParser.IsGeneratedUniGLTFAndOlderThan("UniGLTF-11.16", 1, 16));
+            Assert.True(GltfParser.IsGeneratedUniGLTFAndOlderThan("UniGLTF-0.16", 1, 16));
+            Assert.True(GltfParser.IsGeneratedUniGLTFAndOlderThan("UniGLTF", 1, 16));
         }
 
         [Test]
@@ -439,7 +445,7 @@ namespace UniGLTF
         public void SkinTestEmptyName()
         {
             var model = new glTFSkin()
-            {                
+            {
                 name = "",
                 inverseBindMatrices = 4,
                 joints = new int[] { 1 },
@@ -559,8 +565,9 @@ namespace UniGLTF
 
                 // import
                 {
-                    var context = new ImporterContext();
-                    context.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
+                    var parser = new GltfParser();
+                    parser.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
+                    var context = new ImporterContext(parser);
                     //Debug.LogFormat("{0}", context.Json);
                     context.Load();
 
@@ -577,9 +584,10 @@ namespace UniGLTF
 
                 // import new version
                 {
-                    var context = new ImporterContext();
-                    context.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
+                    var parser = new GltfParser();
+                    parser.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
                     //Debug.LogFormat("{0}", context.Json);
+                    var context = new ImporterContext(parser);
                     context.Load();
 
                     var importedRed = context.Root.transform.GetChild(0);

--- a/Assets/VRM.Samples/Editor/Tests/VRMImportExportTests.cs
+++ b/Assets/VRM.Samples/Editor/Tests/VRMImportExportTests.cs
@@ -42,8 +42,10 @@ namespace VRM.Samples
         public void ImportExportTest()
         {
             var path = AliciaPath;
-            var context = new VRMImporterContext();
-            context.ParseGlb(File.ReadAllBytes(path));
+            var parser = new GltfParser();
+            parser.ParseGlb(File.ReadAllBytes(path));
+
+            var context = new VRMImporterContext(parser);
             context.Load();
             context.ShowMeshes();
             context.EnableUpdateWhenOffscreen();
@@ -114,8 +116,9 @@ namespace VRM.Samples
         public void MeshCopyTest()
         {
             var path = AliciaPath;
-            var context = new VRMImporterContext();
-            context.ParseGlb(File.ReadAllBytes(path));
+            var parser = new GltfParser();
+            parser.ParseGlb(File.ReadAllBytes(path));
+            var context = new VRMImporterContext(parser);
             context.Load();
             context.ShowMeshes();
             context.EnableUpdateWhenOffscreen();
@@ -133,8 +136,9 @@ namespace VRM.Samples
         {
             // Aliciaを古いデシリアライザでロードする
             var path = AliciaPath;
-            var context = new VRMImporterContext();
-            context.ParseGlb(File.ReadAllBytes(path));
+            var parser = new GltfParser();
+            parser.ParseGlb(File.ReadAllBytes(path));
+            var context = new VRMImporterContext(parser);
             var oldJson = context.GLTF.ToJson().ParseAsJson().ToString("  ");
 
             // 生成シリアライザでJSON化する

--- a/Assets/VRM.Samples/Scripts/VRMRuntimeExporter.cs
+++ b/Assets/VRM.Samples/Scripts/VRMRuntimeExporter.cs
@@ -46,11 +46,11 @@ namespace VRM.Samples
             var bytes = File.ReadAllBytes(path);
             // なんらかの方法でByte列を得た
 
-            var context = new VRMImporterContext();
-
             // GLB形式でJSONを取得しParseします
-            context.ParseGlb(bytes);
+            var parser = new GltfParser();
+            parser.ParseGlb(bytes);
 
+            var context = new VRMImporterContext(parser);
 
             // metaを取得(todo: thumbnailテクスチャのロード)
             var meta = await context.ReadMetaAsync();

--- a/Assets/VRM.Samples/Scripts/ViewerUI.cs
+++ b/Assets/VRM.Samples/Scripts/ViewerUI.cs
@@ -309,15 +309,15 @@ namespace VRM.Samples
             {
                 case ".vrm":
                     {
-                        var context = new VRMImporterContext();
                         var file = File.ReadAllBytes(path);
-                        context.ParseGlb(file);
+
+                        var parser = new GltfParser();
+                        parser.ParseGlb(file);
+
+                        var context = new VRMImporterContext(parser);
                         await m_texts.UpdateMetaAsync(context);
-#if true
                         await context.LoadAsync();
-#else
-                        context.Load();
-#endif
+
                         context.ShowMeshes();
                         context.EnableUpdateWhenOffscreen();
                         context.ShowMeshes();
@@ -327,9 +327,11 @@ namespace VRM.Samples
 
                 case ".glb":
                     {
-                        var context = new UniGLTF.ImporterContext();
                         var file = File.ReadAllBytes(path);
-                        context.ParseGlb(file);
+                        var parser = new GltfParser();
+                        parser.ParseGlb(file);
+
+                        var context = new UniGLTF.ImporterContext(parser);
                         context.Load();
                         context.ShowMeshes();
                         context.EnableUpdateWhenOffscreen();
@@ -341,8 +343,10 @@ namespace VRM.Samples
                 case ".gltf":
                 case ".zip":
                     {
-                        var context = new UniGLTF.ImporterContext();
-                        context.Parse(path);
+                        var parser = new GltfParser();
+                        parser.ParsePath(path);
+
+                        var context = new UniGLTF.ImporterContext(parser);
                         context.Load();
                         context.ShowMeshes();
                         context.EnableUpdateWhenOffscreen();

--- a/Assets/VRM/Editor/Format/VRMImporterMenu.cs
+++ b/Assets/VRM/Editor/Format/VRMImporterMenu.cs
@@ -20,8 +20,10 @@ namespace VRM
             if (Application.isPlaying)
             {
                 // load into scene
-                var context = new VRMImporterContext();
-                context.Load(path);
+                var parser = new GltfParser();
+                parser.ParsePath(path);
+                var context = new VRMImporterContext(parser);
+                context.Load();
                 context.ShowMeshes();
                 context.EnableUpdateWhenOffscreen();
                 Selection.activeGameObject = context.Root;
@@ -48,8 +50,9 @@ namespace VRM
 
                 // import as asset
                 var prefabPath = UnityPath.FromUnityPath(assetPath);
-                var context = new VRMImporterContext();
-                context.ParseGlb(File.ReadAllBytes(path));
+                var parser = new GltfParser();
+                parser.ParseGlb(File.ReadAllBytes(path));
+                var context = new VRMImporterContext(parser);
                 context.ExtractImages(prefabPath);
 
                 EditorApplication.delayCall += () =>

--- a/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -36,11 +36,11 @@ namespace VRM
             {
                 throw new Exception();
             }
-            var context = new VRMImporterContext();
 
+            var parser = new GltfParser();
             try
             {
-                context.ParseGlb(File.ReadAllBytes(path.FullPath));
+                parser.ParseGlb(File.ReadAllBytes(path.FullPath));
             }
             catch (KeyNotFoundException)
             {
@@ -52,6 +52,7 @@ namespace VRM
             var prefabPath = path.Parent.Child(path.FileNameWithoutExtension + ".prefab");
 
             // save texture assets !
+            var context = new VRMImporterContext(parser);
             context.ExtractImages(prefabPath);
 
             EditorApplication.delayCall += () =>

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -286,7 +286,7 @@ namespace VRM
             meta.ContactInformation = gltfMeta.contactInformation;
             meta.Reference = gltfMeta.reference;
             meta.Title = gltfMeta.title;
-            meta.Thumbnail = await TextureFactory.GetTextureAsync(GetTextureParam.Create(gltfMeta.texture));
+            meta.Thumbnail = await TextureFactory.GetTextureAsync(GLTF, GetTextureParam.Create(GLTF, gltfMeta.texture));
             meta.AllowedUser = gltfMeta.allowedUser;
             meta.ViolentUssage = gltfMeta.violentUssage;
             meta.SexualUssage = gltfMeta.sexualUssage;

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -174,6 +174,7 @@ namespace VRM
                     }
 
                     var material = MaterialFactory.Materials
+                        .Select(y => y.Asset)
                         .FirstOrDefault(y => y.name == x.materialName);
                     var propertyName = x.propertyName;
                     if (x.propertyName.FastEndsWith("_ST_S")

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -15,30 +15,8 @@ namespace VRM
     {
         public VRM.glTF_VRM_extensions VRM { get; private set; }
 
-        public VRMImporterContext()
+        public VRMImporterContext(GltfParser parser) : base(parser)
         {
-        }
-
-        public override void Parse(string path, byte[] bytes)
-        {
-            var ext = Path.GetExtension(path).ToLower();
-            switch (ext)
-            {
-                case ".vrm":
-                    ParseGlb(bytes);
-                    break;
-
-                default:
-                    base.Parse(path, bytes);
-                    break;
-            }
-        }
-
-        public override void ParseJson(string json, IStorage storage)
-        {
-            // parse GLTF part(core + unlit, textureTransform, targetNames)
-            base.ParseJson(json, storage);
-
             // parse VRM part
             if (glTF_VRM_extensions.TryDeserilize(GLTF.extensions, out glTF_VRM_extensions vrm))
             {

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -53,7 +53,7 @@ namespace VRM
         }
 
         #region OnLoad
-        protected override async Awaitable OnLoadModel()
+        protected override async Awaitable OnLoadModel(Func<string, IDisposable> MeasureTime)
         {
             Root.name = "VRM";
 

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -39,26 +39,26 @@ namespace VRM
             {
                 await LoadMetaAsync();
             }
-            await LoopAwaitable.Create();
+            await NextFrameAwaitable.Create();
 
             using (MeasureTime("VRM LoadHumanoid"))
             {
                 LoadHumanoid();
             }
-            await LoopAwaitable.Create();
+            await NextFrameAwaitable.Create();
 
             using (MeasureTime("VRM LoadBlendShapeMaster"))
             {
                 LoadBlendShapeMaster();
             }
-            await LoopAwaitable.Create();
+            await NextFrameAwaitable.Create();
 
             using (MeasureTime("VRM LoadSecondary"))
             {
                 VRMSpringUtility.LoadSecondary(Root.transform, Nodes,
                 VRM.secondaryAnimation);
             }
-            await LoopAwaitable.Create();
+            await NextFrameAwaitable.Create();
 
             using (MeasureTime("VRM LoadFirstPerson"))
             {

--- a/Assets/VRM/Runtime/IO/VRMMaterialImporter.cs
+++ b/Assets/VRM/Runtime/IO/VRMMaterialImporter.cs
@@ -71,7 +71,8 @@ namespace VRM
             }
             foreach (var kv in item.textureProperties)
             {
-                var texture = await getTexture(new GetTextureParam(kv.Key, default, kv.Value, default, default, default, default, default));
+                var param = GetTextureParam.Create(gltf, kv.Value, kv.Key);
+                var texture = await getTexture(gltf, param);
                 if (texture != null)
                 {
                     material.SetTexture(kv.Key, texture);

--- a/Assets/VRM10.Samples/Runtime/ViewerUI.cs
+++ b/Assets/VRM10.Samples/Runtime/ViewerUI.cs
@@ -333,9 +333,11 @@ namespace UniVRM10.Samples
 
                 case ".glb":
                     {
-                        var context = new UniGLTF.ImporterContext();
                         var file = File.ReadAllBytes(path);
-                        context.ParseGlb(file);
+                        var parser = new GltfParser();
+                        parser.ParseGlb(file);
+
+                        var context = new UniGLTF.ImporterContext(parser);
                         context.Load();
                         context.ShowMeshes();
                         context.EnableUpdateWhenOffscreen();
@@ -347,8 +349,10 @@ namespace UniVRM10.Samples
                 case ".gltf":
                 case ".zip":
                     {
-                        var context = new UniGLTF.ImporterContext();
-                        context.Parse(path);
+                        var parser = new GltfParser();
+                        parser.ParsePath(path);
+
+                        var context = new UniGLTF.ImporterContext(parser);
                         context.Load();
                         context.ShowMeshes();
                         context.EnableUpdateWhenOffscreen();


### PR DESCRIPTION
`v0.68.0` での ScriptedImporter の導入は、 `glb` の Asset import のみ。
`v0.69.0` 以降で `vrm` にも拡大する予定。

* #747 軸指定を選べるようにした

```cs
var context = new ImporterContext(parser, externalObjectMap);
context.InvertAxis = m_reverseAxis; // これ
```

* #733 GLB に ScriptedImporter 導入

![impoption](https://user-images.githubusercontent.com/68057/109128284-af01e680-7792-11eb-8bab-d3cbc750dc02.gif)

* #587 texture の extract 概念により解決
