### PR TITLE
Fix/enum texture unique

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfTextureEnumerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfTextureEnumerator.cs
@@ -52,11 +52,14 @@ namespace UniGLTF
 
         public static IEnumerable<GetTextureParam> Enumerate(glTF gltf)
         {
+            var used = new HashSet<GetTextureParam>();
             foreach (var material in gltf.materials)
             {
                 foreach (var textureInfo in EnumerateTextures(gltf, material))
                 {
-                    yield return textureInfo;
+                    if(used.Add(textureInfo)){
+                        yield return textureInfo;
+                    }
                 }
             }
         }

--- a/Assets/UniGLTF/Tests/UniGLTF/GltfLoadTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/GltfLoadTests.cs
@@ -101,10 +101,6 @@ namespace UniGLTF
             // should unique
             var gltfTextures = GltfTextureEnumerator.Enumerate(parser.GLTF);
             var distinct = gltfTextures.Distinct().ToArray();
-            if (!gltfTextures.SequenceEqual(distinct))
-            {
-                var a = 0;
-            }
             Assert.True(gltfTextures.SequenceEqual(distinct));
         }
 

--- a/Assets/UniGLTF/Tests/UniGLTF/GltfLoadTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/GltfLoadTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -53,7 +54,7 @@ namespace UniGLTF
             }
         }
 
-        static void Load(FileInfo gltf, DirectoryInfo root)
+        static void RuntimeLoad(FileInfo gltf, int subStrStart)
         {
             var parser = new GltfParser();
             try
@@ -75,8 +76,36 @@ namespace UniGLTF
             }
             catch (Exception ex)
             {
-                Message(gltf.FullName.Substring(root.FullName.Length), ex);
+                Message(gltf.FullName.Substring(subStrStart), ex);
             }
+        }
+
+        /// <summary>
+        /// Extract をテスト
+        /// </summary>
+        /// <param name="gltf"></param>
+        /// <param name="root"></param>
+        static void EditorLoad(FileInfo gltf, int subStrStart)
+        {
+            var parser = new GltfParser();
+            try
+            {
+                parser.ParsePath(gltf.FullName);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"ParseError: {gltf}");
+                Debug.LogException(ex);
+            }
+
+            // should unique
+            var gltfTextures = GltfTextureEnumerator.Enumerate(parser.GLTF);
+            var distinct = gltfTextures.Distinct().ToArray();
+            if (!gltfTextures.SequenceEqual(distinct))
+            {
+                var a = 0;
+            }
+            Assert.True(gltfTextures.SequenceEqual(distinct));
         }
 
         [Test]
@@ -95,7 +124,9 @@ namespace UniGLTF
 
             foreach (var gltf in EnumerateGltfFiles(root))
             {
-                Load(gltf, root);
+                RuntimeLoad(gltf, root.FullName.Length);
+
+                EditorLoad(gltf, root.FullName.Length);
             }
         }
     }


### PR DESCRIPTION
GltfTextureEnumerator.Enumerate を unique にする。

`*.gltf` の AssetImport で Exception
