### PR TITLE
Add test cases for validating null materials

### DIFF
--- a/Assets/UniGLTF/Tests/UniGLTF/MeshExportValidatorTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/MeshExportValidatorTests.cs
@@ -1,0 +1,84 @@
+﻿using NUnit.Framework;
+using System.Linq;
+using UnityEngine;
+
+namespace UniGLTF
+{
+    public class MeshExportValidatorTests
+    {
+        [Test]
+        public void NoMaterialTest()
+        {
+            var validator = ScriptableObject.CreateInstance<MeshExportValidator>();
+            var root = new GameObject("root");
+
+            try
+            {
+                var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                cube.transform.SetParent(root.transform);
+
+                var renderer = cube.GetComponent<Renderer>();
+                renderer.sharedMaterials = new Material[0];
+
+                validator.SetRoot(root, MeshExportSettings.Default);
+                var vs = validator.Validate(root);
+                Assert.False(vs.All(x => x.CanExport));
+            }
+            finally
+            {
+                GameObject.DestroyImmediate(root);
+                ScriptableObject.DestroyImmediate(validator);
+            }
+        }
+
+        [Test]
+        public void NullMaterialTest()
+        {
+            var validator = ScriptableObject.CreateInstance<MeshExportValidator>();
+            var root = new GameObject("root");
+
+            try
+            {
+                var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                cube.transform.SetParent(root.transform);
+
+                var renderer = cube.GetComponent<Renderer>();
+                renderer.sharedMaterials = new Material[] { null };
+
+                validator.SetRoot(root, MeshExportSettings.Default);
+                var vs = validator.Validate(root);
+                Assert.False(vs.All(x => x.CanExport));
+            }
+            finally
+            {
+                GameObject.DestroyImmediate(root);
+                ScriptableObject.DestroyImmediate(validator);
+            }
+        }
+
+        [Test]
+        public void NullMaterialsTest()
+        {
+            var validator = ScriptableObject.CreateInstance<MeshExportValidator>();
+            var root = new GameObject("root");
+
+            try
+            {
+                var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                cube.transform.SetParent(root.transform);
+
+                var renderer = cube.GetComponent<Renderer>();
+                renderer.sharedMaterials = new Material[] { null, null };
+
+                validator.SetRoot(root, MeshExportSettings.Default);
+                var vs = validator.Validate(root);
+                Assert.False(vs.All(x => x.CanExport));
+            }
+            finally
+            {
+                GameObject.DestroyImmediate(root);
+                ScriptableObject.DestroyImmediate(validator);
+            }
+        }
+    }
+}

--- a/Assets/UniGLTF/Tests/UniGLTF/MeshExportValidatorTests.cs.meta
+++ b/Assets/UniGLTF/Tests/UniGLTF/MeshExportValidatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 125889535256e95488606b67463c18cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
`MeshExportValidator` のテストケースを追加しました。

1 つのメッシュを持つオブジェクトに対し、

- マテリアル数 0
- `null` のマテリアル数 1
- `null` のマテリアル数 2

のテストケースを作成しました。  

いずれのケースも、Validator は、エクスポート不可とすべきはずです。  
しかし、`null` のマテリアル数 2 の場合は、エクスポート不可にならず、テストに失敗します。