### PR TITLE
既存の morphTarget の sparse export を整理して、divided 頂点バッファでも動くようにした

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/BlendShapeExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/BlendShapeExporter.cs
@@ -21,15 +21,58 @@ namespace UniGLTF
     {
         public static gltfMorphTarget Export(glTF gltf, int gltfBuffer, Vector3[] positions, Vector3[] normals, SparseBase? sparseBase)
         {
+            var accessorCount = positions.Length;
+            if (normals != null && positions.Length != normals.Length)
+            {
+                throw new Exception();
+            }
+
+            bool useSparse = sparseBase.HasValue;
             if (sparseBase.HasValue)
             {
-                throw new NotImplementedException();
+                var sparseIndices = Enumerable.Range(0, positions.Length).Where(x => positions[x] != Vector3.zero).ToArray();
+                if (sparseIndices.Length == 0)
+                {
+                    useSparse = false;
+                }
+            }
+
+            if (useSparse)
+            {
+                // positions
+                var positionAccessorIndex = -1;
+                var sparseIndices = Enumerable.Range(0, positions.Length).Where(x => positions[x] != Vector3.zero).ToArray();
+                if (sparseIndices.Length > 0)
+                {
+                    Debug.LogFormat("Sparse {0}/{1}", sparseIndices.Length, positions.Length);
+                    var sparseIndicesViewIndex = gltf.ExtendBufferAndGetViewIndex(gltfBuffer, sparseIndices);
+                    positionAccessorIndex = gltf.ExtendSparseBufferAndGetAccessorIndex(gltfBuffer, accessorCount, positions, sparseIndices, sparseIndicesViewIndex, glBufferTarget.NONE);
+                }
+
+                // normals
+                var normalAccessorIndex = -1;
+                if (normals != null)
+                {
+                    var sparseNormalIndices = Enumerable.Range(0, positions.Length).Where(x => normals[x] != Vector3.zero).ToArray();
+                    if (sparseNormalIndices.Length > 0)
+                    {
+                        var sparseNormalIndicesViewIndex = gltf.ExtendBufferAndGetViewIndex(gltfBuffer, sparseNormalIndices);
+                        normalAccessorIndex = gltf.ExtendSparseBufferAndGetAccessorIndex(gltfBuffer, accessorCount, normals, sparseNormalIndices, sparseNormalIndicesViewIndex, glBufferTarget.NONE);
+                    }
+                }
+
+                return new gltfMorphTarget
+                {
+                    POSITION = positionAccessorIndex,
+                    NORMAL = normalAccessorIndex,
+                };
             }
             else
             {
                 // position
                 var positionAccessorIndex = gltf.ExtendBufferAndGetAccessorIndex(gltfBuffer, positions, glBufferTarget.ARRAY_BUFFER);
                 gltf.accessors[positionAccessorIndex].min = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Min(a.x, b.x), Math.Min(a.y, b.y), Mathf.Min(a.z, b.z))).ToArray();
+                gltf.accessors[positionAccessorIndex].max = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Max(a.x, b.x), Math.Max(a.y, b.y), Mathf.Max(a.z, b.z))).ToArray();
 
                 // normal
                 var normalAccessorIndex = -1;
@@ -37,7 +80,6 @@ namespace UniGLTF
                 {
                     normalAccessorIndex = gltf.ExtendBufferAndGetAccessorIndex(gltfBuffer, normals, glBufferTarget.ARRAY_BUFFER);
                 }
