### PR TITLE
[1.0] aim constraint の up vector の目標空間 model/local を実装

### DIFF
--- a/Assets/VRM10/Editor/Components/Constraint/VRM10AimConstraintEditor.cs
+++ b/Assets/VRM10/Editor/Components/Constraint/VRM10AimConstraintEditor.cs
@@ -78,6 +78,10 @@ namespace UniVRM10
                 new TR(init, m_target.transform.position).Draw(0.2f);
                 DrawAimUp(init * m_target.DestinationOffset * m_target.Delta, m_target.transform.position, Color.magenta);
             }
+
+            // Target UPVector
+            Handles.color = Color.red;
+            Handles.DrawLine(m_target.transform.position, m_target.transform.position + m_target.UpVector);
         }
     }
 }

--- a/Assets/VRM10/Editor/Components/Constraint/VRM10AimConstraintEditor.cs
+++ b/Assets/VRM10/Editor/Components/Constraint/VRM10AimConstraintEditor.cs
@@ -54,34 +54,29 @@ namespace UniVRM10
 
             var pos = m_target.transform.position;
 
-            var pr = m_target.ParentRotation;
+            var pr = TR.FromParent(m_target.transform);
 
-            if (m_target.Logic == null)
+            if (m_target.m_src == null)
             {
                 EditorGUI.BeginChangeCheck();
                 TR.FromWorld(m_target.transform).Draw(0.2f);
 
                 Handles.matrix = Matrix4x4.identity;
-                var rot = Handles.RotationHandle(pr * m_target.DestinationOffset, pos);
+                var rot = Handles.RotationHandle(pr.Rotation * m_target.DestinationOffset, pos);
                 if (EditorGUI.EndChangeCheck())
                 {
                     Undo.RecordObject(m_target, "Rotated RotateAt Point");
-                    m_target.DestinationOffset = Quaternion.Inverse(pr) * rot;
+                    m_target.DestinationOffset = Quaternion.Inverse(pr.Rotation) * rot;
                 }
 
                 DrawAimUp(rot, pos, Color.yellow);
             }
             else
             {
-                var init = m_target.ParentRotation * m_target.Logic.InitialLocalRotation;
+                var init = pr.Rotation * m_target.m_src.LocalInitial.Rotation;
                 DrawAimUp(init * m_target.DestinationOffset, m_target.transform.position, Color.yellow);
                 new TR(init, m_target.transform.position).Draw(0.2f);
                 DrawAimUp(init * m_target.DestinationOffset * m_target.Delta, m_target.transform.position, Color.magenta);
-
-                var sb = new StringBuilder();
-                sb.AppendLine($"yaw: {m_target.Yaw:0.}");
-                sb.AppendLine($"pitch: {m_target.Pitch:0.}");
-                Handles.Label(m_target.transform.position, sb.ToString(), Style);
             }
         }
     }

--- a/Assets/VRM10/Editor/Components/Constraint/VRM10AimConstraintEditor.cs
+++ b/Assets/VRM10/Editor/Components/Constraint/VRM10AimConstraintEditor.cs
@@ -80,7 +80,7 @@ namespace UniVRM10
             }
 
             // Target UPVector
-            Handles.color = Color.red;
+            Handles.color = Color.green;
             Handles.DrawLine(m_target.transform.position, m_target.transform.position + m_target.UpVector);
         }
     }

