### PR TITLE
Export textures without alpha channel if the texture was linear, normal, or metallic-roughness.

### DIFF
--- a/Assets/VRMShaders/GLTF/IO/Runtime/NormalConverter.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/NormalConverter.cs
@@ -36,14 +36,14 @@ namespace VRMShaders
         // ConvertToNormalValueFromRawColorWhenCompressionIsRequired
         public static Texture2D Import(Texture2D texture)
         {
-            return TextureConverter.Convert(texture, ColorSpace.Linear, null, Encoder);
+            return TextureConverter.CopyTexture(texture, ColorSpace.Linear, false, Encoder);
         }
 
         // Unity texture to GLTF data
         // ConvertToRawColorWhenNormalValueIsCompressed
         public static Texture2D Export(Texture texture)
         {
-            return TextureConverter.Convert(texture, ColorSpace.Linear, null, Decoder);
+            return TextureConverter.CopyTexture(texture, ColorSpace.Linear, false, Decoder);
         }
     }
 }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/RuntimeTextureSerializer.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/RuntimeTextureSerializer.cs
@@ -41,7 +41,8 @@ namespace UniGLTF
 
         private static (byte[] bytes, string mime) CopyTextureAndGetBytesWithMime(Texture2D texture, ColorSpace colorSpace)
         {
-            var copiedTex = TextureConverter.CopyTexture(texture, colorSpace, null);
+            var needsAlpha = texture.format != TextureFormat.RGB24;
+            var copiedTex = TextureConverter.CopyTexture(texture, colorSpace, needsAlpha, null);
             var bytes = copiedTex.EncodeToPNG();
             if (Application.isPlaying)
             {

--- a/Assets/VRMShaders/GLTF/IO/Runtime/TextureExporter.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/TextureExporter.cs
@@ -79,7 +79,7 @@ namespace VRMShaders
             }
             else
             {
-                texture2D = TextureConverter.CopyTexture(src, ColorSpace.sRGB, null);
+                texture2D = TextureConverter.CopyTexture(src, ColorSpace.sRGB, true, null);
             }
             m_exported.Add((texture2D, ColorSpace.sRGB));
             m_exportMap.Add(new ExportKey(src, ExportTypes.Srgb), index);
@@ -110,7 +110,7 @@ namespace VRMShaders
             }
             else
             {
-                texture2d = TextureConverter.CopyTexture(src, ColorSpace.Linear, null);
+                texture2d = TextureConverter.CopyTexture(src, ColorSpace.Linear, false, null);
             }
             m_exported.Add((texture2d, ColorSpace.Linear));
             m_exportMap.Add(exportKey, index);

--- a/Assets/VRMShaders/GLTF/IO/Tests/CopyTextureTests.cs
+++ b/Assets/VRMShaders/GLTF/IO/Tests/CopyTextureTests.cs
@@ -36,7 +36,7 @@ namespace VRMShaders
         {
             var nonReadableTex = AssetDatabase.LoadAssetAtPath<Texture2D>($"{AssetPath}/4x4_non_readable.png");
             Assert.False(nonReadableTex.isReadable);
-            var copiedTex = TextureConverter.CopyTexture(nonReadableTex, ColorSpace.sRGB, null);
+            var copiedTex = TextureConverter.CopyTexture(nonReadableTex, ColorSpace.sRGB, true, null);
             var pixels = copiedTex.GetPixels32(miplevel: 0);
             Assert.AreEqual(pixels.Length, PngTextureValues.Length);
             for (var idx = 0; idx < pixels.Length; ++idx)
@@ -50,13 +50,33 @@ namespace VRMShaders
         {
             var compressedTex = AssetDatabase.LoadAssetAtPath<Texture2D>($"{AssetPath}/4x4_non_readable_compressed.dds");
             Assert.False(compressedTex.isReadable);
-            var copiedTex = TextureConverter.CopyTexture(compressedTex, ColorSpace.sRGB, null);
+            var copiedTex = TextureConverter.CopyTexture(compressedTex, ColorSpace.sRGB, true, null);
             var pixels = copiedTex.GetPixels32(miplevel: 0);
             Assert.AreEqual(pixels.Length, DdsTextureValues.Length);
             for (var idx = 0; idx < pixels.Length; ++idx)
             {
                 Assert.AreEqual(DdsTextureValues[idx], pixels[idx]);
             }
+        }
+
+        [Test]
+        public void CopyAttributes()
+        {
+            var src = AssetDatabase.LoadAssetAtPath<Texture2D>($"{AssetPath}/4x4_non_readable.png");
+            var dst = TextureConverter.CopyTexture(src, ColorSpace.sRGB, false, null);
+            Assert.AreEqual(src.name, dst.name);
+            Assert.AreEqual(src.anisoLevel, dst.anisoLevel);
+            Assert.AreEqual(src.filterMode, dst.filterMode);
+            Assert.AreEqual(src.mipMapBias, dst.mipMapBias);
+            Assert.AreEqual(src.wrapMode, dst.wrapMode);
+            Assert.AreEqual(src.wrapModeU, dst.wrapModeU);
+            Assert.AreEqual(src.wrapModeV, dst.wrapModeV);
+            Assert.AreEqual(src.wrapModeW, dst.wrapModeW);
+            Assert.AreEqual(src.mipmapCount, dst.mipmapCount);
+            Assert.AreEqual(src.width, dst.width);
+            Assert.AreEqual(src.height, dst.height);
+            Assert.AreEqual(src.format, dst.format);
+            Assert.AreEqual(src.imageContentsHash, dst.imageContentsHash);
         }
     }
 }


### PR DESCRIPTION
#983 をマージ後にレビューお願いします。

glTF Export 時、アルファチャンネルが不要であると判断できる以下の場合にアルファチャンネル無しで Export します。

- Linear
- Normal
- Metallic-Roughness

以下の glTF-Sample-Models の再出力を行った場合、以下のようになりました
https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/FlightHelmet

| File | Bytes |
| --- | --- |
| original | 48,392,382 bytes (46.1 MB) |
| export with UniGLTF (old) | 61,554,876 bytes (58.7 MB) |
| export with UniGLTF (PR) | 57,222,392 bytes (54.5 MB) |

さらに sRGB テクスチャもアルファチャンネルを考慮して出力すれば original と同様のサイズになります。
しかし sRGB テクスチャは「アルファチャンネルを必要とするプロパティと必要としないプロパティどちらからも参照されうる」ので今の仕組みではできない判定を行う必要があるため、本 PR では行いません。
