### PR TITLE
VRMMaterialImporterのリネームと、コメントと未使用コード削除

### DIFF
--- a/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
@@ -20,51 +20,6 @@ namespace VRM
             m_prefabPath = prefabPath;
         }
 
-        public bool AvoidOverwriteAndLoad(UnityPath assetPath, UnityEngine.Object o)
-        {
-            if (o is BlendShapeAvatar)
-            {
-                var loaded = assetPath.LoadAsset<BlendShapeAvatar>();
-                var proxy = m_context.Root.GetComponent<VRMBlendShapeProxy>();
-                proxy.BlendShapeAvatar = loaded;
-
-                return true;
-            }
-
-            if (o is BlendShapeClip)
-            {
-                return true;
-            }
-
-            if (o is Material)
-            {
-                var loaded = assetPath.LoadAsset<Material>();
-                if (loaded == null)
-                {
-                    throw new Exception();
-                }
-
-                // replace component reference
-                foreach (var mesh in m_context.Meshes)
-                {
-                    foreach (var r in mesh.Renderers)
-                    {
-                        for (int i = 0; i < r.sharedMaterials.Length; ++i)
-                        {
-                            if (r.sharedMaterials.Contains(o))
-                            {
-                                r.sharedMaterials = r.sharedMaterials.Select(x => x == o ? loaded : x).ToArray();
-                            }
-                        }
-                    }
-                }
-
-                return true;
-            }
-
-            return false;
-        }
-
         public UnityPath GetAssetPath(UnityPath prefabPath, UnityEngine.Object o)
         {
             if (o is BlendShapeAvatar
@@ -98,13 +53,6 @@ namespace VRM
                 var materialPath = materialDir.Child(o.name.EscapeFilePath() + ".asset");
                 return materialPath;
             }
-            // texture is already extracted
-            // else if (o is Texture2D)
-            // {
-            //     var textureDir = prefabPath.GetAssetFolder(".Textures");
-            //     var texturePath = textureDir.Child(o.name.EscapeFilePath() + ".asset");
-            //     return texturePath;
-            // }
             else if (o is Mesh)
             {
                 var meshDir = prefabPath.GetAssetFolder(".Meshes");
@@ -176,18 +124,6 @@ namespace VRM
                 // not dispose
                 return true;
             }
-
-            //             if (assetPath.IsFileExists)
-            //             {
-            //                 if (AvoidOverwriteAndLoad(assetPath, o))
-            //                 {
-            // #if VRM_DEVELOP                    
-            //                     Debug.Log($"AvoidOverwriteAndLoad: {assetPath}");
-            // #endif
-            //                     // 上書きせずに既存のアセットからロードして置き換えた
-            //                     return true;
-            //                 }
-            //             }
 
             // アセットとして書き込む
             assetPath.Parent.EnsureFolder();

--- a/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
@@ -149,7 +149,7 @@ namespace VRM
                     .Where(x => x.IsUsed)
                     .Select(x => (new SubAssetKey(typeof(Texture2D), x.Texture.name), x.Texture))
                     .ToArray();
-            var vrmTextures = new VRMMtoonMaterialImporter(m_context.VRM);
+            var vrmTextures = new VRMMaterialImporter(m_context.VRM);
             var dirName = $"{m_prefabPath.FileNameWithoutExtension}.Textures";
             TextureExtractor.ExtractTextures(m_context.Parser, m_prefabPath.Parent.Child(dirName), vrmTextures.EnumerateAllTexturesDistinct, subAssets, (_x, _y) => { }, onTextureReloaded);
         }

