### PR TITLE
Check Keyframe length of AnimationCurve

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/AnimationExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/AnimationExporter.cs
@@ -129,6 +129,11 @@ namespace UniGLTF
             {
                 var curve = AnimationUtility.GetEditorCurve(clip, binding);
 
+                if (!curve.keys.Any())
+                {
+                    throw new Exception("There is no keyframe in AnimationCurve : " + clip.name);
+                }
+
                 var property = AnimationExporter.PropertyToTarget(binding.propertyName);
                 if (property == glTFAnimationTarget.AnimationProperties.NotImplemented)
                 {


### PR DESCRIPTION
`AnimationCuve.keys` が空だった場合に、166 行目の`AnimationUtility.GetKeyRightTangentMode(curve, 0)` でエラーが出るのでAnimationCuve.keysのチェックを追加