### PR TITLE
同一のMeshとMaterialを参照しているNodeをExportする場合に、重複をチェックして同じMeshIndexを参照するように変更

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshWithRenderer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshWithRenderer.cs
@@ -91,5 +91,21 @@ namespace UniGLTF
                 yield return x;
             }
         }
+
+        public bool IsSameMeshAndMaterials(MeshWithRenderer other)
+        {
+            return IsSameMeshAndMaterials(other.Mesh, other.Renderer.sharedMaterials);
+        }
+
+        public bool IsSameMeshAndMaterials(Mesh mesh, Material[] materials)
+        {
+            if (Mesh != mesh) return false;
+            if (Renderer.sharedMaterials.Length != materials.Length) return false;
+            for (var i = 0; i < Renderer.sharedMaterials.Length; i++)
+            {
+                if (Renderer.sharedMaterials[i] != materials[i]) return false;
+            }
+            return true;
+        }
     }
 }


### PR DESCRIPTION
* Rendererのインスタンス一致でmeshIndexを決定してた部分を、MeshインスタンスとMaterialインスタンスを見てmeshIndexを決定するように変更
![image](https://user-images.githubusercontent.com/39366194/115531405-b4ca0300-a2cf-11eb-869d-3ac93dbf1d61.png)

* Cube_1とCube_2はそれぞれRendererコンポーネントが付いている状態
* 両方とも同じMeshとMaterialインスタンスをRendererが参照している
* このプルリクの変更を入れてExportした場合、以下のjsonのように両方ともmeshIndex = 0を指し、かつmeshは１つだけexportされる
* 以下Exportしたglbの中身を一部抜粋
```
  "nodes": [
    {
      "mesh": 0,
      "name": "Cube_1",
      "rotation": [
        0,
        0,
        0,
        1
      ],
      "scale": [
        1,
        1,
        1
      ],
      "translation": [
        0,
        0,
        0
      ]
    },
    {
      "mesh": 0,
      "name": "Cube_2",
      "rotation": [
        0,
        0,
        0,
        1
      ],
      "scale": [
        1,
        1,
        1
      ],
      "translation": [
        0,
        0,
        0
      ]
    }
  ],
  "meshes": [
    {
      "extras": {
        "targetNames": []
      },
      "name": "Cube",
      "primitives": [
        {
          "attributes": {
            "NORMAL": 1,
            "POSITION": 0,
            "TEXCOORD_0": 2,
            "TEXCOORD_1": 3
          },
          "extras": {
            "targetNames": []
          },
          "indices": 4,
          "material": 0,
          "mode": 4
        }
      ]
    }
  ],
```