### PR TITLE
Add support for single pass instanced stereo rendering to UniUnlit shader

### DIFF
--- a/Assets/VRMShaders/UniUnlit/Resources/UniUnlit.shader
+++ b/Assets/VRMShaders/UniUnlit/Resources/UniUnlit.shader
@@ -44,6 +44,7 @@
             #if defined(_VERTEXCOL_MUL)
                 fixed4 color : COLOR;
             #endif
+                UNITY_VERTEX_INPUT_INSTANCE_ID
             };
 
             struct v2f
@@ -54,6 +55,7 @@
             #if defined(_VERTEXCOL_MUL)
                 fixed4 color : COLOR;
             #endif
+                UNITY_VERTEX_OUTPUT_STEREO
             };
 
             sampler2D _MainTex;
@@ -64,6 +66,8 @@
             v2f vert (appdata v)
             {
                 v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = TRANSFORM_TEX(v.uv, _MainTex);
                 UNITY_TRANSFER_FOG(o,o.vertex);


### PR DESCRIPTION
Fixed an issue where the right eye was not rendered when rendering in Single Pass Instanced mode.

## Before
![image](https://user-images.githubusercontent.com/36906576/112620458-e6d07c80-8e6b-11eb-91ef-ff308f674001.png)

## After
![image](https://user-images.githubusercontent.com/36906576/112620391-d02a2580-8e6b-11eb-87da-cf7f7bb3c9cb.png)

Verified to work with Unity 2020.3.1f1 + OpenVR XR Plugin.