--- a/Assets/VRM10/Editor/Components/Constraint/VRM10PostionRotationConstraintEditorBase.cs
+++ b/Assets/VRM10/Editor/Components/Constraint/VRM10PostionRotationConstraintEditorBase.cs
@@ -47,7 +47,7 @@ namespace UniVRM10
 
         public void OnSceneGUI()
         {
-            if (m_target.GetSource() == null)
+            if (m_target.Source == null)
             {
                 return;
             }
@@ -56,7 +56,7 @@ namespace UniVRM10
             if (!Application.isPlaying)
             {
                 EditorGUI.BeginChangeCheck();
-                Quaternion offset = Handles.RotationHandle(m_target.SourceOffset, m_target.GetSource().position);
+                Quaternion offset = Handles.RotationHandle(m_target.SourceOffset, m_target.Source.position);
                 if (EditorGUI.EndChangeCheck())
                 {
                     Undo.RecordObject(m_target.GetComponent(), "source offset");
@@ -78,7 +78,7 @@ namespace UniVRM10
 
             // this to target line
             Handles.color = Color.yellow;
-            Handles.DrawLine(m_target.GetSource().position, m_target.GetComponent().transform.position);
+            Handles.DrawLine(m_target.Source.position, m_target.GetComponent().transform.position);
 
             var delta = Clamp180(m_target.Delta);
 
@@ -91,7 +91,7 @@ namespace UniVRM10
                 sb.AppendLine($"{delta.x:0.00}");
                 sb.AppendLine($"{delta.y:0.00}");
                 sb.Append($"{delta.z:0.00}");
-                Handles.Label(m_target.GetSource().position, sb.ToString(), Style);
+                Handles.Label(m_target.Source.position, sb.ToString(), Style);
             }
 
             // show dst

--- a/Assets/VRM10/Runtime/Components/Constraint/ConstraintSource.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/ConstraintSource.cs
@@ -19,7 +19,7 @@ namespace UniVRM10
             {
                 // case SourceCoordinates.World: return m_transform.rotation * Quaternion.Inverse(m_initial.Rotation);
                 case ObjectSpace.local: return TR.FromLocal(Source) * (LocalInitial * new TR(sourceRotationOffset)).Inverse();
-                case ObjectSpace.model: return TR.FromWorld(Source) * (TR.FromWorld(ModelRoot) * ModelInitial * new TR(sourceRotationOffset)).Inverse();
+                case ObjectSpace.model: return TR.FromWorld(Source) * (TR.FromParent(ModelRoot) * ModelInitial * new TR(sourceRotationOffset)).Inverse();
                 default: throw new NotImplementedException();
             }
         }

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10AimConstraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10AimConstraint.cs
@@ -1,53 +1,34 @@
 ﻿using System;
+using UniGLTF.Extensions.VRMC_node_constraint;
 using UnityEngine;
 
 
 namespace UniVRM10
 {
-    /// <summary>
-    /// WIP
-    /// 
-    /// Slerp(thisRot * offsetRot(Aim x Up), sourceRot, weight)
-    /// 
-    /// </summary>
     [DisallowMultipleComponent]
     public class VRM10AimConstraint : VRM10Constraint
     {
         [SerializeField]
-        public Transform Source = default;
-
-        [SerializeField]
         [Range(0, 10.0f)]
         public float Weight = 1.0f;
 
-        public Quaternion ParentRotation => transform.parent == null ? Quaternion.identity : transform.parent.rotation;
+        [SerializeField]
+        public Transform ModelRoot = default;
+
+        [Header("Source")]
+        [SerializeField]
+        public Transform Source = default;
+
+        [Header("Destination")]
+        [SerializeField]
+        ObjectSpace m_destinationCoordinate = default;
 
         [SerializeField]
         public Quaternion DestinationOffset = Quaternion.identity;
 
-        public class AimLogic
-        {
-            public readonly Quaternion InitialLocalRotation;
-            public AimLogic(Quaternion initialLocalRotation)
-            {
-                InitialLocalRotation = initialLocalRotation;
-            }
-        }
-        public AimLogic Logic { get; private set; }
+        public ConstraintSource m_src;
 
-        void Start()
-        {
-            if (Source == null)
-            {
-                enabled = false;
-                return;
-            }
-
-            if (Logic == null)
-            {
-                Logic = new AimLogic(transform.localRotation);
-            }
-        }
+        public Quaternion Delta;
 
         /// <summary>
         /// TargetのUpdateよりも先か後かはその時による。
@@ -55,21 +36,24 @@ namespace UniVRM10
         /// </summary>
         public override void Process()
         {
-            if (Logic == null)
+            if (Source == null)
             {
+                enabled = false;
                 return;
+            }
+
+            if (m_src == null)
+            {
+                m_src = new ConstraintSource(Source, ModelRoot);
             }
 
             var zAxis = (Source.position - transform.position).normalized;
             var xAxis = Vector3.Cross(Vector3.up, zAxis);
             var yAxis = Vector3.Cross(zAxis, xAxis);
             var m = new Matrix4x4(xAxis, yAxis, zAxis, new Vector4(0, 0, 0, 1));
-            Delta = Quaternion.Inverse(ParentRotation * Logic.InitialLocalRotation * DestinationOffset) * m.rotation;
-            transform.rotation = ParentRotation * Logic.InitialLocalRotation * Delta;
+            var parent = TR.FromParent(transform);
+            Delta = Quaternion.Inverse(parent.Rotation * m_src.LocalInitial.Rotation * DestinationOffset) * m.rotation;
+            transform.rotation = parent.Rotation * m_src.LocalInitial.Rotation * Delta;
         }
-
-        public float Yaw;
-        public float Pitch;
-        public Quaternion Delta;
     }
 }

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10AimConstraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10AimConstraint.cs
@@ -10,8 +10,12 @@ namespace UniVRM10
     {
         [Header("Source")]
         [SerializeField]
-        public Transform m_source = default;
-        public override Transform Source => m_source;
+        Transform m_source = default;
+        public override Transform Source
+        {
+            get => m_source;
+            set => m_source = value;
+        }
 
         [Header("Destination")]
         [SerializeField]

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10AimConstraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10AimConstraint.cs
@@ -8,16 +8,10 @@ namespace UniVRM10
     [DisallowMultipleComponent]
     public class VRM10AimConstraint : VRM10Constraint
     {
-        [SerializeField]
-        [Range(0, 10.0f)]
-        public float Weight = 1.0f;
-
-        [SerializeField]
-        public Transform ModelRoot = default;
-
         [Header("Source")]
         [SerializeField]
-        public Transform Source = default;
+        public Transform m_source = default;
+        public override Transform Source => m_source;
 
         [Header("Destination")]
         [SerializeField]
@@ -26,33 +20,41 @@ namespace UniVRM10
         [SerializeField]
         public Quaternion DestinationOffset = Quaternion.identity;
 
-        public ConstraintSource m_src;
+        Quaternion m_delta;
+        public Quaternion Delta => m_delta;
 
-        public Quaternion Delta;
-
-        /// <summary>
-        /// TargetのUpdateよりも先か後かはその時による。
-        /// 厳密に制御するのは無理。
-        /// </summary>
-        public override void Process()
+        public Vector3 UpVector
         {
-            if (Source == null)
+            get
             {
-                enabled = false;
-                return;
-            }
+                switch (m_destinationCoordinate)
+                {
+                    case ObjectSpace.model: return ModelRoot.up;
 
-            if (m_src == null)
-            {
-                m_src = new ConstraintSource(Source, ModelRoot);
-            }
+                    case ObjectSpace.local:
+                        {
+                            if (m_src == null)
+                            {
+                                return transform.up;
+                            }
 
+                            return (TR.FromParent(transform).Rotation * m_dst.LocalInitial.Rotation) * Vector3.up;
+                        }
+
+                    default:
+                        throw new NotImplementedException();
+                }
+            }
+        }
+
+        public override void OnProcess()
+        {
             var zAxis = (Source.position - transform.position).normalized;
-            var xAxis = Vector3.Cross(Vector3.up, zAxis);
+            var xAxis = Vector3.Cross(UpVector, zAxis);
             var yAxis = Vector3.Cross(zAxis, xAxis);
             var m = new Matrix4x4(xAxis, yAxis, zAxis, new Vector4(0, 0, 0, 1));
             var parent = TR.FromParent(transform);
-            Delta = Quaternion.Inverse(parent.Rotation * m_src.LocalInitial.Rotation * DestinationOffset) * m.rotation;
+            m_delta = Quaternion.Inverse(parent.Rotation * m_src.LocalInitial.Rotation * DestinationOffset) * m.rotation;
             transform.rotation = parent.Rotation * m_src.LocalInitial.Rotation * Delta;
         }
     }

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10Constraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10Constraint.cs
@@ -1,4 +1,5 @@
 using System;
+using UniGLTF.Extensions.VRMC_node_constraint;
 using UnityEngine;
 
 namespace UniVRM10
@@ -37,33 +38,35 @@ namespace UniVRM10
 
         public ConstraintSource m_src;
 
-        protected TR SourceModelCoords
-        {
-            get
-            {
-                if (m_src == null)
-                {
-                    return TR.FromWorld(ModelRoot);
-                }
-                else
-                {
-                    return TR.FromParent(ModelRoot) * m_src.ModelInitial;
-                }
-            }
-        }
 
-        protected TR SourceInitialCoords
+        protected TR SourceInitialCoords(ObjectSpace space)
         {
-            get
+            switch (space)
             {
-                if (m_src == null)
-                {
-                    return TR.FromWorld(Source);
-                }
-                else
-                {
-                    return TR.FromParent(Source) * m_src.LocalInitial;
-                }
+                case ObjectSpace.model:
+                    if (m_src == null)
+                    {
+                        return TR.FromWorld(ModelRoot);
+                    }
+                    else
+                    {
+                        var r = (TR.FromParent(ModelRoot) * m_src.ModelInitial).Rotation;
+                        var t = (TR.FromParent(transform) * m_src.LocalInitial).Translation;
+                        return new TR(r, t);
+                    }
+
+                case ObjectSpace.local:
+                    if (m_src == null)
+                    {
+                        return TR.FromWorld(Source);
+                    }
+                    else
+                    {
+                        return TR.FromParent(Source) * m_src.LocalInitial;
+                    }
+
+                default:
+                    throw new NotImplementedException();
             }
         }
         #endregion
@@ -71,33 +74,34 @@ namespace UniVRM10
         #region Destination
         protected ConstraintDestination m_dst;
 
-        protected TR DestinationModelCoords
+        protected TR DestinationInitialCoords(ObjectSpace space)
         {
-            get
+            switch (space)
             {
-                if (m_dst == null)
-                {
-                    return TR.FromWorld(ModelRoot);
-                }
-                else
-                {
-                    return TR.FromParent(ModelRoot) * m_dst.ModelInitial;
-                }
-            }
-        }
+                case ObjectSpace.model:
+                    if (m_dst == null)
+                    {
+                        return new TR(ModelRoot.rotation, transform.position);
+                    }
+                    else
+                    {
+                        var r = (TR.FromParent(ModelRoot) * m_dst.ModelInitial).Rotation;
+                        var t = (TR.FromParent(transform) * m_dst.LocalInitial).Translation;
+                        return new TR(r, t);
+                    }
 
-        public TR DestinationInitialCoords
-        {
-            get
-            {
-                if (m_dst == null)
-                {
-                    return TR.FromWorld(transform);
-                }
-                else
-                {
-                    return TR.FromParent(transform) * m_dst.LocalInitial;
-                }
+                case ObjectSpace.local:
+                    if (m_dst == null)
+                    {
+                        return TR.FromWorld(transform);
+                    }
+                    else
+                    {
+                        return TR.FromParent(transform) * m_dst.LocalInitial;
+                    }
+
+                default:
+                    throw new NotImplementedException();
             }
         }
         #endregion

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10Constraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10Constraint.cs
@@ -51,7 +51,7 @@ namespace UniVRM10
                     else
                     {
                         var r = (TR.FromParent(ModelRoot) * m_src.ModelInitial).Rotation;
-                        var t = (TR.FromParent(transform) * m_src.LocalInitial).Translation;
+                        var t = (TR.FromParent(Source) * m_src.LocalInitial).Translation;
                         return new TR(r, t);
                     }
 

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10Constraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10Constraint.cs
@@ -34,7 +34,7 @@ namespace UniVRM10
         }
 
         #region Source
