### PR TITLE
scene.nodes が無い glTF ファイルを Import したときに null reference exception が発生していた問題を修正

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -145,11 +145,14 @@ namespace UniGLTF
                     NodeImporter.SetupSkinning(this, nodes, i, inverter);
                 }
 
-                // connect root
-                foreach (var x in GLTF.rootnodes)
+                if (GLTF.rootnodes != null)
                 {
-                    var t = nodes[x].Transform;
-                    t.SetParent(Root.transform, false);
+                    // connect root
+                    foreach (var x in GLTF.rootnodes)
+                    {
+                        var t = nodes[x].Transform;
+                        t.SetParent(Root.transform, false);
+                    }
                 }
             }
             await m_awaitCaller.NextFrame();

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/NodeImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/NodeImporter.cs
@@ -133,6 +133,10 @@ namespace UniGLTF
         //
         public static void FixCoordinate(ImporterContext context, List<TransformWithSkin> nodes, IAxisInverter inverter)
         {
+            if (context.GLTF.rootnodes == null)
+            {
+                return;
+            }
             var globalTransformMap = nodes.ToDictionary(x => x.Transform, x => new PosRot
             {
                 Position = x.Transform.position,


### PR DESCRIPTION
* あまり root のみのオブジェクトを Export/Import するケースは無いが、念のため修正