### PR TITLE
[VRM1] SpringBone center をモデルレベルに移動など

### DIFF
--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringSelectorWindow.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringSelectorWindow.cs
@@ -1,0 +1,97 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniVRM10
+{
+    /// <summary>
+    /// ヒエラルキーから VRM10SpringBone と VRM10ColliderGroup を集めてリスト表示する
+    /// </summary>
+    public class VRM10SpringSelectorWindow : EditorWindow
+    {
+        const string MENU_KEY = VRMVersion.MENU + "/SpringBone";
+
+        [MenuItem(MENU_KEY, false, 0)]
+        private static void ExportFromMenu()
+        {
+            var window = (VRM10SpringSelectorWindow)GetWindow(typeof(VRM10SpringSelectorWindow));
+            window.titleContent = new GUIContent("SpringBone selector");
+            window.Show();
+        }
+
+        void OnEnable()
+        {
+            // Debug.Log("OnEnable");
+            Undo.willFlushUndoRecord += Repaint;
+            Selection.selectionChanged += Repaint;
+        }
+
+        void OnDisable()
+        {
+            // Debug.Log("OnDisable");
+            Selection.selectionChanged -= Repaint;
+            Undo.willFlushUndoRecord -= Repaint;
+        }
+
+        Transform m_root;
+        Transform Root
+        {
+            get => m_root;
+            set
+            {
+                if (m_root == value)
+                {
+                    return;
+                }
+                if (value != null && !value.gameObject.scene.IsValid())
+                {
+                    // skip prefab
+                    return;
+                }
+                m_root = value;
+                if (m_root != null)
+                {
+                    m_springs = m_root.GetComponentsInChildren<VRM10SpringBone>();
+                    m_colliderGroups = m_root.GetComponentsInChildren<VRM10SpringBoneColliderGroup>();
+                }
+            }
+        }
+
+        static bool s_foldSprings = true;
+        public VRM10SpringBone[] m_springs;
+
+        static bool s_foldColliders = true;
+        public VRM10SpringBoneColliderGroup[] m_colliderGroups;
+
+
+        private void OnGUI()
+        {
+            Root = (Transform)EditorGUILayout.ObjectField(m_root, typeof(Transform), true);
+
+            GUI.enabled = false;
+            s_foldSprings = EditorGUILayout.Foldout(s_foldSprings, "springs");
+            if (s_foldSprings)
+            {
+                if (m_springs != null)
+                {
+                    foreach (var s in m_springs)
+                    {
+                        EditorGUILayout.ObjectField(s, typeof(VRM10SpringBone), true);
+                    }
+                }
+            }
+
+            s_foldColliders = EditorGUILayout.Foldout(s_foldColliders, "colliders");
+            if (s_foldColliders)
+            {
+                if (m_colliderGroups != null)
+                {
+                    foreach (var c in m_colliderGroups)
+                    {
+                        EditorGUILayout.ObjectField(c, typeof(VRM10SpringBoneColliderGroup), true);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringSelectorWindow.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringSelectorWindow.cs
@@ -63,10 +63,21 @@ namespace UniVRM10
         static bool s_foldColliders = true;
         public VRM10SpringBoneColliderGroup[] m_colliderGroups;
 
+        void Reload()
+        {
+            var backup = Root;
+            Root = null;
+            Root = backup;
+        }
 
         private void OnGUI()
         {
-            Root = (Transform)EditorGUILayout.ObjectField(m_root, typeof(Transform), true);
+            Root = (Transform)EditorGUILayout.ObjectField("vrm1 root", m_root, typeof(Transform), true);
+
+            if (m_springs != null && m_springs.Length > 0 && m_springs[0] == null)
+            {
+                Reload();
+            }
 
             GUI.enabled = false;
             s_foldSprings = EditorGUILayout.Foldout(s_foldSprings, "springs");

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringSelectorWindow.cs.meta
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringSelectorWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a38b6d598e4f6c9458cd0a819302b438
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBone.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBone.cs
@@ -20,6 +20,9 @@ namespace UniVRM10
     public class VRM10SpringBone : MonoBehaviour
     {
         [SerializeField]
+        Color m_gizmoColor = Color.yellow;
+
+        [SerializeField]
         public string Comment;
 
         [SerializeField]
@@ -100,13 +103,13 @@ namespace UniVRM10
             }
         }
 
-        public void DrawGizmo(Color color)
+        public void OnDrawGizmosSelected()
         {
             foreach (var joint in Joints)
             {
                 if (joint != null)
                 {
-                    joint.DrawGizmo(m_center, color);
+                    joint.DrawGizmo(m_center, m_gizmoColor);
                 }
             }
         }

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBone.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBone.cs
@@ -31,9 +31,6 @@ namespace UniVRM10
         [SerializeField]
         public List<VRM10SpringBoneColliderGroup> ColliderGroups = new List<VRM10SpringBoneColliderGroup>();
 
-        [SerializeField]
-        public Transform m_center;
-
         [ContextMenu("Reset bones")]
         public void ResetJoints()
         {
@@ -46,9 +43,12 @@ namespace UniVRM10
             }
         }
 
+        Transform m_center;
+
         List<SpringBoneLogic.InternalCollider> m_colliderList = new List<SpringBoneLogic.InternalCollider>();
-        public void Process()
+        public void Process(Transform center)
         {
+            m_center = center;
             if (Joints == null)
             {
                 return;
@@ -96,10 +96,10 @@ namespace UniVRM10
                 VRM10SpringJoint lastJoint = Joints.FirstOrDefault(x => x != null);
                 foreach (var joint in Joints.Where(x => x != null).Skip(1))
                 {
-                    lastJoint.Update(m_center, Time.deltaTime, m_colliderList, joint);
+                    lastJoint.Update(center, Time.deltaTime, m_colliderList, joint);
                     lastJoint = joint;
                 }
-                lastJoint.Update(m_center, Time.deltaTime, m_colliderList, null);
+                lastJoint.Update(center, Time.deltaTime, m_colliderList, null);
             }
         }
 

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneColliderGroup.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneColliderGroup.cs
@@ -11,6 +11,9 @@ namespace UniVRM10
     public class VRM10SpringBoneColliderGroup : MonoBehaviour
     {
         [SerializeField]
+        Color m_gizmoColor = Color.cyan;
+
+        [SerializeField]
         public List<VRM10SpringBoneCollider> Colliders = new List<VRM10SpringBoneCollider>();
 
         public static void DrawWireCapsule(Vector3 headPos, Vector3 tailPos, float radius)
@@ -61,9 +64,9 @@ namespace UniVRM10
             }
         }
 
-        public void DrawGizmos(Color color)
+        public void OnDrawGizmosSelected()
         {
-            Gizmos.color = color;
+            Gizmos.color = m_gizmoColor;
             Matrix4x4 mat = transform.localToWorldMatrix;
             Gizmos.matrix = mat * Matrix4x4.Scale(new Vector3(
                 1.0f / transform.lossyScale.x,

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringJoint.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringJoint.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace UniVRM10
 {
@@ -43,7 +46,11 @@ namespace UniVRM10
             }
             else
             {
-                // TODO
+#if UNITY_EDITOR                
+                // Gizmos.matrix = Transform.localToWorldMatrix;
+                Gizmos.color = color;
+                Gizmos.DrawSphere(Transform.position, m_jointRadius);
+#endif
             }
         }
 

--- a/Assets/VRM10/Runtime/Components/VRM10Controller.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Controller.cs
@@ -27,6 +27,9 @@ namespace UniVRM10
 
             [SerializeField, Header("UpdateSetting")]
             public UpdateTypes UpdateType = UpdateTypes.LateUpdate;
+
+            [SerializeField, Header("SpringBone")]
+            public Transform SpringBoneCenter;
         }
 
         [SerializeField]
@@ -128,7 +131,7 @@ namespace UniVRM10
             }
             foreach (var spring in m_springs)
             {
-                spring.Process();
+                spring.Process(Controller.SpringBoneCenter);
             }
 
             //


### PR DESCRIPTION
スプリングボーン周り

* Spring と Collider をヒエラルキーから探索するのが大変なので、 VRM10SpringSelectorWindow 作った。
* 構成変更により無効になった Gizmo を復旧
* SpringBone の center の仕様を変更
