### PR TITLE
Fix incorrect value caching of M17N

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/M17N.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/M17N.cs
@@ -61,7 +61,7 @@ namespace UniGLTF.M17N
                 {
                     var match = GetAttribute(value, language);
                     // Attribute。無かったら enum の ToString
-                    map.Add(value, match != null ? match.Message : key.ToString());
+                    map.Add(value, match != null ? match.Message : value.ToString());
                 }
 
                 s_cache.Add(language, map);

--- a/Assets/UniGLTF/Tests/UniGLTF/M17NTest.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/M17NTest.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using UniGLTF.M17N;
+using UnityEngine;
+
+namespace UniGLTF
+{
+    public class M17NTest
+    {
+        enum M17NTestEnum
+        {
+            Foo,
+            Bar,
+            Baz,
+        }
+
+        [Test]
+        public void SimpleMsgTest()
+        {
+            Assert.AreEqual("Foo", M17NTestEnum.Foo.Msg());
+            Assert.AreEqual("Bar", M17NTestEnum.Bar.Msg());
+            Assert.AreEqual("Baz", M17NTestEnum.Baz.Msg());
+
+            // test caching
+            Assert.AreEqual("Foo", M17NTestEnum.Foo.Msg());
+            Assert.AreEqual("Bar", M17NTestEnum.Bar.Msg());
+            Assert.AreEqual("Baz", M17NTestEnum.Baz.Msg());
+        }
+    }
+}

--- a/Assets/UniGLTF/Tests/UniGLTF/M17NTest.cs.meta
+++ b/Assets/UniGLTF/Tests/UniGLTF/M17NTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e993fe746592bab4abe41c880b81555a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
`MsgCache` が `enum` の `value` を保存すべきところで、引数で渡された `key` を保存しています。 
これでは、`enum` のすべての値が、最初に渡された `key` の文字列としてキャッシュされてしまうため、これを修正しました。
