### PR TITLE
メッシュが無いオブジェクトに対する MeshExportValidator のテストを追加

### DIFF
--- a/Assets/UniGLTF/Tests/UniGLTF/MeshExportValidatorTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/MeshExportValidatorTests.cs
@@ -76,5 +76,53 @@ namespace UniGLTF
                 ScriptableObject.DestroyImmediate(validator);
             }
         }
+
+        [Test]
+        public void NoMeshTest()
+        {
+            var validator = ScriptableObject.CreateInstance<MeshExportValidator>();
+            var root = new GameObject("root");
+
+            try
+            {
+                var child = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                child.transform.SetParent(root.transform);
+                // remove MeshFilter
+                Component.DestroyImmediate(child.GetComponent<MeshFilter>());
+
+                validator.SetRoot(root, MeshExportSettings.Default);
+                var vs = validator.Validate(root);
+                Assert.True(vs.All(x => x.CanExport));
+            }
+            finally
+            {
+                GameObject.DestroyImmediate(root);
+                ScriptableObject.DestroyImmediate(validator);
+            }
+        }
+
+        [Test]
+        public void NullMeshTest()
+        {
+            var validator = ScriptableObject.CreateInstance<MeshExportValidator>();
+            var root = new GameObject("root");
+
+            try
+            {
+                var child = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                child.transform.SetParent(root.transform);
+                // set null
+                child.GetComponent<MeshFilter>().sharedMesh = null;
+
+                validator.SetRoot(root, MeshExportSettings.Default);
+                var vs = validator.Validate(root);
+                Assert.True(vs.All(x => x.CanExport));
+            }
+            finally
+            {
+                GameObject.DestroyImmediate(root);
+                ScriptableObject.DestroyImmediate(validator);
+            }
+        }
     }
 }


### PR DESCRIPTION
`MeshExportValidator` のテストケースを追加しました。

以下のオブジェクトを Validator に渡すと `NullReferenceException` が発生します。 

- MeshFilter 無し、マテリアル有り
- MeshFilter のメッシュが `null`、マテリアル有り

Validator は、例外を発生させることなく、適切な結果を返すことを期待します。

```
NullReferenceException: Object reference not set to an instance of an object

UniGLTF.MeshExportValidator.CalcMeshSize (UniGLTF.MeshExportInfo& info, System.String relativePath) (at Assets/UniGLTF/Editor/UniGLTF/ExportDialog/MeshExportValidator.cs:47)
UniGLTF.MeshExportValidator.TryGetMeshInfo (UnityEngine.GameObject root, UnityEngine.Renderer renderer, UniGLTF.MeshExportInfo& info) (at Assets/UniGLTF/Editor/UniGLTF/ExportDialog/MeshExportValidator.cs:156)
UniGLTF.MeshExportValidator.SetRoot (UnityEngine.GameObject ExportRoot, UniGLTF.MeshExportSettings settings) (at Assets/UniGLTF/Editor/UniGLTF/ExportDialog/MeshExportValidator.cs:172)
```

追記：
このテストケースでは、Validator はエクスポート可の結果を返すものとしています。
もし、エクスポート不可とすべきであれば、適切に修正されてください。