--- a/Assets/VRM/Editor/Format/VRMImporterMenu.cs
+++ b/Assets/VRM/Editor/Format/VRMImporterMenu.cs
@@ -83,7 +83,7 @@ namespace VRM
                 using (var context = new VRMImporterContext(parser, map))
                 {
                     var editor = new VRMEditorImporterContext(context, prefabPath);
-                    foreach (var (key, textureInfo) in new VRMMtoonMaterialImporter(context.VRM).EnumerateAllTexturesDistinct(parser))
+                    foreach (var (key, textureInfo) in new VRMMaterialImporter(context.VRM).EnumerateAllTexturesDistinct(parser))
                     {
                         TextureImporterConfigurator.Configure(textureInfo, map.ToDictionary(x => x.name, x => x.texture as Texture2D));
                     }

--- a/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -60,7 +60,7 @@ namespace VRM
                 using (var context = new VRMImporterContext(parser, map))
                 {
                     var editor = new VRMEditorImporterContext(context, prefabPath);
-                    foreach (var (key, textureInfo) in new VRMMtoonMaterialImporter(context.VRM).EnumerateAllTexturesDistinct(parser))
+                    foreach (var (key, textureInfo) in new VRMMaterialImporter(context.VRM).EnumerateAllTexturesDistinct(parser))
                     {
                         TextureImporterConfigurator.Configure(textureInfo, map.ToDictionary(x => x.name, x => x.texture as Texture2D));
                     }

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -26,7 +26,7 @@ namespace VRM
             {
                 VRM = vrm;
                 // override material importer
-                GltfMaterialImporter.GltfMaterialParamProcessors.Insert(0, new VRMMtoonMaterialImporter(VRM).TryCreateParam);
+                GltfMaterialImporter.GltfMaterialParamProcessors.Insert(0, new VRMMaterialImporter(VRM).TryCreateParam);
             }
             else
             {

--- a/Assets/VRM/Runtime/IO/VRMMaterialImporter.cs
+++ b/Assets/VRM/Runtime/IO/VRMMaterialImporter.cs
@@ -6,10 +6,10 @@ using VRMShaders;
 
 namespace VRM
 {
-    public class VRMMtoonMaterialImporter
+    public class VRMMaterialImporter
     {
         readonly glTF_VRM_extensions m_vrm;
-        public VRMMtoonMaterialImporter(glTF_VRM_extensions vrm)
+        public VRMMaterialImporter(glTF_VRM_extensions vrm)
         {
             m_vrm = vrm;
         }

--- a/Assets/VRM/Runtime/IO/VRMMaterialImporter.cs.meta
+++ b/Assets/VRM/Runtime/IO/VRMMaterialImporter.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bad75b40d017eb74ba79f561d22dc372
+guid: 9dd63f87d0de96f4ca4ad4dcd8540584
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/VRM/Tests/MToonTest.cs
+++ b/Assets/VRM/Tests/MToonTest.cs
@@ -30,7 +30,7 @@ namespace VRM
             var vrmMaterial = VRMMaterialExporter.CreateFromMaterial(srcMaterial, textureManager);
             Assert.AreEqual(vrmMaterial.vectorProperties["_MainTex"], new float[] { 0.3f, 0.2f, 0.5f, 0.6f });
 
-            var materialImporter = new VRMMtoonMaterialImporter(new glTF_VRM_extensions
+            var materialImporter = new VRMMaterialImporter(new glTF_VRM_extensions
             {
                 materialProperties = new System.Collections.Generic.List<glTF_VRM_Material> { vrmMaterial }
             });
@@ -49,7 +49,7 @@ namespace VRM
 
             var importer = new VRMImporterContext(parser, null);
 
-            var materialImporter = new VRMMtoonMaterialImporter(importer.VRM);
+            var materialImporter = new VRMMaterialImporter(importer.VRM);
 
             Assert.AreEqual(73, parser.GLTF.materials.Count);
             Assert.True(materialImporter.TryCreateParam(parser, 0, out MaterialImportParam param));

--- a/Assets/VRM/Tests/VRMTextureEnumerateTests.cs
+++ b/Assets/VRM/Tests/VRMTextureEnumerateTests.cs
@@ -72,7 +72,7 @@ namespace VRM
                         },
                      }
                 };
-                var items = new VRMMtoonMaterialImporter(vrm).EnumerateAllTexturesDistinct(parser).ToArray();
+                var items = new VRMMaterialImporter(vrm).EnumerateAllTexturesDistinct(parser).ToArray();
                 Assert.AreEqual(1, items.Length);
             }
         }


### PR DESCRIPTION
* VRMMToonMaterialImporter を VRMMaterialImporter にリネーム(Exporterと対になるように)
* VRMEditorImporterContext.AvoidOverwriteAndLoad 周りの未使用コード・コメントを削除
