### PR TITLE
ExportRoot を animate する Animation を Export するときの挙動を修正

### DIFF
--- a/Assets/UniGLTF/Editor/Animation.meta
+++ b/Assets/UniGLTF/Editor/Animation.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 31c3691403d341e2a9b49d6eb895e013
+timeCreated: 1615194750

--- a/Assets/UniGLTF/Editor/Animation/AnimationValidator.cs
+++ b/Assets/UniGLTF/Editor/Animation/AnimationValidator.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using MeshUtility;
+using MeshUtility.M17N;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniGLTF.Animation
+{
+    public static class AnimationValidator
+    {
+        private enum ExporterValidatorMessages
+        {
+            [LangMsg(Languages.ja, "ExportRootをanimateすることはできません")]
+            [LangMsg(Languages.en, "ExportRoot cannot be animated")]
+            ROOT_ANIMATED,
+        }
+
+        public static IEnumerable<Validation> Validate(GameObject root)
+        {
+            if (root == null)
+            {
+                yield break;
+            }
+
+            var animationClips = new List<AnimationClip>();
+            var animator = root.GetComponent<Animator>();
+            var animation = root.GetComponent<UnityEngine.Animation>();
+            if (animator != null)
+            {
+                animationClips = AnimationExporter.GetAnimationClips(animator);
+            }
+            else if (animation != null)
+            {
+                animationClips = AnimationExporter.GetAnimationClips(animation);
+            }
+
+            if (!animationClips.Any())
+            {
+                yield break;
+            }
+
+            foreach (var animationClip in animationClips)
+            {
+                foreach (var editorCurveBinding in AnimationUtility.GetCurveBindings(animationClip))
+                {
+                    // is root included in animation?
+                    if (string.IsNullOrEmpty(editorCurveBinding.path))
+                    {
+                        yield return Validation.Error(ExporterValidatorMessages.ROOT_ANIMATED.Msg());
+                        yield break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/UniGLTF/Editor/Animation/AnimationValidator.cs.meta
+++ b/Assets/UniGLTF/Editor/Animation/AnimationValidator.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0f8cc79b14e847b6a9f12c3ff2631661
+timeCreated: 1615188291

--- a/Assets/UniGLTF/Editor/UniGLTF/GltfExportWindow.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/GltfExportWindow.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using MeshUtility.M17N;
+using UniGLTF.Animation;
 using UnityEditor;
 using UnityEngine;
 
@@ -123,6 +123,7 @@ namespace UniGLTF
         IEnumerable<MeshUtility.Validator> ValidatorFactory()
         {
             yield return MeshUtility.Validators.HierarchyValidator.ValidateRoot;
+            yield return AnimationValidator.Validate;
             if (!m_state.ExportRoot)
             {
                 yield break;

--- a/Assets/UniGLTF/Runtime/Extensions/UnityExtensions.cs
+++ b/Assets/UniGLTF/Runtime/Extensions/UnityExtensions.cs
@@ -213,7 +213,7 @@ namespace UniGLTF
         {
             var current = self;
 
-            var split = path.Split('/');
+            var split = path.Split(new [] {'/'}, StringSplitOptions.RemoveEmptyEntries);
 
             foreach (var childName in split)
             {


### PR DESCRIPTION
* ExportRoot を animate する Animation を Export するときに `KeyNotFoundException` が発生する
  * 上記の場合 Export 時に `UnityExtensions.GetFromPath`  の path に空文字が渡され、そのまま `UnityExtensions.GetChildByName` に空文字が渡されることに起因する
* 「ExportRoot を animate することはできない」は仕様的に正しいが、上記エラーの発生は意図したものではなさそうなので `GetFromPath` を修正する
  * path を split するときに空文字を除外することで、path に空文字が渡されたときに自身の Transform を返すようにする

* `GetFromPath` を修正したことにより、ExportRoot を animate する Animation を正常に Export できる状態になってしまうので gltf エクスポート時に Validation を追加する