-                gltf.accessors[positionAccessorIndex].max = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Max(a.x, b.x), Math.Max(a.y, b.y), Mathf.Max(a.z, b.z))).ToArray();
 
                 return new gltfMorphTarget
                 {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/BlendShapeExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/BlendShapeExporter.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace UniGLTF
+{
+    public struct SparseBase
+    {
+        public readonly Vector3[] Positions;
+        public readonly Vector3[] Normals;
+
+        public SparseBase(Vector3[] positions, Vector3[] normals)
+        {
+            Positions = positions;
+            Normals = normals;
+        }
+    }
+
+    public static class BlendShapeExporter
+    {
+        public static gltfMorphTarget Export(glTF gltf, int gltfBuffer, Vector3[] positions, Vector3[] normals, SparseBase? sparseBase)
+        {
+            if (sparseBase.HasValue)
+            {
+                throw new NotImplementedException();
+            }
+            else
+            {
+                // position
+                var positionAccessorIndex = gltf.ExtendBufferAndGetAccessorIndex(gltfBuffer, positions, glBufferTarget.ARRAY_BUFFER);
+                gltf.accessors[positionAccessorIndex].min = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Min(a.x, b.x), Math.Min(a.y, b.y), Mathf.Min(a.z, b.z))).ToArray();
+
+                // normal
+                var normalAccessorIndex = -1;
+                if (normals != null)
+                {
+                    normalAccessorIndex = gltf.ExtendBufferAndGetAccessorIndex(gltfBuffer, normals, glBufferTarget.ARRAY_BUFFER);
+                }
+                gltf.accessors[positionAccessorIndex].max = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Max(a.x, b.x), Math.Max(a.y, b.y), Mathf.Max(a.z, b.z))).ToArray();
+
+                return new gltfMorphTarget
+                {
+                    POSITION = positionAccessorIndex,
+                    NORMAL = normalAccessorIndex,
+                };
+            }
+        }
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/BlendShapeExporter.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/BlendShapeExporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49e5f06c3492116409bc0c0745b5edf7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportUtil.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportUtil.cs
@@ -30,12 +30,12 @@ namespace UniGLTF
                 m_normals[index] = normal;
             }
 
-            public gltfMorphTarget ToGltf(glTF gltf, int gltfBuffer, bool useNormal, SparseBase? sparseBase)
+            public gltfMorphTarget ToGltf(glTF gltf, int gltfBuffer, bool useNormal, bool useSparse)
             {
                 return BlendShapeExporter.Export(gltf, gltfBuffer,
                     m_positions,
                     useNormal ? m_normals : null,
-                    sparseBase);
+                    useSparse);
             }
         }
 
@@ -103,12 +103,13 @@ namespace UniGLTF
                 m_weights.Add(new Vector4(boneWeight.weight0, boneWeight.weight1, boneWeight.weight2, boneWeight.weight3));
             }
 
-            public (glTFPrimitives, SparseBase) ToGltfPrimitive(glTF gltf, int bufferIndex, int materialIndex, IEnumerable<int> indices)
+            public glTFPrimitives ToGltfPrimitive(glTF gltf, int bufferIndex, int materialIndex, IEnumerable<int> indices)
             {
-                var sparseBase = new SparseBase(m_positions.ToArray(), m_normals.ToArray());
                 var indicesAccessorIndex = gltf.ExtendBufferAndGetAccessorIndex(bufferIndex, indices.Select(x => (uint)m_vertexIndexMap[x]).ToArray(), glBufferTarget.ELEMENT_ARRAY_BUFFER);
-                var positionAccessorIndex = gltf.ExtendBufferAndGetAccessorIndex(bufferIndex, sparseBase.Positions, glBufferTarget.ARRAY_BUFFER);
-                var normalAccessorIndex = gltf.ExtendBufferAndGetAccessorIndex(bufferIndex, sparseBase.Normals, glBufferTarget.ARRAY_BUFFER);
+                var positions = m_positions.ToArray();
+                var positionAccessorIndex = gltf.ExtendBufferAndGetAccessorIndex(bufferIndex, positions, glBufferTarget.ARRAY_BUFFER);
+                var normals = m_normals.ToArray();
+                var normalAccessorIndex = gltf.ExtendBufferAndGetAccessorIndex(bufferIndex, normals, glBufferTarget.ARRAY_BUFFER);
                 var uvAccessorIndex0 = gltf.ExtendBufferAndGetAccessorIndex(bufferIndex, m_uv.ToArray(), glBufferTarget.ARRAY_BUFFER);
 
                 int? jointsAccessorIndex = default;
@@ -137,7 +138,7 @@ namespace UniGLTF
                     mode = 4,
                 };
 
-                return (primitive, sparseBase);
+                return primitive;
             }
         }
     }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_DividedVertexBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_DividedVertexBuffer.cs
@@ -84,7 +84,7 @@ namespace UniGLTF
                     flipped.Add(t1);
                     flipped.Add(t0);
                 }
-                var (gltfPrimitive, sparseBase) = buffer.ToGltfPrimitive(gltf, gltfBuffer, materialIndex, flipped);
+                var gltfPrimitive = buffer.ToGltfPrimitive(gltf, gltfBuffer, materialIndex, flipped);
 
                 // blendShape(morph target)
                 for (int j = 0; j < mesh.blendShapeCount; ++j)
