### PR TITLE
ExpressionAvatar は 独立した ScriptableObject をやめる

### DIFF
--- a/Assets/VRM10/Editor/Components/VRM10ControllerEditor.cs
+++ b/Assets/VRM10/Editor/Components/VRM10ControllerEditor.cs
@@ -148,7 +148,7 @@ namespace UniVRM10
                     break;
 
                 case Tabs.Expression:
-                    m_expression.RecursiveProperty();
+                    // m_expression.RecursiveProperty();
                     ExpressionGUI();
                     break;
 

--- a/Assets/VRM10/Editor/Components/VRM10ControllerEditor.cs
+++ b/Assets/VRM10/Editor/Components/VRM10ControllerEditor.cs
@@ -39,15 +39,13 @@ namespace UniVRM10
         void OnEnable()
         {
             m_target = (VRM10Controller)target;
-            if (m_target.Expression.ExpressionAvatar != null && m_target.Expression.ExpressionAvatar.Clips != null)
-            {
-                m_expressionKeyWeights = m_target.Expression.ExpressionAvatar.Clips.ToDictionary(x => ExpressionKey.CreateFromClip(x), x => 0.0f);
-                m_sliders = m_target.Expression.ExpressionAvatar.Clips
-                    .Where(x => x != null)
-                    .Select(x => new ExpressionSlider(m_expressionKeyWeights, ExpressionKey.CreateFromClip(x)))
-                    .ToList()
-                    ;
-            }
+
+            m_expressionKeyWeights = m_target.Expression.Clips.ToDictionary(x => ExpressionKey.CreateFromClip(x), x => 0.0f);
+            m_sliders = m_target.Expression.Clips
+                .Where(x => x != null)
+                .Select(x => new ExpressionSlider(m_expressionKeyWeights, ExpressionKey.CreateFromClip(x)))
+                .ToList()
+                ;
 
             if (m_target?.Meta.Meta != null)
             {
@@ -173,11 +171,6 @@ namespace UniVRM10
             if (!Application.isPlaying)
             {
                 EditorGUILayout.HelpBox("Enable when playing", MessageType.Info);
-            }
-
-            if (m_target.Expression.ExpressionAvatar == null)
-            {
-                return;
             }
 
             if (m_sliders != null)

--- a/Assets/VRM10/Editor/ScriptedImporter/EditorVrm.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/EditorVrm.cs
@@ -40,9 +40,6 @@ namespace UniVRM10
             // meta
             importer.DrawRemapGUI<VRM10MetaObject>(new SubAssetKey[] { VRM10MetaObject.SubAssetKey });
 
-            // expression avatar
-            importer.DrawRemapGUI<VRM10ExpressionAvatar>(new SubAssetKey[] { VRM10ExpressionAvatar.SubAssetKey });
-
             // expressions
             importer.DrawRemapGUI<VRM10Expression>(vrm.Expressions.Select(x => CreateKey(x).SubAssetKey));
 

--- a/Assets/VRM10/Runtime/Components/Expression/VRM10ExpressionAvatar.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/VRM10ExpressionAvatar.cs
@@ -10,11 +10,8 @@ using UnityEditor;
 
 namespace UniVRM10
 {
-    [CreateAssetMenu(menuName = "VRM10/ExpressionAvatar")]
-    public sealed class VRM10ExpressionAvatar : ScriptableObject
+    public sealed class VRM10ExpressionAvatar : MonoBehaviour
     {
-        public static UniGLTF.SubAssetKey SubAssetKey => new UniGLTF.SubAssetKey(typeof(VRM10ExpressionAvatar), "ExpressionAvatar");
-
         [SerializeField]
         public List<VRM10Expression> Clips = new List<VRM10Expression>();
 

--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -542,7 +542,8 @@ namespace UniVRM10
 
         void ExportExpression(UniGLTF.Extensions.VRMC_vrm.VRMC_vrm vrm, VRM10Controller vrmController, Model model, ModelExporter converter)
         {
-            if (vrmController?.Expression?.ExpressionAvatar?.Clips == null)
+            var expressionAvatar = vrmController.GetComponent<VRM10ExpressionAvatar>();
+            if (expressionAvatar?.Clips == null)
             {
                 return;
             }
@@ -567,7 +568,7 @@ namespace UniVRM10
             };
 
             vrm.Expressions = new List<UniGLTF.Extensions.VRMC_vrm.Expression>();
-            foreach (var e in vrmController.Expression.ExpressionAvatar.Clips)
+            foreach (var e in expressionAvatar.Clips)
             {
                 var vrmExpression = new UniGLTF.Extensions.VRMC_vrm.Expression
                 {


### PR DESCRIPTION
当初考えていたExpressionAvatar だけ保存しておいて付け替えるような使い方はしなかったので、
分かりにくいだけになってしまった。

カスタムエディタ記述のため  SerializedObject に出来た方がいいので、 MonoBehaviour になる。