-        public abstract Transform Source { get; }
+        public abstract Transform Source { get; set; }
 
         public ConstraintSource m_src;
 

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10Constraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10Constraint.cs
@@ -5,7 +5,123 @@ namespace UniVRM10
 {
     public abstract class VRM10Constraint : MonoBehaviour
     {
-        public abstract void Process();
+        [SerializeField]
+        [Range(0, 10.0f)]
+        public float Weight = 1.0f;
 
+        [SerializeField]
+        public Transform ModelRoot = default;
+
+        protected virtual void Reset()
+        {
+            var current = transform;
+            while (true)
+            {
+                current = current.parent;
+                if (current.parent == null)
+                {
+                    // root
+                    break;
+                }
+                if (current.GetComponent<VRM10Controller>() != null)
+                {
+                    // model root
+                    break;
+                }
+            }
+            ModelRoot = current;
+        }
+
+        #region Source
+        public abstract Transform Source { get; }
+
+        public ConstraintSource m_src;
+
+        protected TR SourceModelCoords
+        {
+            get
+            {
+                if (m_src == null)
+                {
+                    return TR.FromWorld(ModelRoot);
+                }
+                else
+                {
+                    return TR.FromParent(ModelRoot) * m_src.ModelInitial;
+                }
+            }
+        }
+
+        protected TR SourceInitialCoords
+        {
+            get
+            {
+                if (m_src == null)
+                {
+                    return TR.FromWorld(Source);
+                }
+                else
+                {
+                    return TR.FromParent(Source) * m_src.LocalInitial;
+                }
+            }
+        }
+        #endregion
+
+        #region Destination
+        protected ConstraintDestination m_dst;
+
+        protected TR DestinationModelCoords
+        {
+            get
+            {
+                if (m_dst == null)
+                {
+                    return TR.FromWorld(ModelRoot);
+                }
+                else
+                {
+                    return TR.FromParent(ModelRoot) * m_dst.ModelInitial;
+                }
+            }
+        }
+
+        public TR DestinationInitialCoords
+        {
+            get
+            {
+                if (m_dst == null)
+                {
+                    return TR.FromWorld(transform);
+                }
+                else
+                {
+                    return TR.FromParent(transform) * m_dst.LocalInitial;
+                }
+            }
+        }
+        #endregion
+
+        public void Process()
+        {
+            if (Source == null)
+            {
+                enabled = false;
+                return;
+            }
+
+            if (m_src == null)
+            {
+                m_src = new ConstraintSource(Source, ModelRoot);
+            }
+            if (m_dst == null)
+            {
+                m_dst = new ConstraintDestination(transform, ModelRoot);
+            }
+
+            OnProcess();
+        }
+
+        public abstract void OnProcess();
     }
 }

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10Constraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10Constraint.cs
@@ -46,7 +46,7 @@ namespace UniVRM10
                 case ObjectSpace.model:
                     if (m_src == null)
                     {
-                        return TR.FromWorld(ModelRoot);
+                        return new TR(ModelRoot.rotation, Source.position);
                     }
                     else
                     {

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10PositionConstraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10PositionConstraint.cs
@@ -37,11 +37,11 @@ namespace UniVRM10
             switch (DestinationCoordinate)
             {
                 case ObjectSpace.local:
-                    m_dst.ApplyLocal(m_dst.LocalInitial * new TR(DestinationOffset) * new TR(Delta));
+                    m_dst.ApplyLocal(DestinationInitialCoords(ObjectSpace.local) * new TR(DestinationOffset) * new TR(Delta));
                     break;
 
                 case ObjectSpace.model:
-                    m_dst.ApplyModel(DestinationInitialCoords * new TR(DestinationOffset) * new TR(Delta));
+                    m_dst.ApplyModel(DestinationInitialCoords(ObjectSpace.model) * new TR(DestinationOffset) * new TR(Delta));
                     break;
 
                 default:

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10RotationConstraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10RotationConstraint.cs
@@ -41,7 +41,7 @@ namespace UniVRM10
                     break;
 
                 case ObjectSpace.model:
-                    m_dst.ApplyModel(DestinationInitialCoords * new TR(DestinationOffset) * new TR(Quaternion.Euler(Delta)));
+                    m_dst.ApplyModel(DestinationInitialCoords(ObjectSpace.model) * new TR(DestinationOffset) * new TR(Quaternion.Euler(Delta)));
                     break;
 
                 default:

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10RotationPositionConstraintBase.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10RotationPositionConstraintBase.cs
@@ -15,19 +15,11 @@ namespace UniVRM10
             set => m_freezeAxes = value;
         }
 
-        [SerializeField]
-        [Range(0, 10.0f)]
-        public float Weight = 1.0f;
-
-        [SerializeField]
-        public Transform ModelRoot = default;
-
         #region Source
         [Header("Source")]
         [SerializeField]
-        public Transform Source = default;
-
-        public Transform GetSource() => Source;
+        public Transform m_source = default;
+        public override Transform Source => m_source;
 
         [SerializeField]
         ObjectSpace m_sourceCoordinate = default;
@@ -68,38 +60,6 @@ namespace UniVRM10
         }
         #endregion
 