@@ -102,7 +102,7 @@ namespace UniGLTF
                     }
 
                     gltfPrimitive.targets.Add(blendShape.ToGltf(gltf, gltfBuffer, !settings.ExportOnlyBlendShapePosition,
-                        settings.UseSparseAccessorForMorphTarget ? sparseBase : default));
+                        settings.UseSparseAccessorForMorphTarget));
                 }
 
                 gltfMesh.primitives.Add(gltfPrimitive);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_DividedVertexBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_DividedVertexBuffer.cs
@@ -7,7 +7,17 @@ namespace UniGLTF
 {
     public static class MeshExporter_DividedVertexBuffer
     {
-        public static (glTFMesh, Dictionary<int, int>) Export(glTF gltf, int bufferIndex,
+        /// <summary>
+        /// Divide vertex buffer(Position, Normal, UV, VertexColor, Skinning and BlendShapes) by submesh usage, then export
+        /// </summary>
+        /// <param name="gltf"></param>
+        /// <param name="gltfBuffer"></param>
+        /// <param name="unityMesh"></param>
+        /// <param name="unityMaterials"></param>
+        /// <param name="axisInverter"></param>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        public static (glTFMesh, Dictionary<int, int>) Export(glTF gltf, int gltfBuffer,
             MeshExportInfo unityMesh, List<Material> unityMaterials,
             IAxisInverter axisInverter, MeshExportSettings settings)
         {
@@ -16,7 +26,7 @@ namespace UniGLTF
 
             if (settings.ExportTangents)
             {
-                // support しない
+                // no support
                 throw new NotImplementedException();
             }
 
@@ -40,15 +50,14 @@ namespace UniGLTF
                 var indices = mesh.GetIndices(i);
                 var hash = new HashSet<int>(indices);
 
-                // mesh
-                // index の順に attributes を蓄える                
+                // aggrigate vertex attributes
                 var buffer = new MeshExportUtil.VertexBuffer(indices.Length, getJointIndex);
                 usedIndices.Clear();
                 for (int k = 0; k < positions.Length; ++k)
                 {
                     if (hash.Contains(k))
                     {
-                        // indices から参照される頂点だけを蓄える
+                        // aggrigate indices
                         usedIndices.Add(k);
                         buffer.Push(k, axisInverter.InvertVector3(positions[k]), axisInverter.InvertVector3(normals[k]), uv[k].ReverseUV());
                         if (getJointIndex != null)
@@ -75,23 +84,25 @@ namespace UniGLTF
                     flipped.Add(t1);
                     flipped.Add(t0);
                 }
-                var gltfPrimitive = buffer.ToGltfPrimitive(gltf, bufferIndex, materialIndex, flipped);
+                var (gltfPrimitive, sparseBase) = buffer.ToGltfPrimitive(gltf, gltfBuffer, materialIndex, flipped);
 
-                // blendShape
+                // blendShape(morph target)
                 for (int j = 0; j < mesh.blendShapeCount; ++j)
                 {
                     var blendShape = new MeshExportUtil.BlendShapeBuffer(indices.Length);
 
-                    // index の順に attributes を蓄える                
+                    // aggriage morph target
                     mesh.GetBlendShapeFrameVertices(j, 0, blendShapePositions, blendShapeNormals, null);
+                    int l = 0;
                     foreach (var k in usedIndices)
                     {
-                        blendShape.Push(
+                        blendShape.Set(l++,
                             axisInverter.InvertVector3(blendShapePositions[k]),
                             axisInverter.InvertVector3(blendShapeNormals[k]));
                     }
 
-                    gltfPrimitive.targets.Add(blendShape.ToGltf(gltf, bufferIndex, !settings.ExportOnlyBlendShapePosition));
+                    gltfPrimitive.targets.Add(blendShape.ToGltf(gltf, gltfBuffer, !settings.ExportOnlyBlendShapePosition,
+                        settings.UseSparseAccessorForMorphTarget ? sparseBase : default));
                 }
 
                 gltfMesh.primitives.Add(gltfPrimitive);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
@@ -10,11 +10,12 @@ namespace UniGLTF
     {
         /// <summary>
         /// primitive 間で vertex を共有する形で Export する。
+        /// UniVRM-0.71.0 以降は、MeshExporterDivided.Export もある。
         /// 
-        /// UniVRM-0.71.0 までの挙動
+        /// * GLB/GLTF は shared(default) と divided を選択可能
+        /// * VRM0 は shared 仕様
+        /// * VRM1 は divided 仕様
         /// 
-        /// UniVRM-0.71.0 以降は、MeshExporterDivided.Export もある
-        ///
         /// /// </summary>
         /// <param name="gltf"></param>
         /// <param name="bufferIndex"></param>
@@ -159,12 +160,13 @@ namespace UniGLTF
                         unityMesh.Mesh, j,
                         settings.UseSparseAccessorForMorphTarget,
                         settings.ExportOnlyBlendShapePosition, axisInverter);
-                    if (morphTarget.POSITION < 0 && morphTarget.NORMAL < 0 && morphTarget.TANGENT < 0)
+                    if (morphTarget.POSITION < 0)
                     {
+                        // Skip empty blendShape.
+                        // Shift blendShape's index.
                         continue;
                     }
 
-                    // maybe skip
                     var blendShapeName = unityMesh.Mesh.GetBlendShapeName(j);
                     blendShapeIndexMap.Add(j, exportBlendShapes++);
                     targetNames.Add(blendShapeName);
@@ -199,7 +201,7 @@ namespace UniGLTF
         }
 
         static gltfMorphTarget ExportMorphTarget(glTF gltf, int bufferIndex,
-            Mesh mesh, int j,
+            Mesh mesh, int blendShapeIndex,
             bool useSparseAccessorForMorphTarget,
             bool exportOnlyBlendShapePosition,
             IAxisInverter axisInverter)
@@ -215,8 +217,8 @@ namespace UniGLTF
             //var useTangent = usePosition && blendShapeTangents != null && blendShapeTangents.Length == blendShapeVertices.Length;
             var useTangent = false;
 
-            var frameCount = mesh.GetBlendShapeFrameCount(j);
-            mesh.GetBlendShapeFrameVertices(j, frameCount - 1, blendShapeVertices, blendShapeNormals, null);
+            var frameCount = mesh.GetBlendShapeFrameCount(blendShapeIndex);
+            mesh.GetBlendShapeFrameVertices(blendShapeIndex, frameCount - 1, blendShapeVertices, blendShapeNormals, null);
 
             var blendShapePositionAccessorIndex = -1;
             var blendShapeNormalAccessorIndex = -1;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
@@ -231,20 +231,23 @@ namespace UniGLTF
             {
                 blendShapeNormals[i] = axisInverter.InvertVector3(blendShapeNormals[i]);
             }
-            var sparseBase = new SparseBase(mesh.vertices, mesh.normals);
-            for (int i = 0; i < sparseBase.Positions.Length; ++i)
+
+            var positions = mesh.vertices;
+            for (int i = 0; i < positions.Length; ++i)
             {
-                sparseBase.Positions[i] = axisInverter.InvertVector3(sparseBase.Positions[i]);
+                positions[i] = axisInverter.InvertVector3(positions[i]);
             }
-            for (int i = 0; i < sparseBase.Normals.Length; ++i)
+
+            var normals = mesh.normals;
+            for (int i = 0; i < normals.Length; ++i)
             {
-                sparseBase.Normals[i] = axisInverter.InvertVector3(sparseBase.Normals[i]);
+                normals[i] = axisInverter.InvertVector3(normals[i]);
             }
 
             return BlendShapeExporter.Export(gltf, bufferIndex,
                 blendShapeVertices,
                 exportOnlyBlendShapePosition && useNormal ? null : blendShapeNormals,
-                useSparseAccessorForMorphTarget ? sparseBase : default);
+                useSparseAccessorForMorphTarget);
         }
     }
 }

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
@@ -62,9 +62,9 @@ namespace UniVRM10
                     return "cannot migrate";
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                return "migration error";
+                return $"migration error: {ex}";
             }
 
             parser = new GltfParser();

