### PR TITLE
Feature10/spring bone collider identifier uniqueness violation

### DIFF
--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderGroupEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderGroupEditor.cs
@@ -23,14 +23,16 @@ namespace UniVRM10
             Gizmos.color = Color.green;
 
             bool changed = false;
-
             foreach (var x in m_target.Colliders)
             {
-                var offset = Handles.PositionHandle(x.Offset, Quaternion.identity);
-                if (offset != x.Offset)
+                foreach (var y in x.Shapes)
                 {
-                    changed = true;
-                    x.Offset = offset;
+                    var offset = Handles.PositionHandle(y.Offset, Quaternion.identity);
+                    if (offset != y.Offset)
+                    {
+                        changed = true;
+                        y.Offset = offset;
+                    }
                 }
             }
 
@@ -48,34 +50,15 @@ namespace UniVRM10
 
             Undo.RecordObject(target, "X Mirror");
 
-            foreach (var sphereCollider in target.Colliders)
+            foreach (var collider in target.Colliders)
             {
-                var offset = sphereCollider.Offset;
-                offset.x *= -1f;
-                sphereCollider.Offset = offset;
+                foreach (var shape in collider.Shapes)
+                {
+                    var offset = shape.Offset;
+                    offset.x *= -1f;
+                    shape.Offset = offset;
+                }
             }
-        }
-
-        [MenuItem("CONTEXT/VRM10SpringBoneColliderGroup/Sort Colliders by Radius")]
-        private static void SortByRadius(MenuCommand command)
-        {
-            var target = command.context as VRM10SpringBoneColliderGroup;
-            if (target == null) return;
-
-            Undo.RecordObject(target, "Sort Colliders by Radius");
-
-            target.Colliders = target.Colliders.OrderBy(x => -x.Radius);
-        }
-
-        [MenuItem("CONTEXT/VRM10SpringBoneColliderGroup/Sort Colliders by Offset Y")]
-        private static void SortByOffsetY(MenuCommand command)
-        {
-            var target = command.context as VRM10SpringBoneColliderGroup;
-            if (target == null) return;
-
-            Undo.RecordObject(target, "Sort Colliders by Offset Y");
-
-            target.Colliders = target.Colliders.OrderBy(x => -x.Offset.y);
         }
     }
 }