-        protected ConstraintSource m_src;
-
-        TR SourceModelCoords
-        {
-            get
-            {
-                if (m_src == null)
-                {
-                    return TR.FromWorld(ModelRoot);
-                }
-                else
-                {
-                    return TR.FromParent(ModelRoot) * m_src.ModelInitial;
-                }
-            }
-        }
-
-        TR SourceInitialCoords
-        {
-            get
-            {
-                if (m_src == null)
-                {
-                    return TR.FromWorld(Source);
-                }
-                else
-                {
-                    return TR.FromParent(Source) * m_src.LocalInitial;
-                }
-            }
-        }
-
         public TR GetSourceCoords()
         {
             if (Source == null)
@@ -130,38 +90,6 @@ namespace UniVRM10
 
         public abstract TR GetSourceCurrent();
 
-        protected ConstraintDestination m_dst;
-
-        TR DestinationModelCoords
-        {
-            get
-            {
-                if (m_dst == null)
-                {
-                    return TR.FromWorld(ModelRoot);
-                }
-                else
-                {
-                    return TR.FromParent(ModelRoot) * m_dst.ModelInitial;
-                }
-            }
-        }
-
-        public TR DestinationInitialCoords
-        {
-            get
-            {
-                if (m_dst == null)
-                {
-                    return TR.FromWorld(transform);
-                }
-                else
-                {
-                    return TR.FromParent(transform) * m_dst.LocalInitial;
-                }
-            }
-        }
-
         public TR GetDstCoords()
         {
             switch (DestinationCoordinate)
@@ -187,7 +115,6 @@ namespace UniVRM10
 
         public abstract TR GetDstCurrent();
 
-
         /// <summary>
         /// Editorで設定値の変更を反映するために、クリアする
         /// </summary>
@@ -204,16 +131,6 @@ namespace UniVRM10
             }
         }
 