--- a/Assets/VRM10/Runtime/IO/Model/MeshImporterDivided.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshImporterDivided.cs
@@ -93,7 +93,15 @@ namespace UniVRM10
                 {
                     var morphTarget = src.Meshes[meshIndex].MorphTargets[i];
                     positions.AddRange(morphTarget.VertexBuffer.Positions.GetSpan<Vector3>());
-                    normals.AddRange(morphTarget.VertexBuffer.Normals.GetSpan<Vector3>());
+                    if (morphTarget.VertexBuffer.Normals != null)
+                    {
+                        normals.AddRange(morphTarget.VertexBuffer.Normals.GetSpan<Vector3>());
+                    }
+                    else
+                    {
+                        // fill zero
+                        normals.AddRange(Enumerable.Range(0, morphTarget.VertexBuffer.Count).Select(x => Vector3.zero));
+                    }
                 }
                 dst.AddBlendShapeFrame(name, 100.0f, positions.ToArray(), normals.ToArray(), null);
             }

--- a/Assets/VRM10/Runtime/IO/Model/MeshWriter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshWriter.cs
@@ -121,7 +121,7 @@ namespace UniVRM10
                     }
                 }
                 var materialIndex = submesh.Material;
-                var (gltfPrimitive, sparseBase) = buffer.ToGltfPrimitive(storage.Gltf, bufferIndex, materialIndex, indices);
+                var gltfPrimitive = buffer.ToGltfPrimitive(storage.Gltf, bufferIndex, materialIndex, indices);
 
                 // blendShape
                 for (int j = 0; j < mesh.MorphTargets.Count; ++j)