--- a/Assets/VRM10/Runtime/Components/SpringBone/SpringBoneLogic.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/SpringBoneLogic.cs
@@ -63,7 +63,7 @@ namespace UniVRM10
 
         public struct InternalCollider
         {
-            public VRM10SpringBoneColliderTypes ColliderTypes;
+            public VRM10SpringBoneColliderShapeTypes ColliderTypes;
             public Vector3 WorldPosition;
             public float Radius;
             public Vector3 WorldTail;
@@ -163,11 +163,11 @@ namespace UniVRM10
                 // すべての衝突判定を順番に実行する
                 switch (collider.ColliderTypes)
                 {
-                    case VRM10SpringBoneColliderTypes.Sphere:
+                    case VRM10SpringBoneColliderShapeTypes.Sphere:
                         TrySphereCollision(collider.WorldPosition, collider.Radius, ref nextTail, jointRadius);
                         break;
 
-                    case VRM10SpringBoneColliderTypes.Capsule:
+                    case VRM10SpringBoneColliderShapeTypes.Capsule:
                         TryCapsuleCollision(in collider, ref nextTail, jointRadius);
                         break;
 

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBone.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBone.cs
@@ -62,27 +62,30 @@ namespace UniVRM10
                 {
                     foreach (var collider in group.Colliders)
                     {
-                        switch (collider.ColliderType)
+                        foreach (var shape in collider.Shapes)
                         {
-                            case VRM10SpringBoneColliderTypes.Sphere:
-                                m_colliderList.Add(new SpringBoneLogic.InternalCollider
-                                {
-                                    ColliderTypes = VRM10SpringBoneColliderTypes.Sphere,
-                                    WorldPosition = group.transform.TransformPoint(collider.Offset),
-                                    Radius = collider.Radius,
+                            switch (shape.ShapeType)
+                            {
+                                case VRM10SpringBoneColliderShapeTypes.Sphere:
+                                    m_colliderList.Add(new SpringBoneLogic.InternalCollider
+                                    {
+                                        ColliderTypes = VRM10SpringBoneColliderShapeTypes.Sphere,
+                                        WorldPosition = group.transform.TransformPoint(shape.Offset),
+                                        Radius = shape.Radius,
 
-                                });
-                                break;
+                                    });
+                                    break;
 
-                            case VRM10SpringBoneColliderTypes.Capsule:
-                                m_colliderList.Add(new SpringBoneLogic.InternalCollider
-                                {
-                                    ColliderTypes = VRM10SpringBoneColliderTypes.Capsule,
-                                    WorldPosition = group.transform.TransformPoint(collider.Offset),
-                                    Radius = collider.Radius,
-                                    WorldTail = group.transform.TransformPoint(collider.Tail)
-                                });
-                                break;
+                                case VRM10SpringBoneColliderShapeTypes.Capsule:
+                                    m_colliderList.Add(new SpringBoneLogic.InternalCollider
+                                    {
+                                        ColliderTypes = VRM10SpringBoneColliderShapeTypes.Capsule,
+                                        WorldPosition = group.transform.TransformPoint(shape.Offset),
+                                        Radius = shape.Radius,
+                                        WorldTail = group.transform.TransformPoint(shape.Tail)
+                                    });
+                                    break;
+                            }
                         }
                     }
                 }

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneCollider.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneCollider.cs
@@ -1,27 +1,36 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace UniVRM10
 {
-    public enum VRM10SpringBoneColliderTypes
+    public enum VRM10SpringBoneColliderShapeTypes
     {
         Sphere,
         Capsule,
     }
 
-    [Serializable]
+    [AddComponentMenu("VRM10/VRM10SpringBoneCollider")]
+    [DisallowMultipleComponent]
     public class VRM10SpringBoneCollider : MonoBehaviour
     {
-        public VRM10SpringBoneColliderTypes ColliderType;
+        [Serializable]
+        public class Shape
+        {
+            public VRM10SpringBoneColliderShapeTypes ShapeType;
 
-        /// <summary>bone local position</summary>
-        public Vector3 Offset;
+            /// <summary>bone local position</summary>
+            public Vector3 Offset;
 
-        [Range(0, 1.0f)]
-        public float Radius;
+            [Range(0, 1.0f)]
+            public float Radius;
 
-        /// <summary>bone local position</summary>
-        public Vector3 Tail;
+            /// <summary>bone local position</summary>
+            public Vector3 Tail;
+        }
+
+        [SerializeField]
+        public List<Shape> Shapes = new List<Shape>();
 
         public static void DrawWireCapsule(Vector3 headPos, Vector3 tailPos, float radius)
         {
@@ -80,15 +89,19 @@ namespace UniVRM10
                 1.0f / transform.lossyScale.y,
                 1.0f / transform.lossyScale.z
                 ));
-            switch (ColliderType)
-            {
-                case VRM10SpringBoneColliderTypes.Sphere:
-                    Gizmos.DrawWireSphere(Offset, Radius);
-                    break;
 
-                case VRM10SpringBoneColliderTypes.Capsule:
-                    DrawWireCapsule(Offset, Tail, Radius);
-                    break;
+            foreach (var shape in Shapes)
+            {
+                switch (shape.ShapeType)
+                {
+                    case VRM10SpringBoneColliderShapeTypes.Sphere:
+                        Gizmos.DrawWireSphere(shape.Offset, shape.Radius);
+                        break;
+
+                    case VRM10SpringBoneColliderShapeTypes.Capsule:
+                        DrawWireCapsule(shape.Offset, shape.Tail, shape.Radius);
+                        break;
+                }
             }
         }
     }

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneColliderGroup.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneColliderGroup.cs
@@ -8,6 +8,8 @@ namespace UniVRM10
     /// <summary>
     /// VRMC_node_collider
     /// </summary>
+    [DisallowMultipleComponent]
+
     [AddComponentMenu("VRM10/VRM10SpringBoneColliderGroup")]
     public class VRM10SpringBoneColliderGroup : MonoBehaviour
     {

--- a/Assets/VRM10/Runtime/Format/SpringBone/Format.g.cs
+++ b/Assets/VRM10/Runtime/Format/SpringBone/Format.g.cs
@@ -62,6 +62,9 @@ namespace UniGLTF.Extensions.VRMC_springBone
         // Application-specific data.
         public object Extras;
 
+        // Name of the Spring
+        public string Name;
+
         public List<Collider> Colliders;
     }
 
@@ -119,6 +122,9 @@ namespace UniGLTF.Extensions.VRMC_springBone
 
         // Application-specific data.
         public object Extras;
+
+        // Name of the Spring
+        public string Name;
 
         // An array of colliderGroups.
         public List<ColliderGroup> ColliderGroups;

--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -263,12 +263,12 @@ namespace UniVRM10
             return (vrm, vrmSpringBone, thumbnailTextureIndex);
         }
 
-        UniGLTF.Extensions.VRMC_springBone.ColliderShape ExportShape(VRM10SpringBoneCollider z)
+        UniGLTF.Extensions.VRMC_springBone.ColliderShape ExportShape(VRM10SpringBoneCollider.Shape z)
         {
             var shape = new UniGLTF.Extensions.VRMC_springBone.ColliderShape();
-            switch (z.ColliderType)
+            switch (z.ShapeType)
             {
-                case VRM10SpringBoneColliderTypes.Sphere:
+                case VRM10SpringBoneColliderShapeTypes.Sphere:
                     {
                         shape.Sphere = new UniGLTF.Extensions.VRMC_springBone.ColliderShapeSphere
                         {
@@ -278,7 +278,7 @@ namespace UniVRM10
                         break;
                     }
 
-                case VRM10SpringBoneColliderTypes.Capsule:
+                case VRM10SpringBoneColliderShapeTypes.Capsule:
                     {
                         shape.Capsule = new UniGLTF.Extensions.VRMC_springBone.ColliderShapeCapsule
                         {
@@ -335,11 +335,14 @@ namespace UniVRM10
                     {
                         continue;
                     }
-                    colliderGroup.Colliders.Add(new UniGLTF.Extensions.VRMC_springBone.Collider
+                    foreach (var z in y.Shapes)
                     {
-                        Node = getNodeIndexFromTransform(y.transform),
-                        Shape = ExportShape(y),
-                    });
+                        colliderGroup.Colliders.Add(new UniGLTF.Extensions.VRMC_springBone.Collider
+                        {
+                            Node = getNodeIndexFromTransform(y.transform),
+                            Shape = ExportShape(z),
+                        });
+                    }
                 }
             }
 

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -358,7 +358,7 @@ namespace UniVRM10
             }
         }
 
-        const string NODE_NAME = "colliderGroups";
+        public const string COLLIDER_GROUPS_NODE_NAME = "colliderGroups";
         async Task LoadSpringBoneAsync(IAwaitCaller awaitCaller, VRM10Controller controller, UniGLTF.Extensions.VRMC_springBone.VRMC_springBone gltfVrmSpringBone)
         {
             await awaitCaller.NextFrame();
@@ -366,10 +366,10 @@ namespace UniVRM10
             // springs
             if (gltfVrmSpringBone.Springs != null)
             {
-                var colliderGroupsNode = Root.transform.Find(NODE_NAME);
+                var colliderGroupsNode = Root.transform.Find(COLLIDER_GROUPS_NODE_NAME);
                 if (colliderGroupsNode == null)
                 {
-                    colliderGroupsNode = new GameObject(NODE_NAME).transform;
+                    colliderGroupsNode = new GameObject(COLLIDER_GROUPS_NODE_NAME).transform;
                     colliderGroupsNode.SetParent(Root.transform, false);
                 }
 

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -358,6 +358,7 @@ namespace UniVRM10
             }
         }
 
+        const string NODE_NAME = "colliderGroups";
         async Task LoadSpringBoneAsync(IAwaitCaller awaitCaller, VRM10Controller controller, UniGLTF.Extensions.VRMC_springBone.VRMC_springBone gltfVrmSpringBone)
         {
             await awaitCaller.NextFrame();
@@ -365,18 +366,23 @@ namespace UniVRM10
             // springs
             if (gltfVrmSpringBone.Springs != null)
             {
-                var secondary = Root.transform.Find("secondary");
-                if (secondary == null)
+                var colliderGroupsNode = Root.transform.Find(NODE_NAME);
+                if (colliderGroupsNode == null)
                 {
-                    secondary = new GameObject("secondary").transform;
-                    secondary.SetParent(Root.transform, false);
+                    colliderGroupsNode = new GameObject(NODE_NAME).transform;
+                    colliderGroupsNode.SetParent(Root.transform, false);
                 }
 
                 // colliderGroup
                 var list = new List<VRM10SpringBoneColliderGroup>();
-                foreach (var g in gltfVrmSpringBone.ColliderGroups)
+                for (var i = 0; i < gltfVrmSpringBone.ColliderGroups.Count; ++i)
                 {
-                    var colliderGroup = secondary.gameObject.AddComponent<VRM10SpringBoneColliderGroup>();
+                    var g = gltfVrmSpringBone.ColliderGroups[i];
+                    var name = string.IsNullOrEmpty(g.Name) ? $"group_{i:00}" : g.Name;
+                    var colliderGroupNode = new GameObject(name).transform;
+                    colliderGroupNode.SetParent(colliderGroupsNode, colliderGroupNode);
+
+                    var colliderGroup = colliderGroupNode.gameObject.AddComponent<VRM10SpringBoneColliderGroup>();
                     list.Add(colliderGroup);
 
                     foreach (var c in g.Colliders)

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -389,21 +389,28 @@ namespace UniVRM10
                     {
                         var node = Nodes[c.Node.Value];
 
-                        var collider = node.gameObject.AddComponent<VRM10SpringBoneCollider>();
-                        colliderGroup.AddCollider(collider);
+                        var collider = node.gameObject.GetComponent<VRM10SpringBoneCollider>();
+                        if (collider == null)
+                        {
+                            // 各ノードにひとつだけ
+                            collider = node.gameObject.AddComponent<VRM10SpringBoneCollider>();
+                            colliderGroup.AddCollider(collider);
+                        }
 
+                        var shape = new VRM10SpringBoneCollider.Shape();
+                        collider.Shapes.Add(shape);
                         if (c.Shape.Sphere is UniGLTF.Extensions.VRMC_springBone.ColliderShapeSphere sphere)
                         {
-                            collider.ColliderType = VRM10SpringBoneColliderTypes.Sphere;
-                            collider.Radius = sphere.Radius.Value;
-                            collider.Offset = Vector3InvertX(sphere.Offset);
+                            shape.ShapeType = VRM10SpringBoneColliderShapeTypes.Sphere;
+                            shape.Radius = sphere.Radius.Value;
+                            shape.Offset = Vector3InvertX(sphere.Offset);
                         }
                         else if (c.Shape.Capsule is UniGLTF.Extensions.VRMC_springBone.ColliderShapeCapsule capsule)
                         {
-                            collider.ColliderType = VRM10SpringBoneColliderTypes.Capsule;
-                            collider.Radius = capsule.Radius.Value;
-                            collider.Offset = Vector3InvertX(capsule.Offset);
-                            collider.Tail = Vector3InvertX(capsule.Tail);
+                            shape.ShapeType = VRM10SpringBoneColliderShapeTypes.Capsule;
+                            shape.Radius = capsule.Radius.Value;
+                            shape.Offset = Vector3InvertX(capsule.Offset);
+                            shape.Tail = Vector3InvertX(capsule.Tail);
                         }
                         else
                         {


### PR DESCRIPTION
## VRM10SpringBoneColliderとVRM10SpringBoneColliderGroup DisallowMultipleComponent

複数の同一の Component が単一の GameObject にアタッチされていると

import 時に
`identifier uniqueness violation`
が発生する。

Editor からも操作しづらい。

* VRM10SpringBoneCollider => [DisallowMultipleComponent], Shapes を追加
* VRM10SpringBoneColliderGroup => [DisallowMultipleComponent], import 時にノードを追加

でこれを回避することにした。

## VRM10SpringBoneColliderGroupEditor の修正

* 描画位置
* undo