-        void Reset()
-        {
-            var current = transform;
-            while (current.parent != null)
-            {
-                current = current.parent;
-            }
-            ModelRoot = current;
-        }
-
         public Component GetComponent()
         {
             return this;
@@ -224,23 +141,8 @@ namespace UniVRM10
 
         protected abstract void ApplyDelta();
 
-        public override void Process()
+        public override void OnProcess()
         {
-            if (Source == null)
-            {
-                enabled = false;
-                return;
-            }
-
-            if (m_src == null)
-            {
-                m_src = new ConstraintSource(Source, ModelRoot);
-            }
-            if (m_dst == null)
-            {
-                m_dst = new ConstraintDestination(transform, ModelRoot);
-            }
-
             m_delta = m_src.Delta(SourceCoordinate, SourceOffset);
             ApplyDelta();
         }

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10RotationPositionConstraintBase.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10RotationPositionConstraintBase.cs
@@ -75,12 +75,14 @@ namespace UniVRM10
                         {
                             throw new ConstraintException(ConstraintException.ExceptionTypes.NoModelWithModelSpace);
                         }
-                        return new TR(SourceModelCoords.Rotation * SourceOffset, SourceInitialCoords.Translation);
+                        var init = SourceInitialCoords(ObjectSpace.model);
+                        return new TR(init.Rotation * SourceOffset, init.Translation);
                     }
 
                 case ObjectSpace.local:
                     {
-                        return new TR(SourceInitialCoords.Rotation * SourceOffset, SourceInitialCoords.Translation);
+                        var init = SourceInitialCoords(ObjectSpace.local);
+                        return new TR(init.Rotation * SourceOffset, init.Translation);
                     }
 
                 default:
@@ -100,12 +102,14 @@ namespace UniVRM10
                         {
                             throw new ConstraintException(ConstraintException.ExceptionTypes.NoModelWithModelSpace);
                         }
-                        return new TR(DestinationModelCoords.Rotation * DestinationOffset, DestinationInitialCoords.Translation);
+                        var init = DestinationInitialCoords(ObjectSpace.model);
+                        return new TR(init.Rotation * DestinationOffset, init.Translation);
                     }
 
                 case ObjectSpace.local:
                     {
-                        return new TR(DestinationInitialCoords.Rotation * DestinationOffset, DestinationInitialCoords.Translation);
+                        var init = DestinationInitialCoords(ObjectSpace.local);
+                        return new TR(init.Rotation * DestinationOffset, init.Translation);
                     }
 
                 default:

--- a/Assets/VRM10/Runtime/Components/Constraint/VRM10RotationPositionConstraintBase.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/VRM10RotationPositionConstraintBase.cs
@@ -18,8 +18,12 @@ namespace UniVRM10
         #region Source
         [Header("Source")]
         [SerializeField]
-        public Transform m_source = default;
-        public override Transform Source => m_source;
+        Transform m_source = default;
+        public override Transform Source
+        {
+            get => m_source;
+            set => m_source = value;
+        }
 
         [SerializeField]
         ObjectSpace m_sourceCoordinate = default;

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -479,7 +479,7 @@ namespace UniVRM10
                         var p = constraint.Position;
                         var positionConstraint = node.gameObject.AddComponent<VRM10PositionConstraint>();
                         positionConstraint.SourceCoordinate = p.SourceSpace;