@@ -145,7 +145,7 @@ namespace UniVRM10
                             );
                     }
 
-                    gltfPrimitive.targets.Add(blendShape.ToGltf(storage.Gltf, bufferIndex, !option.removeMorphNormal, option.sparse ? sparseBase : default));
+                    gltfPrimitive.targets.Add(blendShape.ToGltf(storage.Gltf, bufferIndex, !option.removeMorphNormal, option.sparse));
                 }
 
                 yield return gltfPrimitive;

--- a/Assets/VRM10/Runtime/IO/Model/MeshWriter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshWriter.cs
@@ -121,7 +121,7 @@ namespace UniVRM10
                     }
                 }
                 var materialIndex = submesh.Material;
-                var gltfPrimitive = buffer.ToGltfPrimitive(storage.Gltf, bufferIndex, materialIndex, indices);
+                var (gltfPrimitive, sparseBase) = buffer.ToGltfPrimitive(storage.Gltf, bufferIndex, materialIndex, indices);
 
                 // blendShape
                 for (int j = 0; j < mesh.MorphTargets.Count; ++j)
@@ -136,15 +136,16 @@ namespace UniVRM10
                     {
                         blendShapeNormals = morph.VertexBuffer.Normals.GetSpan<UnityEngine.Vector3>();
                     }
+                    int l = 0;
                     foreach (var k in usedIndices)
                     {
-                        blendShape.Push(
+                        blendShape.Set(l++,
                             blendShapePositions[k],
                             blendShapeNormals.HasValue ? blendShapeNormals.Value[k] : UnityEngine.Vector3.zero
                             );
                     }
 
-                    gltfPrimitive.targets.Add(blendShape.ToGltf(storage.Gltf, bufferIndex, !option.removeMorphNormal));
+                    gltfPrimitive.targets.Add(blendShape.ToGltf(storage.Gltf, bufferIndex, !option.removeMorphNormal, option.sparse ? sparseBase : default));
                 }
 
                 yield return gltfPrimitive;

--- a/Assets/VRM10/Runtime/IO/Model/MeshWriter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshWriter.cs
@@ -126,7 +126,7 @@ namespace UniVRM10
                 // blendShape
                 for (int j = 0; j < mesh.MorphTargets.Count; ++j)
                 {
-                    var blendShape = new MeshExportUtil.BlendShapeBuffer(indices.Length);
+                    var blendShape = new MeshExportUtil.BlendShapeBuffer(usedIndices.Count);
 
                     // index の順に attributes を蓄える
                     var morph = mesh.MorphTargets[j];

--- a/Assets/VRM10/Runtime/Migration/RotateY180.cs
+++ b/Assets/VRM10/Runtime/Migration/RotateY180.cs
@@ -49,6 +49,11 @@ namespace UniVRM10
 
         static void ReverseVector3Array(glTF gltf, int accessorIndex, HashSet<int> used)
         {
+            if (accessorIndex == -1)
+            {
+                return;
+            }
+
             if (!used.Add(accessorIndex))
             {
                 return;


### PR DESCRIPTION
#962 #861

|          | vertex buffer | defaut | comment          |
|----------|---------------|--------|------------------|
| glb/gltf | shared        |        | 既存             |
| vrm      | shared(仕様)  |        | 既存             |
| glb/gltf | divided       |        | この修正から有効 |
| vrm1     | divided(仕様) | on     | この修正から有効 |

UniVRM では、morphTarget の accessor にのみ sparse を適用します。
