### PR TITLE
古いvrmのTextureImportを修正

### DIFF
--- a/Assets/VRM/Runtime/IO/VRMMToonTextureImporter.cs
+++ b/Assets/VRM/Runtime/IO/VRMMToonTextureImporter.cs
@@ -22,7 +22,8 @@ namespace VRM
         public static bool TryGetTextureFromMaterialProperty(GltfParser parser, glTF_VRM_extensions vrm, int materialIdx, string textureKey, out (SubAssetKey, TextureDescriptor) texture)
         {
             var vrmMaterial = vrm.materialProperties[materialIdx];
-            if (vrmMaterial.shader == MToon.Utils.ShaderName && vrmMaterial.textureProperties.TryGetValue(textureKey, out var textureIdx))
+            // 任意の shader の import を許容する
+            if (/*vrmMaterial.shader == MToon.Utils.ShaderName &&*/ vrmMaterial.textureProperties.TryGetValue(textureKey, out var textureIdx))
             {
                 var (offset, scale) = (new Vector2(0, 0), new Vector2(1, 1));
                 if (TryGetTextureOffsetAndScale(vrm, materialIdx, textureKey, out var os))

--- a/Assets/VRM/Runtime/IO/VrmTextureDescriptorGenerator.cs
+++ b/Assets/VRM/Runtime/IO/VrmTextureDescriptorGenerator.cs
@@ -40,18 +40,18 @@ namespace VRM
                 var material = parser.GLTF.materials[materialIdx];
                 var vrmMaterial = vrm.materialProperties[materialIdx];
 
-                if (vrmMaterial.shader == MToon.Utils.ShaderName)
+                if (vrmMaterial.shader == VRM.glTF_VRM_Material.VRM_USE_GLTFSHADER)
                 {
-                    // MToon
-                    foreach (var kv in VRMMToonTextureImporter.EnumerateAllTextures(parser, vrm, materialIdx))
+                    // Unlit or PBR
+                    foreach (var kv in GltfPbrTextureImporter.EnumerateAllTextures(parser, materialIdx))
                     {
                         yield return kv;
                     }
                 }
                 else
                 {
-                    // Unlit or PBR
-                    foreach (var kv in GltfPbrTextureImporter.EnumerateAllTextures(parser, materialIdx))
+                    // MToon など任意の shader
+                    foreach (var kv in VRMMToonTextureImporter.EnumerateAllTextures(parser, vrm, materialIdx))
                     {
                         yield return kv;
                     }

--- a/Assets/VRM/Tests/VRMTextureEnumerateTests.cs
+++ b/Assets/VRM/Tests/VRMTextureEnumerateTests.cs
@@ -76,5 +76,60 @@ namespace VRM
                 Assert.AreEqual(1, items.Length);
             }
         }
+
+        [Test]
+        public void TextureEnumerationInUnknownShader()
+        {
+            var parser = new GltfParser
+            {
+                GLTF = new glTF
+                {
+                    images = new List<glTFImage>
+                        {
+                            new glTFImage{
+                                mimeType = "image/png",
+                            }
+                        },
+                    textures = new List<glTFTexture>
+                        {
+                            new glTFTexture{
+                                name = "texture0",
+                                source = 0,
+                            }
+                        },
+                    materials = new List<glTFMaterial>
+                        {
+                            new glTFMaterial{
+                                pbrMetallicRoughness = new glTFPbrMetallicRoughness{
+                                    baseColorTexture = new glTFMaterialBaseColorTextureInfo{
+                                        index = 0,
+                                    }
+                                }
+                            },
+                        }
+                }
+            };
+            var vrm = new glTF_VRM_extensions
+            {
+                materialProperties = new List<glTF_VRM_Material>
+                    {
+                        new glTF_VRM_Material
+                        {
+                            shader = "UnknownShader",
+                            textureProperties = new Dictionary<string, int>
+                            {
+                                {"_MainTex", 0},
+                            }
+                        },
+                     }
+            };
+
+            // 2系統ある？
+            Assert.IsTrue(VRMMToonMaterialImporter.TryCreateParam(parser, vrm, 0, out VRMShaders.MaterialDescriptor matDesc));
+            Assert.AreEqual(1, matDesc.TextureSlots.Count);
+
+            var items = new VrmTextureDescriptorGenerator(parser, vrm).Get().GetEnumerable().ToArray();
+            Assert.AreEqual(1, items.Length);
+        }
     }
 }


### PR DESCRIPTION
standard, unlit に fallback する条件を変更

* `ShaderName != "VRM/MToon"` => `ShaderName == VRM_USE_GLTFSHADER`

未知のシェーダーも vrm extensions の dictionary を使う。