-                        positionConstraint.Source = Nodes[p.Source.Value];
+                        positionConstraint.m_source = Nodes[p.Source.Value];
                         positionConstraint.DestinationCoordinate = p.DestinationSpace;
                         positionConstraint.FreezeAxes = FreezeAxis(p.FreezeAxes);
                         positionConstraint.Weight = p.Weight.Value;
@@ -490,7 +490,7 @@ namespace UniVRM10
                         var r = constraint.Rotation;
                         var rotationConstraint = node.gameObject.AddComponent<VRM10RotationConstraint>();
                         rotationConstraint.SourceCoordinate = r.SourceSpace;
-                        rotationConstraint.Source = Nodes[r.Source.Value];
+                        rotationConstraint.m_source = Nodes[r.Source.Value];
                         rotationConstraint.DestinationCoordinate = r.DestinationSpace;
                         rotationConstraint.FreezeAxes = FreezeAxis(r.FreezeAxes);
                         rotationConstraint.Weight = r.Weight.Value;
@@ -500,7 +500,7 @@ namespace UniVRM10
                     {
                         var a = constraint.Aim;
                         var aimConstraint = node.gameObject.AddComponent<VRM10AimConstraint>();
-                        aimConstraint.Source = Nodes[a.Source.Value];
+                        aimConstraint.m_source = Nodes[a.Source.Value];
                         // aimConstraint.AimVector = Vector3InvertX(a.AimVector);
                         // aimConstraint.UpVector = Vector3InvertX(a.UpVector);
                     }

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -479,7 +479,7 @@ namespace UniVRM10
                         var p = constraint.Position;
                         var positionConstraint = node.gameObject.AddComponent<VRM10PositionConstraint>();
                         positionConstraint.SourceCoordinate = p.SourceSpace;
-                        positionConstraint.m_source = Nodes[p.Source.Value];
+                        positionConstraint.Source = Nodes[p.Source.Value];
                         positionConstraint.DestinationCoordinate = p.DestinationSpace;
                         positionConstraint.FreezeAxes = FreezeAxis(p.FreezeAxes);
                         positionConstraint.Weight = p.Weight.Value;
@@ -490,7 +490,7 @@ namespace UniVRM10
                         var r = constraint.Rotation;
                         var rotationConstraint = node.gameObject.AddComponent<VRM10RotationConstraint>();
                         rotationConstraint.SourceCoordinate = r.SourceSpace;
-                        rotationConstraint.m_source = Nodes[r.Source.Value];
+                        rotationConstraint.Source = Nodes[r.Source.Value];
                         rotationConstraint.DestinationCoordinate = r.DestinationSpace;
                         rotationConstraint.FreezeAxes = FreezeAxis(r.FreezeAxes);
                         rotationConstraint.Weight = r.Weight.Value;
@@ -500,7 +500,7 @@ namespace UniVRM10
                     {
                         var a = constraint.Aim;
                         var aimConstraint = node.gameObject.AddComponent<VRM10AimConstraint>();
-                        aimConstraint.m_source = Nodes[a.Source.Value];
+                        aimConstraint.Source = Nodes[a.Source.Value];
                         // aimConstraint.AimVector = Vector3InvertX(a.AimVector);
                         // aimConstraint.UpVector = Vector3InvertX(a.UpVector);
                     }


### PR DESCRIPTION
![up_vector](https://user-images.githubusercontent.com/68057/118625329-e073d680-b804-11eb-93e0-c8eeea577e72.gif)
* 赤の線が up_vector

* 位置部の共通機能(ModelRootなど)を親 class に移動