### PR TITLE
UnityObjectDestoyer 改め UnityObjectManager

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/EditorAnimation.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/EditorAnimation.cs
@@ -21,7 +21,7 @@ namespace UniGLTF
                 }
             }
 
-            importer.DrawRemapGUI<AnimationClip>(parser.GLTF.animations.Select(x => new SubAssetKey(typeof(AnimationClip), x.name)));
+            importer.DrawRemapGUI<AnimationClip>(AnimationImporterUtil.EnumerateSubAssetKeys(parser.GLTF));
 
             if (GUILayout.Button("Clear"))
             {

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterImpl.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterImpl.cs
@@ -51,7 +51,7 @@ namespace UniGLTF
                 var loaded = loader.Load();
                 loaded.ShowMeshes();
 
-                loader.TransferOwnership((k, o) =>
+                loaded.TransferOwnership((k, o) =>
                 {
                     context.AddObjectToAsset(k.Name, o);
                     return true;

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterImpl.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterImpl.cs
@@ -54,7 +54,6 @@ namespace UniGLTF
                 loaded.TransferOwnership((k, o) =>
                 {
                     context.AddObjectToAsset(k.Name, o);
-                    return true;
                 });
 
                 context.AddObjectToAsset(loaded.name, loaded.gameObject);

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterImpl.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterImpl.cs
@@ -48,20 +48,17 @@ namespace UniGLTF
                 }
 
                 loader.InvertAxis = reverseAxis;
-                loader.Load();
-                loader.ShowMeshes();
+                var loaded = loader.Load();
+                loaded.ShowMeshes();
 
                 loader.TransferOwnership((k, o) =>
                 {
                     context.AddObjectToAsset(k.Name, o);
-                    if (o is GameObject)
-                    {
-                        // Root GameObject is main object
-                        context.SetMainObject(loader.Root);
-                    }
-
                     return true;
                 });
+
+                context.AddObjectToAsset(loaded.name, loaded.gameObject);
+                context.SetMainObject(loaded.gameObject);
             }
         }
     }

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterImpl.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterImpl.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Linq;
-using UnityEditor;
 using UnityEngine;
 using VRMShaders;
 #if UNITY_2020_2_OR_NEWER
@@ -53,9 +51,9 @@ namespace UniGLTF
                 loader.Load();
                 loader.ShowMeshes();
 
-                loader.TransferOwnership(o =>
+                loader.TransferOwnership((k, o) =>
                 {
-                    context.AddObjectToAsset(o.name, o);
+                    context.AddObjectToAsset(k.Name, o);
                     if (o is GameObject)
                     {
                         // Root GameObject is main object

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterImpl.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ScriptedImporterImpl.cs
@@ -55,9 +55,11 @@ namespace UniGLTF
                 {
                     context.AddObjectToAsset(k.Name, o);
                 });
+                var root = loaded.Root;
+                GameObject.DestroyImmediate(loaded);
 
-                context.AddObjectToAsset(loaded.name, loaded.gameObject);
-                context.SetMainObject(loaded.gameObject);
+                context.AddObjectToAsset(root.name, root);
+                context.SetMainObject(root);
             }
         }
     }

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/TextureExtractor.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/TextureExtractor.cs
@@ -107,13 +107,4 @@ namespace UniGLTF
             };
         }
     }
-
-    public static class KeyValuePariExtensions
-    {
-        public static void Deconstruct<T, U>(this KeyValuePair<T, U> pair, out T key, out U value)
-        {
-            key = pair.Key;
-            value = pair.Value;
-        }
-    }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/AnimationIO/AnimationImporterUtil.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/AnimationIO/AnimationImporterUtil.cs
@@ -312,5 +312,13 @@ namespace UniGLTF
             }
             return clip;
         }
+
+        public static IEnumerable<VRMShaders.SubAssetKey> EnumerateSubAssetKeys(glTF gltf)
+        {
+            foreach (var gltfAnimation in gltf.animations)
+            {
+                yield return new VRMShaders.SubAssetKey(typeof(AnimationClip), gltfAnimation.name);
+            }
+        }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -313,10 +313,8 @@ namespace UniGLTF
         {
             foreach (var mesh in Meshes.ToArray())
             {
-                if (take(SubAssetKey.Create(mesh.Mesh), mesh.Mesh))
-                {
-                    Meshes.Remove(mesh);
-                }
+                take(SubAssetKey.Create(mesh.Mesh), mesh.Mesh);
+                Meshes.Remove(mesh);
             }
 
             TextureFactory.TransferOwnership(take);
@@ -324,10 +322,8 @@ namespace UniGLTF
 
             foreach (var (key, animation) in AnimationClips.ToArray())
             {
-                if (take(key, animation))
-                {
-                    AnimationClips.Remove((key, animation));
-                }
+                take(key, animation);
+                AnimationClips.Remove((key, animation));
             }
         }
     }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -10,7 +10,7 @@ namespace UniGLTF
     /// <summary>
     /// GLTF importer
     /// </summary>
-    public class ImporterContext : IDisposable
+    public class ImporterContext : IResponsibilityForDestroyObjects
     {
         public ITextureDescriptorGenerator TextureDescriptorGenerator { get; protected set; }
         public IMaterialDescriptorGenerator MaterialDescriptorGenerator { get; protected set; }
@@ -358,7 +358,7 @@ namespace UniGLTF
         /// Root ヒエラルキーで使っているリソース
         /// </summary>
         /// <returns></returns>
-        public virtual void TransferOwnership(Func<UnityEngine.Object, bool> take)
+        public virtual void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
             var list = new List<UnityEngine.Object>();
             foreach (var mesh in Meshes)

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -313,8 +313,7 @@ namespace UniGLTF
         {
             foreach (var mesh in Meshes.ToArray())
             {
-                // mesh の extract は実装していないので SubAssetKey を使わない
-                if (take(default, mesh.Mesh))
+                if (take(SubAssetKey.Create(mesh.Mesh), mesh.Mesh))
                 {
                     Meshes.Remove(mesh);
                 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -313,7 +313,7 @@ namespace UniGLTF
         /// </summary>
         public virtual void Dispose()
         {
-            Action<UnityEngine.Object> destroy = UnityResourceDestroyer.DestroyResource();
+            Action<UnityEngine.Object> destroy = UnityObjectManager.DestroyResource();
 
             foreach (var (k, x) in AnimationClips)
             {
@@ -391,9 +391,9 @@ namespace UniGLTF
         /// ImporterContext.Dispose の対象から外れる。
         /// </summary>
         /// <returns></returns>
-        public UnityResourceDestroyer DisposeOnGameObjectDestroyed()
+        public UnityObjectManager DisposeOnGameObjectDestroyed()
         {
-            var destroyer = Root.AddComponent<UnityResourceDestroyer>();
+            var destroyer = Root.AddComponent<UnityObjectManager>();
             TransferOwnership((k, o) =>
             {
                 destroyer.Resources.Add(o);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -61,7 +61,7 @@ namespace UniGLTF
         };
 
         #region Load. Build unity objects
-        public virtual async Task<UnityObjectManager> LoadAsync(IAwaitCaller awaitCaller = null, Func<string, IDisposable> MeasureTime = null)
+        public virtual async Task<RuntimeGltfInstance> LoadAsync(IAwaitCaller awaitCaller = null, Func<string, IDisposable> MeasureTime = null)
         {
             if (awaitCaller == null)
             {
@@ -109,7 +109,7 @@ namespace UniGLTF
 
             await OnLoadHierarchy(awaitCaller, MeasureTime);
 
-            return UnityObjectManager.AttachTo(Root, this);
+            return RuntimeGltfInstance.AttachTo(Root, this);
         }
 
         /// <summary>

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
@@ -8,7 +8,7 @@ namespace UniGLTF
         /// <summary>
         /// Build unity objects from parsed gltf
         /// </summary>
-        public static void Load(this ImporterContext self)
+        public static UnityObjectManager Load(this ImporterContext self)
         {
             var meassureTime = new ImporterContextSpeedLog();
             var task = self.LoadAsync(default(ImmediateCaller), meassureTime.MeasureTime);
@@ -24,6 +24,8 @@ namespace UniGLTF
 #if VRM_DEVELOP
             Debug.Log($"{self.Parser.TargetPath}: {meassureTime.GetSpeedLog()}");
 #endif
+
+            return task.Result;
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
@@ -8,7 +8,7 @@ namespace UniGLTF
         /// <summary>
         /// Build unity objects from parsed gltf
         /// </summary>
-        public static UnityObjectManager Load(this ImporterContext self)
+        public static RuntimeGltfInstance Load(this ImporterContext self)
         {
             var meassureTime = new ImporterContextSpeedLog();
             var task = self.LoadAsync(default(ImmediateCaller), meassureTime.MeasureTime);

--- a/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs
@@ -1,14 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
 using VRMShaders;
 
 namespace UniGLTF
 {
     /// <summary>
-    /// Mesh, Material, Texture などを抱えておいて確実に破棄できるようにする
+    /// ImporterContext の Load 結果の GltfModel
+    /// 
+    /// Runtime でモデルを Destory したときに関連リソース(Texture, Material...などの UnityEngine.Object)を自動的に Destroy する。
     /// </summary>
-    public class UnityObjectManager : MonoBehaviour, IResponsibilityForDestroyObjects
+    public class RuntimeGltfInstance : MonoBehaviour, IResponsibilityForDestroyObjects
     {
         /// <summary>
         /// this is UniGLTF root gameObject
@@ -17,9 +18,9 @@ namespace UniGLTF
 
         List<(SubAssetKey, UnityEngine.Object)> m_resources = new List<(SubAssetKey, UnityEngine.Object)>();
 
-        public static UnityObjectManager AttachTo(GameObject go, ImporterContext context)
+        public static RuntimeGltfInstance AttachTo(GameObject go, ImporterContext context)
         {
-            var loaded = go.AddComponent<UnityObjectManager>();
+            var loaded = go.AddComponent<RuntimeGltfInstance>();
             context.TransferOwnership((k, o) =>
             {
                 loaded.m_resources.Add((k, o));

--- a/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a396b6305c6ed494bad94f21d359e774
+guid: 423fb0cccbe420047ac28163cce68db4
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
@@ -10,6 +10,11 @@ namespace UniGLTF
     /// </summary>
     public class UnityObjectManager : MonoBehaviour, IResponsibilityForDestroyObjects
     {
+        /// <summary>
+        /// this is UniGLTF root gameObject
+        /// </summary>
+        public GameObject Root => this.gameObject;
+
         List<(SubAssetKey, UnityEngine.Object)> m_resources = new List<(SubAssetKey, UnityEngine.Object)>();
 
         public static UnityObjectManager AttachTo(GameObject go, ImporterContext context)

--- a/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
@@ -1,39 +1,64 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
-
+using VRMShaders;
 
 namespace UniGLTF
 {
     /// <summary>
     /// Mesh, Material, Texture などを抱えておいて確実に破棄できるようにする
     /// </summary>
-    public class UnityObjectManager : MonoBehaviour
+    public class UnityObjectManager : MonoBehaviour, IResponsibilityForDestroyObjects
     {
-        List<UnityEngine.Object> m_resources = new List<UnityEngine.Object>();
-        public IList<UnityEngine.Object> Resources => m_resources;
+        List<(SubAssetKey, UnityEngine.Object)> m_resources = new List<(SubAssetKey, UnityEngine.Object)>();
+
+        public static UnityObjectManager AttachTo(GameObject go, ImporterContext context)
+        {
+            var loaded = go.AddComponent<UnityObjectManager>();
+            context.TransferOwnership((k, o) =>
+            {
+                loaded.m_resources.Add((k, o));
+                return true;
+            });
+            return loaded;
+        }
+
+        public void ShowMeshes()
+        {
+            foreach (var r in GetComponentsInChildren<Renderer>())
+            {
+                r.enabled = true;
+            }
+        }
+
+        public void EnableUpdateWhenOffscreen()
+        {
+            foreach (var smr in GetComponentsInChildren<SkinnedMeshRenderer>())
+            {
+                smr.updateWhenOffscreen = true;
+            }
+        }
 
         void OnDestroy()
         {
             Debug.Log("UnityResourceDestroyer.OnDestroy");
-            foreach (var x in Resources)
-            {
-#if VRM_DEVELOP
-                Debug.Log($"Destroy: {x}");
-#endif                
-                Destroy(x);
-            }
+            Dispose();
         }
 
-        public static Action<UnityEngine.Object> DestroyResource()
+        public void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
-            Action<UnityEngine.Object> des = (UnityEngine.Object o) => UnityEngine.Object.Destroy(o);
-            Action<UnityEngine.Object> desi = (UnityEngine.Object o) => UnityEngine.Object.DestroyImmediate(o);
-            Action<UnityEngine.Object> func = Application.isPlaying
-                ? des
-                : desi
-                ;
-            return func;
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            foreach (var (key, x) in m_resources)
+            {
+#if VRM_DEVELOP
+                // Debug.Log($"Destroy: {x}");
+#endif                
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(x);
+            }
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
@@ -8,7 +8,7 @@ namespace UniGLTF
     /// <summary>
     /// Mesh, Material, Texture などを抱えておいて確実に破棄できるようにする
     /// </summary>
-    public class UnityResourceDestroyer : MonoBehaviour
+    public class UnityObjectManager : MonoBehaviour
     {
         List<UnityEngine.Object> m_resources = new List<UnityEngine.Object>();
         public IList<UnityEngine.Object> Resources => m_resources;

--- a/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
@@ -58,7 +58,7 @@ namespace UniGLTF
 
         public void Dispose()
         {
-            UnityObjectDestoyer.DestroyRuntimeOrEditor(this);
+            UnityObjectDestoyer.DestroyRuntimeOrEditor(this.gameObject);
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
@@ -47,16 +47,19 @@ namespace UniGLTF
 
         public void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
-            throw new NotImplementedException();
+            foreach (var (key, x) in m_resources.ToArray())
+            {
+                if (take(key, x))
+                {
+                    m_resources.Remove((key, x));
+                }
+            }
         }
 
         public void Dispose()
         {
             foreach (var (key, x) in m_resources)
             {
-#if VRM_DEVELOP
-                // Debug.Log($"Destroy: {x}");
-#endif                
                 UnityObjectDestoyer.DestroyRuntimeOrEditor(x);
             }
         }

--- a/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
@@ -18,7 +18,6 @@ namespace UniGLTF
             context.TransferOwnership((k, o) =>
             {
                 loaded.m_resources.Add((k, o));
-                return true;
             });
             return loaded;
         }
@@ -49,10 +48,8 @@ namespace UniGLTF
         {
             foreach (var (key, x) in m_resources.ToArray())
             {
-                if (take(key, x))
-                {
-                    m_resources.Remove((key, x));
-                }
+                take(key, x);
+                m_resources.Remove((key, x));
             }
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs
@@ -41,7 +41,10 @@ namespace UniGLTF
         void OnDestroy()
         {
             Debug.Log("UnityResourceDestroyer.OnDestroy");
-            Dispose();
+            foreach (var (key, x) in m_resources)
+            {
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(x);
+            }
         }
 
         public void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
@@ -55,10 +58,7 @@ namespace UniGLTF
 
         public void Dispose()
         {
-            foreach (var (key, x) in m_resources)
-            {
-                UnityObjectDestoyer.DestroyRuntimeOrEditor(x);
-            }
+            UnityObjectDestoyer.DestroyRuntimeOrEditor(this);
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/UnityObjectManager.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 93b3af59a4d8b704a883260f2fd40c44
+guid: a396b6305c6ed494bad94f21d359e774
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/UniGLTF/Tests/UniGLTF/GltfLoadTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/GltfLoadTests.cs
@@ -93,27 +93,27 @@ namespace UniGLTF
             {
                 try
                 {
-                    loader.Load();
+                    var loaded = loader.Load();
+                    if (loaded == null)
+                    {
+                        Debug.LogWarning($"root is null: ${gltf}");
+                        return;
+                    }
+
+                    if (Skip.Contains(gltf.Directory.Parent.Name))
+                    {
+                        // Export issue:
+                        // skip
+                        return;
+                    }
+
+                    Export(loaded.gameObject);
                 }
                 catch (Exception ex)
                 {
                     Message(gltf.FullName.Substring(subStrStart), ex);
                 }
 
-                if (Skip.Contains(gltf.Directory.Parent.Name))
-                {
-                    // Export issue:
-                    // skip
-                    return;
-                }
-
-                if (loader.Root == null)
-                {
-                    Debug.LogWarning($"root is null: ${gltf}");
-                    return;
-                }
-
-                Export(loader.Root);
             }
         }
 

--- a/Assets/UniGLTF/Tests/UniGLTF/UniGLTFTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/UniGLTFTests.cs
@@ -120,9 +120,9 @@ namespace UniGLTF
 
             // import
             using (var context = new ImporterContext(parser))
+            using (var loaded = context.Load())
             {
-                context.Load();
-                AssertAreEqual(go.transform, context.Root.transform);
+                AssertAreEqual(go.transform, loaded.transform);
             }
         }
 
@@ -557,16 +557,14 @@ namespace UniGLTF
                     parser.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
 
                     using (var context = new ImporterContext(parser))
+                    using (var loaded = context.Load())
                     {
-                        //Debug.LogFormat("{0}", context.Json);
-                        context.Load();
-
-                        var importedRed = context.Root.transform.GetChild(0);
+                        var importedRed = loaded.transform.GetChild(0);
                         var importedRedMaterial = importedRed.GetComponent<Renderer>().sharedMaterial;
                         Assert.AreEqual("red", importedRedMaterial.name);
                         Assert.AreEqual(Color.red, importedRedMaterial.color);
 
-                        var importedBlue = context.Root.transform.GetChild(1);
+                        var importedBlue = loaded.transform.GetChild(1);
                         var importedBlueMaterial = importedBlue.GetComponent<Renderer>().sharedMaterial;
                         Assert.AreEqual("blue", importedBlueMaterial.name);
                         Assert.AreEqual(Color.blue, importedBlueMaterial.color);
@@ -579,15 +577,14 @@ namespace UniGLTF
                     parser.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
                     //Debug.LogFormat("{0}", context.Json);
                     using (var context = new ImporterContext(parser))
+                    using (var loaded = context.Load())
                     {
-                        context.Load();
-
-                        var importedRed = context.Root.transform.GetChild(0);
+                        var importedRed = loaded.transform.GetChild(0);
                         var importedRedMaterial = importedRed.GetComponent<Renderer>().sharedMaterial;
                         Assert.AreEqual("red", importedRedMaterial.name);
                         Assert.AreEqual(Color.red, importedRedMaterial.color);
 
-                        var importedBlue = context.Root.transform.GetChild(1);
+                        var importedBlue = loaded.transform.GetChild(1);
                         var importedBlueMaterial = importedBlue.GetComponent<Renderer>().sharedMaterial;
                         Assert.AreEqual("blue", importedBlueMaterial.name);
                         Assert.AreEqual(Color.blue, importedBlueMaterial.color);
@@ -633,13 +630,11 @@ namespace UniGLTF
                     parser.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
 
                     using (var context = new ImporterContext(parser))
+                    using (var loaded = context.Load())
                     {
-                        context.Load();
-
-                        Assert.AreEqual(1, context.Root.transform.GetChildren().Count());
-
+                        Assert.AreEqual(1, loaded.transform.GetChildren().Count());
                         {
-                            var child = context.Root.transform.GetChild(0);
+                            var child = loaded.transform.GetChild(0);
                             Assert.IsNull(child.GetSharedMesh());
                         }
                     }
@@ -700,18 +695,17 @@ namespace UniGLTF
                     parser.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
 
                     using (var context = new ImporterContext(parser))
+                    using (var loaded = context.Load())
                     {
-                        context.Load();
-
-                        Assert.AreEqual(2, context.Root.transform.GetChildren().Count());
+                        Assert.AreEqual(2, loaded.transform.GetChildren().Count());
 
                         {
-                            var child = context.Root.transform.GetChild(0);
+                            var child = loaded.transform.GetChild(0);
                             Assert.IsNull(child.GetSharedMesh());
                         }
 
                         {
-                            var child = context.Root.transform.GetChild(1);
+                            var child = loaded.transform.GetChild(1);
                             Assert.IsNull(child.GetSharedMesh());
                         }
                     }

--- a/Assets/VRM.Samples/Editor/Tests/VRMImportExportTests.cs
+++ b/Assets/VRM.Samples/Editor/Tests/VRMImportExportTests.cs
@@ -47,152 +47,144 @@ namespace VRM.Samples
             parser.ParseGlb(File.ReadAllBytes(path));
 
             using (var context = new VRMImporterContext(parser))
+            using (var loaded = context.Load())
             {
-                context.Load();
-                context.ShowMeshes();
-                context.EnableUpdateWhenOffscreen();
+                loaded.ShowMeshes();
+                loaded.EnableUpdateWhenOffscreen();
 
-                var destroyer = context.DisposeOnGameObjectDestroyed();
-                try
+                // mesh
                 {
-                    // mesh
+                    foreach (var renderer in loaded.GetComponentsInChildren<Renderer>())
                     {
-                        foreach (var renderer in destroyer.GetComponentsInChildren<Renderer>())
+                        Mesh mesh = default;
+                        if (renderer is MeshRenderer)
                         {
-                            Mesh mesh = default;
-                            if (renderer is MeshRenderer)
+                            var f = renderer.GetComponent<MeshFilter>();
+                            mesh = f.sharedMesh;
+                        }
+                        else if (renderer is SkinnedMeshRenderer smr)
+                        {
+                            mesh = smr.sharedMesh;
+                        }
+
+                        var gltfMesh = parser.GLTF.meshes.Find(x => x.name == mesh.name);
+                        Assert.AreEqual(gltfMesh.name, mesh.name);
+
+                        // materials
+                        foreach (var material in renderer.sharedMaterials)
+                        {
+                            var gltfMaterial = parser.GLTF.materials.Find(x => x.name == material.name);
+                            Assert.AreEqual(gltfMaterial.name, material.name);
+
+                            var materialIndex = parser.GLTF.materials.IndexOf(gltfMaterial);
+                            var vrmMaterial = context.VRM.materialProperties[materialIndex];
+                            // Debug.Log($"shaderName: '{vrmMaterial.shader}'");
+                            if (vrmMaterial.shader == "VRM/MToon")
                             {
-                                var f = renderer.GetComponent<MeshFilter>();
-                                mesh = f.sharedMesh;
+                                // MToon
+                                // Debug.Log($"{material.name} is MToon");
+                                foreach (var kv in vrmMaterial.textureProperties)
+                                {
+                                    var texture = material.GetTexture(kv.Key);
+                                    // Debug.Log($"{kv.Key}: {texture}");
+                                    Assert.NotNull(texture);
+                                }
                             }
-                            else if (renderer is SkinnedMeshRenderer smr)
+                            else if (glTF_KHR_materials_unlit.IsEnable(gltfMaterial))
                             {
-                                mesh = smr.sharedMesh;
+                                // Unlit
+                                // Debug.Log($"{material.name} is unlit");
+                                throw new NotImplementedException();
                             }
-
-                            var gltfMesh = parser.GLTF.meshes.Find(x => x.name == mesh.name);
-                            Assert.AreEqual(gltfMesh.name, mesh.name);
-
-                            // materials
-                            foreach (var material in renderer.sharedMaterials)
+                            else
                             {
-                                var gltfMaterial = parser.GLTF.materials.Find(x => x.name == material.name);
-                                Assert.AreEqual(gltfMaterial.name, material.name);
-
-                                var materialIndex = parser.GLTF.materials.IndexOf(gltfMaterial);
-                                var vrmMaterial = context.VRM.materialProperties[materialIndex];
-                                // Debug.Log($"shaderName: '{vrmMaterial.shader}'");
-                                if (vrmMaterial.shader == "VRM/MToon")
-                                {
-                                    // MToon
-                                    // Debug.Log($"{material.name} is MToon");
-                                    foreach (var kv in vrmMaterial.textureProperties)
-                                    {
-                                        var texture = material.GetTexture(kv.Key);
-                                        // Debug.Log($"{kv.Key}: {texture}");
-                                        Assert.NotNull(texture);
-                                    }
-                                }
-                                else if (glTF_KHR_materials_unlit.IsEnable(gltfMaterial))
-                                {
-                                    // Unlit
-                                    // Debug.Log($"{material.name} is unlit");
-                                    throw new NotImplementedException();
-                                }
-                                else
-                                {
-                                    // PBR
-                                    // Debug.Log($"{material.name} is PBR");
-                                    throw new NotImplementedException();
-                                }
+                                // PBR
+                                // Debug.Log($"{material.name} is PBR");
+                                throw new NotImplementedException();
                             }
                         }
                     }
-
-                    // meta
-                    {
-                        var meta = destroyer.GetComponent<VRMMeta>();
-                    }
-
-                    // humanoid
-                    {
-                        var animator = destroyer.GetComponent<Animator>();
-                    }
-
-
-                    // blendshape
-                    {
-                        var blendshapeProxy = destroyer.GetComponent<VRMBlendShapeProxy>();
-                        for (int i = 0; i < context.VRM.blendShapeMaster.blendShapeGroups.Count; ++i)
-                        {
-                            var gltfBlendShapeClip = context.VRM.blendShapeMaster.blendShapeGroups[i];
-                            var unityBlendShapeClip = blendshapeProxy.BlendShapeAvatar.Clips[i];
-                            Assert.AreEqual(Enum.Parse(typeof(BlendShapePreset), gltfBlendShapeClip.presetName, true), unityBlendShapeClip.Preset);
-                        }
-                    }
-
-                    var importedJson = JsonParser.Parse(context.Json);
-                    importedJson.SetValue("/extensions/VRM/exporterVersion", VRMVersion.VRM_VERSION, (f, x) => f.Value(x));
-                    importedJson.SetValue("/asset/generator", UniGLTF.UniGLTFVersion.UNIGLTF_VERSION, (f, x) => f.Value(x));
-                    importedJson.SetValue("/scene", 0, (f, x) => f.Value(x));
-                    importedJson.SetValue("/materials/*/doubleSided", false, (f, x) => f.Value(x));
-                    //importJson.SetValue("/materials/*/pbrMetallicRoughness/roughnessFactor", 0);
-                    //importJson.SetValue("/materials/*/pbrMetallicRoughness/baseColorFactor", new float[] { 1, 1, 1, 1 });
-                    importedJson.SetValue("/accessors/*/normalized", false, (f, x) => f.Value(x));
-                    importedJson.RemoveValue(Utf8String.From("/nodes/*/extras"));
-                    /*
-                    importJson.SetValue("/bufferViews/12/byteStride", 4);
-                    importJson.SetValue("/bufferViews/13/byteStride", 4);
-                    importJson.SetValue("/bufferViews/14/byteStride", 4);
-                    importJson.SetValue("/bufferViews/15/byteStride", 4);
-                    importJson.SetValue("/bufferViews/22/byteStride", 4);
-                    importJson.SetValue("/bufferViews/29/byteStride", 4);
-                    importJson.SetValue("/bufferViews/45/byteStride", 4);
-                    importJson.SetValue("/bufferViews/46/byteStride", 4);
-                    importJson.SetValue("/bufferViews/47/byteStride", 4);
-                    importJson.SetValue("/bufferViews/201/byteStride", 4);
-                    importJson.SetValue("/bufferViews/202/byteStride", 4);
-                    importJson.SetValue("/bufferViews/203/byteStride", 4);
-                    importJson.SetValue("/bufferViews/204/byteStride", 4);
-                    importJson.SetValue("/bufferViews/211/byteStride", 4);
-                    importJson.SetValue("/bufferViews/212/byteStride", 4);
-                    importJson.SetValue("/bufferViews/213/byteStride", 4);
-                    importJson.SetValue("/bufferViews/214/byteStride", 4);
-                    importJson.SetValue("/bufferViews/215/byteStride", 4);
-                    importJson.SetValue("/bufferViews/243/byteStride", 4);
-                    importJson.SetValue("/bufferViews/247/byteStride", 64);
-                    importJson.SetValue("/bufferViews/248/byteStride", 64);
-                    importJson.SetValue("/bufferViews/249/byteStride", 64);
-                    importJson.SetValue("/bufferViews/250/byteStride", 64);
-                    importJson.SetValue("/bufferViews/251/byteStride", 64);
-                    importJson.SetValue("/bufferViews/252/byteStride", 64);
-                    importJson.SetValue("/bufferViews/253/byteStride", 64);
-                    */
-                    importedJson.RemoveValue(Utf8String.From("/bufferViews/*/byteStride"));
-
-                    var vrm = VRMExporter.Export(UniGLTF.MeshExportSettings.Default, context.Root, new EditorTextureSerializer());
-
-                    // TODO: Check contents in JSON
-                    /*var exportJson = */
-                    JsonParser.Parse(vrm.ToJson());
-
-                    // TODO: Check contents in JSON
-                    /*var newExportedJson = */
-                    // JsonParser.Parse(JsonSchema.FromType<glTF>().Serialize(vrm));
-
-                    /*
-                    foreach (var kv in importJson.Diff(exportJson))
-                    {
-                        Debug.Log(kv);
-                    }
-
-                    Assert.AreEqual(importJson, exportJson);
-                    */
                 }
-                finally
+
+                // meta
                 {
-                    UnityEngine.Object.DestroyImmediate(destroyer.gameObject);
+                    var meta = loaded.GetComponent<VRMMeta>();
                 }
+
+                // humanoid
+                {
+                    var animator = loaded.GetComponent<Animator>();
+                }
+
+
+                // blendshape
+                {
+                    var blendshapeProxy = loaded.GetComponent<VRMBlendShapeProxy>();
+                    for (int i = 0; i < context.VRM.blendShapeMaster.blendShapeGroups.Count; ++i)
+                    {
+                        var gltfBlendShapeClip = context.VRM.blendShapeMaster.blendShapeGroups[i];
+                        var unityBlendShapeClip = blendshapeProxy.BlendShapeAvatar.Clips[i];
+                        Assert.AreEqual(Enum.Parse(typeof(BlendShapePreset), gltfBlendShapeClip.presetName, true), unityBlendShapeClip.Preset);
+                    }
+                }
+
+                var importedJson = JsonParser.Parse(context.Json);
+                importedJson.SetValue("/extensions/VRM/exporterVersion", VRMVersion.VRM_VERSION, (f, x) => f.Value(x));
+                importedJson.SetValue("/asset/generator", UniGLTF.UniGLTFVersion.UNIGLTF_VERSION, (f, x) => f.Value(x));
+                importedJson.SetValue("/scene", 0, (f, x) => f.Value(x));
+                importedJson.SetValue("/materials/*/doubleSided", false, (f, x) => f.Value(x));
+                //importJson.SetValue("/materials/*/pbrMetallicRoughness/roughnessFactor", 0);
+                //importJson.SetValue("/materials/*/pbrMetallicRoughness/baseColorFactor", new float[] { 1, 1, 1, 1 });
+                importedJson.SetValue("/accessors/*/normalized", false, (f, x) => f.Value(x));
+                importedJson.RemoveValue(Utf8String.From("/nodes/*/extras"));
+                /*
+                importJson.SetValue("/bufferViews/12/byteStride", 4);
+                importJson.SetValue("/bufferViews/13/byteStride", 4);
+                importJson.SetValue("/bufferViews/14/byteStride", 4);
+                importJson.SetValue("/bufferViews/15/byteStride", 4);
+                importJson.SetValue("/bufferViews/22/byteStride", 4);
+                importJson.SetValue("/bufferViews/29/byteStride", 4);
+                importJson.SetValue("/bufferViews/45/byteStride", 4);
+                importJson.SetValue("/bufferViews/46/byteStride", 4);
+                importJson.SetValue("/bufferViews/47/byteStride", 4);
+                importJson.SetValue("/bufferViews/201/byteStride", 4);
+                importJson.SetValue("/bufferViews/202/byteStride", 4);
+                importJson.SetValue("/bufferViews/203/byteStride", 4);
+                importJson.SetValue("/bufferViews/204/byteStride", 4);
+                importJson.SetValue("/bufferViews/211/byteStride", 4);
+                importJson.SetValue("/bufferViews/212/byteStride", 4);
+                importJson.SetValue("/bufferViews/213/byteStride", 4);
+                importJson.SetValue("/bufferViews/214/byteStride", 4);
+                importJson.SetValue("/bufferViews/215/byteStride", 4);
+                importJson.SetValue("/bufferViews/243/byteStride", 4);
+                importJson.SetValue("/bufferViews/247/byteStride", 64);
+                importJson.SetValue("/bufferViews/248/byteStride", 64);
+                importJson.SetValue("/bufferViews/249/byteStride", 64);
+                importJson.SetValue("/bufferViews/250/byteStride", 64);
+                importJson.SetValue("/bufferViews/251/byteStride", 64);
+                importJson.SetValue("/bufferViews/252/byteStride", 64);
+                importJson.SetValue("/bufferViews/253/byteStride", 64);
+                */
+                importedJson.RemoveValue(Utf8String.From("/bufferViews/*/byteStride"));
+
+                var vrm = VRMExporter.Export(UniGLTF.MeshExportSettings.Default, loaded.gameObject, new EditorTextureSerializer());
+
+                // TODO: Check contents in JSON
+                /*var exportJson = */
+                JsonParser.Parse(vrm.ToJson());
+
+                // TODO: Check contents in JSON
+                /*var newExportedJson = */
+                // JsonParser.Parse(JsonSchema.FromType<glTF>().Serialize(vrm));
+
+                /*
+                foreach (var kv in importJson.Diff(exportJson))
+                {
+                    Debug.Log(kv);
+                }
+
+                Assert.AreEqual(importJson, exportJson);
+                */
             }
         }
 
@@ -204,10 +196,10 @@ namespace VRM.Samples
             parser.ParseGlb(File.ReadAllBytes(path));
 
             using (var context = new VRMImporterContext(parser))
+            using (var loaded = context.Load())
             {
-                context.Load();
-                context.ShowMeshes();
-                context.EnableUpdateWhenOffscreen();
+                loaded.ShowMeshes();
+                loaded.EnableUpdateWhenOffscreen();
                 foreach (var mesh in context.Meshes)
                 {
                     var src = mesh.Mesh;

--- a/Assets/VRM.Samples/Scripts/VRMRuntimeExporter.cs
+++ b/Assets/VRM.Samples/Scripts/VRMRuntimeExporter.cs
@@ -59,13 +59,12 @@ namespace VRM.Samples
                 Debug.LogFormat("meta: title:{0}", meta.Title);
 
                 // ParseしたJSONをシーンオブジェクトに変換していく
-                await context.LoadAsync();
+                var loaded = await context.LoadAsync();
 
-                context.ShowMeshes();
-                context.EnableUpdateWhenOffscreen();
-                var destroyer = context.DisposeOnGameObjectDestroyed();
+                loaded.ShowMeshes();
+                loaded.EnableUpdateWhenOffscreen();
 
-                OnLoaded(destroyer.gameObject);
+                OnLoaded(loaded.gameObject);
             }
         }
 

--- a/Assets/VRM.Samples/Scripts/VRMRuntimeLoader.cs
+++ b/Assets/VRM.Samples/Scripts/VRMRuntimeLoader.cs
@@ -97,7 +97,7 @@ namespace VRM.Samples
                 Debug.LogFormat("meta: title:{0}", meta.Title);
 
                 // ParseしたJSONをシーンオブジェクトに変換していく
-                var loaded = default(UnityObjectManager);
+                var loaded = default(RuntimeGltfInstance);
                 if (m_loadAsync)
                 {
                     loaded = await context.LoadAsync();
@@ -136,7 +136,7 @@ namespace VRM.Samples
             parser.ParseGlb(bytes);
 
             var context = new VRMImporterContext(parser);
-            var loaded = default(UnityObjectManager);
+            var loaded = default(RuntimeGltfInstance);
             if (m_loadAsync)
             {
                 loaded = await context.LoadAsync();
@@ -167,7 +167,7 @@ namespace VRM.Samples
 #endif
         }
 
-        void OnLoaded(UnityObjectManager loaded)
+        void OnLoaded(RuntimeGltfInstance loaded)
         {
             var root = loaded.gameObject;
 

--- a/Assets/VRM.Samples/Scripts/VRMRuntimeLoader.cs
+++ b/Assets/VRM.Samples/Scripts/VRMRuntimeLoader.cs
@@ -97,16 +97,17 @@ namespace VRM.Samples
                 Debug.LogFormat("meta: title:{0}", meta.Title);
 
                 // ParseしたJSONをシーンオブジェクトに変換していく
+                var loaded = default(UnityObjectManager);
                 if (m_loadAsync)
                 {
-                    await context.LoadAsync();
+                    loaded = await context.LoadAsync();
                 }
                 else
                 {
-                    context.Load();
+                    loaded = context.Load();
                 }
 
-                OnLoaded(context);
+                OnLoaded(loaded);
             }
         }
 
@@ -135,15 +136,16 @@ namespace VRM.Samples
             parser.ParseGlb(bytes);
 
             var context = new VRMImporterContext(parser);
+            var loaded = default(UnityObjectManager);
             if (m_loadAsync)
             {
-                await context.LoadAsync();
+                loaded = await context.LoadAsync();
             }
             else
             {
-                context.Load();
+                loaded = context.Load();
             }
-            OnLoaded(context);
+            OnLoaded(loaded);
         }
 
         void LoadBVHClicked()
@@ -165,15 +167,14 @@ namespace VRM.Samples
 #endif
         }
 
-        void OnLoaded(VRMImporterContext context)
+        void OnLoaded(UnityObjectManager loaded)
         {
-            var root = context.Root;
+            var root = loaded.gameObject;
 
             root.transform.SetParent(transform, false);
 
             //メッシュを表示します
-            context.ShowMeshes();
-            context.DisposeOnGameObjectDestroyed();
+            loaded.ShowMeshes();
 
             // add motion
             var humanPoseTransfer = root.AddComponent<UniHumanoid.HumanPoseTransfer>();

--- a/Assets/VRM.Samples/Scripts/ViewerUI.cs
+++ b/Assets/VRM.Samples/Scripts/ViewerUI.cs
@@ -317,11 +317,10 @@ namespace VRM.Samples
                         using (var context = new VRMImporterContext(parser))
                         {
                             await m_texts.UpdateMetaAsync(context);
-                            await context.LoadAsync();
-                            context.EnableUpdateWhenOffscreen();
-                            context.ShowMeshes();
-                            context.DisposeOnGameObjectDestroyed();
-                            SetModel(context.Root);
+                            var loaded = await context.LoadAsync();
+                            loaded.EnableUpdateWhenOffscreen();
+                            loaded.ShowMeshes();
+                            SetModel(loaded.gameObject);
                         }
                         break;
                     }
@@ -333,11 +332,10 @@ namespace VRM.Samples
                         parser.ParseGlb(file);
 
                         var context = new UniGLTF.ImporterContext(parser);
-                        context.Load();
-                        context.EnableUpdateWhenOffscreen();
-                        context.ShowMeshes();
-                        context.DisposeOnGameObjectDestroyed();
-                        SetModel(context.Root);
+                        var loaded = context.Load();
+                        loaded.EnableUpdateWhenOffscreen();
+                        loaded.ShowMeshes();
+                        SetModel(loaded.gameObject);
                         break;
                     }
 
@@ -348,11 +346,10 @@ namespace VRM.Samples
                         parser.ParsePath(path);
 
                         var context = new UniGLTF.ImporterContext(parser);
-                        context.Load();
-                        context.EnableUpdateWhenOffscreen();
-                        context.ShowMeshes();
-                        context.DisposeOnGameObjectDestroyed();
-                        SetModel(context.Root);
+                        var loaded = context.Load();
+                        loaded.EnableUpdateWhenOffscreen();
+                        loaded.ShowMeshes();
+                        SetModel(loaded.gameObject);
                         break;
                     }
 

--- a/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
@@ -139,18 +139,20 @@ namespace VRM
             m_paths.Clear();
             m_paths.Add(m_prefabPath);
             loaded.TransferOwnership(SaveAsAsset);
+            var root = loaded.Root;
+            GameObject.DestroyImmediate(loaded);
 
             // Create or update Main Asset
             if (m_prefabPath.IsFileExists)
             {
                 Debug.LogFormat("replace prefab: {0}", m_prefabPath);
                 var prefab = m_prefabPath.LoadAsset<GameObject>();
-                PrefabUtility.SaveAsPrefabAssetAndConnect(loaded.gameObject, m_prefabPath.Value, InteractionMode.AutomatedAction);
+                PrefabUtility.SaveAsPrefabAssetAndConnect(root, m_prefabPath.Value, InteractionMode.AutomatedAction);
             }
             else
             {
                 Debug.LogFormat("create prefab: {0}", m_prefabPath);
-                PrefabUtility.SaveAsPrefabAssetAndConnect(loaded.gameObject, m_prefabPath.Value, InteractionMode.AutomatedAction);
+                PrefabUtility.SaveAsPrefabAssetAndConnect(root, m_prefabPath.Value, InteractionMode.AutomatedAction);
             }
 
             foreach (var x in m_paths)

--- a/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
@@ -129,7 +129,7 @@ namespace VRM
             }
         }
 
-        public void SaveAsAsset(UniGLTF.UnityObjectManager loaded)
+        public void SaveAsAsset(UniGLTF.RuntimeGltfInstance loaded)
         {
             loaded.ShowMeshes();
 

--- a/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
@@ -108,36 +108,25 @@ namespace VRM
             TextureExtractor.ExtractTextures(m_context.Parser, m_prefabPath.Parent.Child(dirName), m_context.TextureDescriptorGenerator, subAssets, (_x, _y) => { }, onTextureReloaded);
         }
 
-        bool SaveAsAsset(SubAssetKey _, UnityEngine.Object o)
+        void SaveAsAsset(SubAssetKey _, UnityEngine.Object o)
         {
-            if (o is GameObject)
-            {
-                return false;
-            }
-
             if (!string.IsNullOrEmpty(AssetDatabase.GetAssetPath(o)))
             {
-                // already exists. not dispose
 #if VRM_DEVELOP
-                Debug.Log($"Loaded. skip: {o}");
+                // 来ない？
+                Debug.LogWarning($"{o} already exists. skip write");
 #endif
-                return true;
+                return;
             }
 
             var assetPath = GetAssetPath(m_prefabPath, o);
-            if (assetPath.IsNull)
+            if (!assetPath.IsNull)
             {
-                // not dispose
-                return true;
+                // アセットとして書き込む
+                assetPath.Parent.EnsureFolder();
+                assetPath.CreateAsset(o);
+                m_paths.Add(assetPath);
             }
-
-            // アセットとして書き込む
-            assetPath.Parent.EnsureFolder();
-            assetPath.CreateAsset(o);
-            m_paths.Add(assetPath);
-
-            // 所有権が移動
-            return true;
         }
 
         public void SaveAsAsset(UniGLTF.UnityObjectManager loaded)
@@ -157,7 +146,6 @@ namespace VRM
                 Debug.LogFormat("replace prefab: {0}", m_prefabPath);
                 var prefab = m_prefabPath.LoadAsset<GameObject>();
                 PrefabUtility.SaveAsPrefabAssetAndConnect(loaded.gameObject, m_prefabPath.Value, InteractionMode.AutomatedAction);
-
             }
             else
             {

--- a/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
@@ -108,7 +108,7 @@ namespace VRM
             TextureExtractor.ExtractTextures(m_context.Parser, m_prefabPath.Parent.Child(dirName), m_context.TextureDescriptorGenerator, subAssets, (_x, _y) => { }, onTextureReloaded);
         }
 
-        bool SaveAsAsset(UnityEngine.Object o)
+        bool SaveAsAsset(SubAssetKey _, UnityEngine.Object o)
         {
             if (o is GameObject)
             {

--- a/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
@@ -140,29 +140,29 @@ namespace VRM
             return true;
         }
 
-        public void SaveAsAsset()
+        public void SaveAsAsset(UniGLTF.UnityObjectManager loaded)
         {
-            m_context.ShowMeshes();
+            loaded.ShowMeshes();
 
             //
             // save sub assets
             //
             m_paths.Clear();
             m_paths.Add(m_prefabPath);
-            m_context.TransferOwnership(SaveAsAsset);
+            loaded.TransferOwnership(SaveAsAsset);
 
             // Create or update Main Asset
             if (m_prefabPath.IsFileExists)
             {
                 Debug.LogFormat("replace prefab: {0}", m_prefabPath);
                 var prefab = m_prefabPath.LoadAsset<GameObject>();
-                PrefabUtility.SaveAsPrefabAssetAndConnect(m_context.Root, m_prefabPath.Value, InteractionMode.AutomatedAction);
+                PrefabUtility.SaveAsPrefabAssetAndConnect(loaded.gameObject, m_prefabPath.Value, InteractionMode.AutomatedAction);
 
             }
             else
             {
                 Debug.LogFormat("create prefab: {0}", m_prefabPath);
-                PrefabUtility.SaveAsPrefabAssetAndConnect(m_context.Root, m_prefabPath.Value, InteractionMode.AutomatedAction);
+                PrefabUtility.SaveAsPrefabAssetAndConnect(loaded.gameObject, m_prefabPath.Value, InteractionMode.AutomatedAction);
             }
 
             foreach (var x in m_paths)

--- a/Assets/VRM/Editor/Format/VRMImporterMenu.cs
+++ b/Assets/VRM/Editor/Format/VRMImporterMenu.cs
@@ -50,11 +50,10 @@ namespace VRM
 
             using (var context = new VRMImporterContext(parser))
             {
-                context.Load();
-                context.EnableUpdateWhenOffscreen();
-                context.ShowMeshes();
-                context.DisposeOnGameObjectDestroyed();
-                Selection.activeGameObject = context.Root;
+                var loaded = context.Load();
+                loaded.EnableUpdateWhenOffscreen();
+                loaded.ShowMeshes();
+                Selection.activeGameObject = loaded.gameObject;
             }
         }
 
@@ -88,8 +87,8 @@ namespace VRM
                     {
                         VRMShaders.TextureImporterConfigurator.Configure(textureInfo, context.TextureFactory.ExternalTextures);
                     }
-                    context.Load();
-                    editor.SaveAsAsset();
+                    var loaded = context.Load();
+                    editor.SaveAsAsset(loaded);
                 }
             };
 

--- a/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -63,8 +63,8 @@ namespace VRM
                     {
                         VRMShaders.TextureImporterConfigurator.Configure(textureInfo, context.TextureFactory.ExternalTextures);
                     }
-                    context.Load();
-                    editor.SaveAsAsset();
+                    var loaded = context.Load();
+                    editor.SaveAsAsset(loaded);
                 }
             };
 

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -319,31 +319,33 @@ namespace VRM
 
         public override void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
+            // VRM-0 は SubAssetKey を使っていないので default で済ます
+
             // VRM 固有のリソース(ScriptableObject)
-            if (take(HumanoidAvatar))
+            if (take(default, HumanoidAvatar))
             {
                 HumanoidAvatar = null;
             }
 
-            if (take(Meta))
+            if (take(default, Meta))
             {
                 Meta = null;
             }
 
-            if (take(AvatarDescription))
+            if (take(default, AvatarDescription))
             {
                 AvatarDescription = null;
             }
 
             foreach (var x in BlendShapeAvatar.Clips)
             {
-                if (take(x))
+                if (take(default, x))
                 {
                     // do nothing
                 }
             }
 
-            if (take(BlendShapeAvatar))
+            if (take(default, BlendShapeAvatar))
             {
                 BlendShapeAvatar = null;
             }

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -322,33 +322,25 @@ namespace VRM
             // VRM-0 は SubAssetKey を使っていないので default で済ます
 
             // VRM 固有のリソース(ScriptableObject)
-            if (take(default, HumanoidAvatar))
-            {
-                HumanoidAvatar = null;
-            }
+            take(default, HumanoidAvatar);
+            HumanoidAvatar = null;
 
-            if (take(default, Meta))
-            {
-                Meta = null;
-            }
+            take(default, Meta);
+            Meta = null;
 
-            if (take(default, AvatarDescription))
-            {
-                AvatarDescription = null;
-            }
+            take(default, AvatarDescription);
+            AvatarDescription = null;
 
             foreach (var x in BlendShapeAvatar.Clips)
             {
-                if (take(default, x))
+                take(default, x);
                 {
                     // do nothing
                 }
             }
 
-            if (take(default, BlendShapeAvatar))
-            {
-                BlendShapeAvatar = null;
-            }
+            take(default, BlendShapeAvatar);
+            BlendShapeAvatar = null;
 
             // GLTF のリソース
             base.TransferOwnership(take);

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -356,7 +356,7 @@ namespace VRM
 
         public override void Dispose()
         {
-            Action<UnityEngine.Object> destroy = UnityResourceDestroyer.DestroyResource();
+            Action<UnityEngine.Object> destroy = UnityObjectManager.DestroyResource();
 
             // VRM specific
             if (HumanoidAvatar != null)

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -356,28 +356,26 @@ namespace VRM
 
         public override void Dispose()
         {
-            Action<UnityEngine.Object> destroy = UnityObjectManager.DestroyResource();
-
             // VRM specific
             if (HumanoidAvatar != null)
             {
-                destroy(HumanoidAvatar);
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(HumanoidAvatar);
             }
             if (Meta != null)
             {
-                destroy(Meta);
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(Meta);
             }
             if (AvatarDescription != null)
             {
-                destroy(AvatarDescription);
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(AvatarDescription);
             }
             if (BlendShapeAvatar != null)
             {
                 foreach (var clip in BlendShapeAvatar.Clips)
                 {
-                    destroy(clip);
+                    UnityObjectDestoyer.DestroyRuntimeOrEditor(clip);
                 }
-                destroy(BlendShapeAvatar);
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(BlendShapeAvatar);
             }
 
             base.Dispose();

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -317,7 +317,7 @@ namespace VRM
             return meta;
         }
 
-        public override void TransferOwnership(Func<UnityEngine.Object, bool> take)
+        public override void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
             // VRM 固有のリソース(ScriptableObject)
             if (take(HumanoidAvatar))

--- a/Assets/VRM/Tests/VRMLoadTests.cs
+++ b/Assets/VRM/Tests/VRMLoadTests.cs
@@ -74,8 +74,7 @@ namespace VRM
             {
                 using (var importer = new VRMImporterContext(parser))
                 {
-                    importer.Load();
-                    return importer.DisposeOnGameObjectDestroyed().gameObject;
+                    return importer.Load().gameObject;
                 }
             }
             catch (Exception ex)

--- a/Assets/VRM/Tests/VRMLookAtTests.cs
+++ b/Assets/VRM/Tests/VRMLookAtTests.cs
@@ -24,11 +24,11 @@ namespace VRM
             parser.ParsePath(AliciaPath);
             byte[] bytes = default;
             using (var loader = new VRMImporterContext(parser))
+            using (var loaded = loader.Load())
             {
-                loader.Load();
-                loader.ShowMeshes();
+                loaded.ShowMeshes();
 
-                var go = loader.Root;
+                var go = loaded.gameObject;
                 var fp = go.GetComponent<VRMFirstPerson>();
                 GameObject.DestroyImmediate(go.GetComponent<VRMLookAtBoneApplyer>());
                 var lookAt = go.AddComponent<VRMLookAtBlendShapeApplyer>();
@@ -54,11 +54,11 @@ namespace VRM
             byte[] bytes = default;
             CurveMapper horizontalInner = default;
             using (var loader = new VRMImporterContext(parser))
+            using (var loaded = loader.Load())
             {
-                loader.Load();
-                loader.ShowMeshes();
+                loaded.ShowMeshes();
 
-                var go = loader.Root;
+                var go = loaded.gameObject;
                 var fp = go.GetComponent<VRMFirstPerson>();
                 var lookAt = go.GetComponent<VRMLookAtBoneApplyer>();
                 horizontalInner = lookAt.HorizontalInner;
@@ -71,11 +71,11 @@ namespace VRM
             var parser2 = new GltfParser();
             parser2.Parse(AliciaPath, bytes);
             using (var loader = new VRMImporterContext(parser2))
+            using (var loaded = loader.Load())
             {
-                loader.Load();
-                loader.ShowMeshes();
+                loaded.ShowMeshes();
 
-                var lookAt = loader.Root.GetComponent<VRMLookAtBoneApplyer>();
+                var lookAt = loaded.GetComponent<VRMLookAtBoneApplyer>();
                 Assert.AreEqual(horizontalInner.CurveXRangeDegree, lookAt.HorizontalInner.CurveXRangeDegree);
                 Assert.AreEqual(horizontalInner.CurveYRangeDegree, lookAt.HorizontalInner.CurveYRangeDegree);
             }
@@ -89,11 +89,11 @@ namespace VRM
             byte[] bytes = default;
             CurveMapper horizontalInner = default;
             using (var loader = new VRMImporterContext(parser))
+            using (var loaded = loader.Load())
             {
-                loader.Load();
-                loader.ShowMeshes();
+                loaded.ShowMeshes();
 
-                var go = loader.Root;
+                var go = loaded.gameObject;
                 var fp = go.GetComponent<VRMFirstPerson>();
                 var lookAt = go.GetComponent<VRMLookAtBoneApplyer>();
                 horizontalInner = lookAt.HorizontalInner;
@@ -106,11 +106,11 @@ namespace VRM
             var parser2 = new GltfParser();
             parser2.Parse(AliciaPath, bytes);
             using (var loader = new VRMImporterContext(parser2))
+            using (var loaded = loader.Load())
             {
-                loader.Load();
-                loader.ShowMeshes();
+                loaded.ShowMeshes();
 
-                var lookAt = loader.Root.GetComponent<VRMLookAtBoneApplyer>();
+                var lookAt = loaded.GetComponent<VRMLookAtBoneApplyer>();
                 Assert.AreEqual(horizontalInner.CurveXRangeDegree, lookAt.HorizontalInner.CurveXRangeDegree);
                 Assert.AreEqual(horizontalInner.CurveYRangeDegree, lookAt.HorizontalInner.CurveYRangeDegree);
             }

--- a/Assets/VRM/Tests/VrmDividedMeshTests.cs
+++ b/Assets/VRM/Tests/VrmDividedMeshTests.cs
@@ -26,9 +26,9 @@ namespace VRM
 
             using (var loader = new VRMImporterContext(parser))
             {
-                loader.Load();
-                loader.ShowMeshes();
-                return loader.DisposeOnGameObjectDestroyed().gameObject;
+                var loaded = loader.Load();
+                loaded.ShowMeshes();
+                return loaded.gameObject;
             }
         }
 

--- a/Assets/VRM10.Samples/Runtime/ViewerUI.cs
+++ b/Assets/VRM10.Samples/Runtime/ViewerUI.cs
@@ -308,18 +308,17 @@ namespace UniVRM10.Samples
             {
                 case ".vrm":
                     {
-                        if(!Vrm10Parser.TryParseOrMigrate(path, doMigrate: true, out Vrm10Parser.Result result, out string error))
+                        if (!Vrm10Parser.TryParseOrMigrate(path, doMigrate: true, out Vrm10Parser.Result result, out string error))
                         {
                             Debug.LogError(error);
                             return;
                         }
                         using (var loader = new Vrm10Importer(result.Parser, result.Vrm))
                         {
-                            loader.Load();
-                            loader.ShowMeshes();
-                            loader.EnableUpdateWhenOffscreen();
-                            var destroyer = loader.DisposeOnGameObjectDestroyed();
-                            SetModel(destroyer.gameObject);
+                            var loaded = loader.Load();
+                            loaded.ShowMeshes();
+                            loaded.EnableUpdateWhenOffscreen();
+                            SetModel(loaded.gameObject);
                         }
                         break;
                     }
@@ -332,12 +331,10 @@ namespace UniVRM10.Samples
 
                         using (var loader = new UniGLTF.ImporterContext(parser))
                         {
-                            loader.Load();
-                            loader.ShowMeshes();
-                            loader.EnableUpdateWhenOffscreen();
-                            loader.ShowMeshes();
-                            var destroyer = loader.DisposeOnGameObjectDestroyed();
-                            SetModel(destroyer.gameObject);
+                            var loaded = loader.Load();
+                            loaded.ShowMeshes();
+                            loaded.EnableUpdateWhenOffscreen();
+                            SetModel(loaded.gameObject);
                         }
                         break;
                     }
@@ -350,12 +347,10 @@ namespace UniVRM10.Samples
 
                         using (var loader = new UniGLTF.ImporterContext(parser))
                         {
-                            loader.Load();
-                            loader.ShowMeshes();
-                            loader.EnableUpdateWhenOffscreen();
-                            loader.ShowMeshes();
-                            var destroyer = loader.DisposeOnGameObjectDestroyed();
-                            SetModel(destroyer.gameObject);
+                            var loaded = loader.Load();
+                            loaded.ShowMeshes();
+                            loaded.EnableUpdateWhenOffscreen();
+                            SetModel(loaded.gameObject);
                         }
                         break;
                     }

--- a/Assets/VRM10/Editor/ScriptedImporter/EditorVrm.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/EditorVrm.cs
@@ -15,18 +15,6 @@ namespace UniVRM10
 {
     public static class EditorVrm
     {
-        static ExpressionKey CreateKey(UniGLTF.Extensions.VRMC_vrm.Expression expression)
-        {
-            if (expression.Preset == UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.custom)
-            {
-                return ExpressionKey.CreateCustom(expression.Name);
-            }
-            else
-            {
-                return ExpressionKey.CreateFromPreset(expression.Preset);
-            }
-        }
-
         public static void OnGUI(ScriptedImporter importer, GltfParser parser, UniGLTF.Extensions.VRMC_vrm.VRMC_vrm vrm)
         {
             var hasExternal = importer.GetExternalObjectMap().Any(x => x.Value is VRM10MetaObject || x.Value is VRM10ExpressionAvatar || x.Value is VRM10Expression);
@@ -42,7 +30,7 @@ namespace UniVRM10
             importer.DrawRemapGUI<VRM10MetaObject>(new SubAssetKey[] { VRM10MetaObject.SubAssetKey });
 
             // expressions
-            importer.DrawRemapGUI<VRM10Expression>(vrm.Expressions.Select(x => CreateKey(x).SubAssetKey));
+            importer.DrawRemapGUI<VRM10Expression>(vrm.Expressions.Select(x => ExpressionKey.CreateFromVrm10(x).SubAssetKey));
 
             if (GUILayout.Button("Clear"))
             {

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
@@ -49,9 +49,11 @@ namespace UniVRM10
                 {
                     context.AddObjectToAsset(key.Name, o);
                 });
+                var root = loaded.Root;
+                GameObject.DestroyImmediate(loaded);
 
-                context.AddObjectToAsset(loaded.name, loaded.gameObject);
-                context.SetMainObject(loaded.gameObject);
+                context.AddObjectToAsset(root.name, root);
+                context.SetMainObject(root);
             }
         }
     }

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
@@ -45,7 +45,7 @@ namespace UniVRM10
                 var loaded = loader.Load();
                 loaded.ShowMeshes();
 
-                loader.TransferOwnership((key, o) =>
+                loaded.TransferOwnership((key, o) =>
                 {
                     context.AddObjectToAsset(key.Name, o);
                     return true;

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
@@ -45,9 +45,9 @@ namespace UniVRM10
                 loader.Load();
                 loader.ShowMeshes();
 
-                loader.TransferOwnership(o =>
+                loader.TransferOwnership((key, o) =>
                 {
-                    context.AddObjectToAsset(o.name, o);
+                    context.AddObjectToAsset(key.Name, o);
                     if (o is GameObject)
                     {
                         // Root GameObject is main object

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
@@ -48,7 +48,6 @@ namespace UniVRM10
                 loaded.TransferOwnership((key, o) =>
                 {
                     context.AddObjectToAsset(key.Name, o);
-                    return true;
                 });
 
                 context.AddObjectToAsset(loaded.name, loaded.gameObject);

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
@@ -42,20 +42,17 @@ namespace UniVRM10
                     VRMShaders.TextureImporterConfigurator.Configure(textureInfo, loader.TextureFactory.ExternalTextures);
                 }
 
-                loader.Load();
-                loader.ShowMeshes();
+                var loaded = loader.Load();
+                loaded.ShowMeshes();
 
                 loader.TransferOwnership((key, o) =>
                 {
                     context.AddObjectToAsset(key.Name, o);
-                    if (o is GameObject)
-                    {
-                        // Root GameObject is main object
-                        context.SetMainObject(loader.Root);
-                    }
-
                     return true;
                 });
+
+                context.AddObjectToAsset(loaded.name, loaded.gameObject);
+                context.SetMainObject(loaded.gameObject);
             }
         }
     }

--- a/Assets/VRM10/Runtime/Components/Expression/ExpressionKey.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/ExpressionKey.cs
@@ -133,6 +133,18 @@ namespace UniVRM10
             return new ExpressionKey(clip.Preset, clip.ExpressionName);
         }
 
+        public static ExpressionKey CreateFromVrm10(UniGLTF.Extensions.VRMC_vrm.Expression expression)
+        {
+            if (expression.Preset == UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.custom)
+            {
+                return ExpressionKey.CreateCustom(expression.Name);
+            }
+            else
+            {
+                return ExpressionKey.CreateFromPreset(expression.Preset);
+            }
+        }
+
         public override string ToString()
         {
             return _id.Replace(UnknownPresetPrefix, "");

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using UniGLTF;
 using UnityEngine;
-using VrmLib;
 using VRMShaders;
 
 
@@ -16,7 +14,7 @@ namespace UniVRM10
     /// </summary>
     public class Vrm10Importer : UniGLTF.ImporterContext
     {
-        readonly Model m_model;
+        readonly VrmLib.Model m_model;
 
         UniGLTF.Extensions.VRMC_vrm.VRMC_vrm m_vrm;
 
@@ -54,61 +52,61 @@ namespace UniVRM10
             // assign humanoid bones
             if (m_vrm.Humanoid != null)
             {
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Hips, HumanoidBones.hips);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftUpperLeg, HumanoidBones.leftUpperLeg);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightUpperLeg, HumanoidBones.rightUpperLeg);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLowerLeg, HumanoidBones.leftLowerLeg);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLowerLeg, HumanoidBones.rightLowerLeg);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftFoot, HumanoidBones.leftFoot);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightFoot, HumanoidBones.rightFoot);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Spine, HumanoidBones.spine);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Chest, HumanoidBones.chest);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Neck, HumanoidBones.neck);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Head, HumanoidBones.head);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftShoulder, HumanoidBones.leftShoulder);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightShoulder, HumanoidBones.rightShoulder);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftUpperArm, HumanoidBones.leftUpperArm);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightUpperArm, HumanoidBones.rightUpperArm);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLowerArm, HumanoidBones.leftLowerArm);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLowerArm, HumanoidBones.rightLowerArm);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftHand, HumanoidBones.leftHand);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightHand, HumanoidBones.rightHand);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftToes, HumanoidBones.leftToes);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightToes, HumanoidBones.rightToes);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftEye, HumanoidBones.leftEye);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightEye, HumanoidBones.rightEye);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Jaw, HumanoidBones.jaw);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftThumbProximal, HumanoidBones.leftThumbProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftThumbIntermediate, HumanoidBones.leftThumbIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftThumbDistal, HumanoidBones.leftThumbDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftIndexProximal, HumanoidBones.leftIndexProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftIndexIntermediate, HumanoidBones.leftIndexIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftIndexDistal, HumanoidBones.leftIndexDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftMiddleProximal, HumanoidBones.leftMiddleProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftMiddleIntermediate, HumanoidBones.leftMiddleIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftMiddleDistal, HumanoidBones.leftMiddleDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftRingProximal, HumanoidBones.leftRingProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftRingIntermediate, HumanoidBones.leftRingIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftRingDistal, HumanoidBones.leftRingDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLittleProximal, HumanoidBones.leftLittleProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLittleIntermediate, HumanoidBones.leftLittleIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLittleDistal, HumanoidBones.leftLittleDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightThumbProximal, HumanoidBones.rightThumbProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightThumbIntermediate, HumanoidBones.rightThumbIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightThumbDistal, HumanoidBones.rightThumbDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightIndexProximal, HumanoidBones.rightIndexProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightIndexIntermediate, HumanoidBones.rightIndexIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightIndexDistal, HumanoidBones.rightIndexDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightMiddleProximal, HumanoidBones.rightMiddleProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightMiddleIntermediate, HumanoidBones.rightMiddleIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightMiddleDistal, HumanoidBones.rightMiddleDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightRingProximal, HumanoidBones.rightRingProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightRingIntermediate, HumanoidBones.rightRingIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightRingDistal, HumanoidBones.rightRingDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLittleProximal, HumanoidBones.rightLittleProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLittleIntermediate, HumanoidBones.rightLittleIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLittleDistal, HumanoidBones.rightLittleDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.UpperChest, HumanoidBones.upperChest);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Hips, VrmLib.HumanoidBones.hips);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftUpperLeg, VrmLib.HumanoidBones.leftUpperLeg);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightUpperLeg, VrmLib.HumanoidBones.rightUpperLeg);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLowerLeg, VrmLib.HumanoidBones.leftLowerLeg);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLowerLeg, VrmLib.HumanoidBones.rightLowerLeg);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftFoot, VrmLib.HumanoidBones.leftFoot);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightFoot, VrmLib.HumanoidBones.rightFoot);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Spine, VrmLib.HumanoidBones.spine);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Chest, VrmLib.HumanoidBones.chest);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Neck, VrmLib.HumanoidBones.neck);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Head, VrmLib.HumanoidBones.head);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftShoulder, VrmLib.HumanoidBones.leftShoulder);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightShoulder, VrmLib.HumanoidBones.rightShoulder);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftUpperArm, VrmLib.HumanoidBones.leftUpperArm);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightUpperArm, VrmLib.HumanoidBones.rightUpperArm);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLowerArm, VrmLib.HumanoidBones.leftLowerArm);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLowerArm, VrmLib.HumanoidBones.rightLowerArm);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftHand, VrmLib.HumanoidBones.leftHand);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightHand, VrmLib.HumanoidBones.rightHand);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftToes, VrmLib.HumanoidBones.leftToes);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightToes, VrmLib.HumanoidBones.rightToes);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftEye, VrmLib.HumanoidBones.leftEye);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightEye, VrmLib.HumanoidBones.rightEye);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Jaw, VrmLib.HumanoidBones.jaw);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftThumbProximal, VrmLib.HumanoidBones.leftThumbProximal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftThumbIntermediate, VrmLib.HumanoidBones.leftThumbIntermediate);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftThumbDistal, VrmLib.HumanoidBones.leftThumbDistal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftIndexProximal, VrmLib.HumanoidBones.leftIndexProximal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftIndexIntermediate, VrmLib.HumanoidBones.leftIndexIntermediate);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftIndexDistal, VrmLib.HumanoidBones.leftIndexDistal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftMiddleProximal, VrmLib.HumanoidBones.leftMiddleProximal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftMiddleIntermediate, VrmLib.HumanoidBones.leftMiddleIntermediate);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftMiddleDistal, VrmLib.HumanoidBones.leftMiddleDistal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftRingProximal, VrmLib.HumanoidBones.leftRingProximal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftRingIntermediate, VrmLib.HumanoidBones.leftRingIntermediate);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftRingDistal, VrmLib.HumanoidBones.leftRingDistal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLittleProximal, VrmLib.HumanoidBones.leftLittleProximal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLittleIntermediate, VrmLib.HumanoidBones.leftLittleIntermediate);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLittleDistal, VrmLib.HumanoidBones.leftLittleDistal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightThumbProximal, VrmLib.HumanoidBones.rightThumbProximal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightThumbIntermediate, VrmLib.HumanoidBones.rightThumbIntermediate);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightThumbDistal, VrmLib.HumanoidBones.rightThumbDistal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightIndexProximal, VrmLib.HumanoidBones.rightIndexProximal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightIndexIntermediate, VrmLib.HumanoidBones.rightIndexIntermediate);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightIndexDistal, VrmLib.HumanoidBones.rightIndexDistal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightMiddleProximal, VrmLib.HumanoidBones.rightMiddleProximal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightMiddleIntermediate, VrmLib.HumanoidBones.rightMiddleIntermediate);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightMiddleDistal, VrmLib.HumanoidBones.rightMiddleDistal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightRingProximal, VrmLib.HumanoidBones.rightRingProximal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightRingIntermediate, VrmLib.HumanoidBones.rightRingIntermediate);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightRingDistal, VrmLib.HumanoidBones.rightRingDistal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLittleProximal, VrmLib.HumanoidBones.rightLittleProximal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLittleIntermediate, VrmLib.HumanoidBones.rightLittleIntermediate);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLittleDistal, VrmLib.HumanoidBones.rightLittleDistal);
+                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.UpperChest, VrmLib.HumanoidBones.upperChest);
             }
         }
 
@@ -124,7 +122,7 @@ namespace UniVRM10
         /// <returns></returns>
         readonly ModelMap m_map = new ModelMap();
 
-        static void AssignHumanoid(List<Node> nodes, UniGLTF.Extensions.VRMC_vrm.HumanBone humanBone, VrmLib.HumanoidBones key)
+        static void AssignHumanoid(List<VrmLib.Node> nodes, UniGLTF.Extensions.VRMC_vrm.HumanBone humanBone, VrmLib.HumanoidBones key)
         {
             if (humanBone != null && humanBone.Node.HasValue)
             {
@@ -620,17 +618,17 @@ namespace UniVRM10
             return renderer;
         }
 
-        public override void TransferOwnership(Func<UnityEngine.Object, bool> take)
+        public override void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
             // VRM 固有のリソース(ScriptableObject)
-            if (take(m_humanoid))
+            if (take(default, m_humanoid))
             {
                 m_humanoid = null;
             }
 
             if (m_meta != null)
             {
-                if (take(m_meta))
+                if (take(VRM10MetaObject.SubAssetKey, m_meta))
                 {
                     m_meta = null;
                 }
@@ -638,7 +636,7 @@ namespace UniVRM10
 
             foreach (var x in m_expressions)
             {
-                if (take(x))
+                if (take(ExpressionKey.CreateFromClip(x).SubAssetKey, x))
                 {
                     // do nothing
                 }

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -621,25 +621,19 @@ namespace UniVRM10
         public override void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
             // VRM 固有のリソース(ScriptableObject)
-            if (take(SubAssetKey.Create(m_humanoid), m_humanoid))
-            {
-                m_humanoid = null;
-            }
+            take(SubAssetKey.Create(m_humanoid), m_humanoid);
+            m_humanoid = null;
 
             if (m_meta != null)
             {
-                if (take(VRM10MetaObject.SubAssetKey, m_meta))
-                {
-                    m_meta = null;
-                }
+                take(VRM10MetaObject.SubAssetKey, m_meta);
+                m_meta = null;
             }
 
             foreach (var x in m_expressions)
             {
-                if (take(ExpressionKey.CreateFromClip(x).SubAssetKey, x))
-                {
-                    // do nothing
-                }
+                take(ExpressionKey.CreateFromClip(x).SubAssetKey, x);
+                // do nothing
             }
             m_expressions.Clear();
 

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -649,21 +649,19 @@ namespace UniVRM10
 
         public override void Dispose()
         {
-            Action<UnityEngine.Object> destroy = UnityResourceDestroyer.DestroyResource();
-
             // VRM specific
             if (m_humanoid != null)
             {
-                destroy(m_humanoid);
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(m_humanoid);
             }
             if (m_meta != null)
             {
-                destroy(m_meta);
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(m_meta);
             }
 
             foreach (var clip in m_expressions)
             {
-                destroy(clip);
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(clip);
             }
 
             base.Dispose();

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -621,7 +621,7 @@ namespace UniVRM10
         public override void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
             // VRM 固有のリソース(ScriptableObject)
-            if (take(default, m_humanoid))
+            if (take(SubAssetKey.Create(m_humanoid), m_humanoid))
             {
                 m_humanoid = null;
             }

--- a/Assets/VRM10/Runtime/Scenes/Sample.cs
+++ b/Assets/VRM10/Runtime/Scenes/Sample.cs
@@ -22,9 +22,9 @@ namespace UniVRM10.Sample
 
             using (var loader = new Vrm10Importer(result.Parser, result.Vrm))
             {
-                loader.Load();
-                loader.ShowMeshes();
-                return loader.DisposeOnGameObjectDestroyed().gameObject;
+                var loaded = loader.Load();
+                loaded.ShowMeshes();
+                return loaded.gameObject;
             }
         }
 

--- a/Assets/VRM10/Tests.PlayMode/MaterialTests.cs
+++ b/Assets/VRM10/Tests.PlayMode/MaterialTests.cs
@@ -31,7 +31,7 @@ namespace UniVRM10.Test
         private (GameObject, IReadOnlyList<VRMShaders.MaterialFactory.MaterialLoadInfo>) ToUnity(byte[] bytes)
         {
             // Vrm => Model
-            if(!Vrm10Parser.TryParseOrMigrate("tpm.vrm", bytes, true, out Vrm10Parser.Result result, out string error))
+            if (!Vrm10Parser.TryParseOrMigrate("tpm.vrm", bytes, true, out Vrm10Parser.Result result, out string error))
             {
                 throw new Exception();
             }
@@ -44,9 +44,8 @@ namespace UniVRM10.Test
             // Model => Unity
             using (var loader = new Vrm10Importer(parser, vrm))
             {
-                loader.Load();
-                loader.DisposeOnGameObjectDestroyed();
-                return (loader.Root, loader.MaterialFactory.Materials);
+                var loaded = loader.Load();
+                return (loaded.gameObject, loader.MaterialFactory.Materials);
             }
         }
 

--- a/Assets/VRM10/Tests/ApiSampleTests.cs
+++ b/Assets/VRM10/Tests/ApiSampleTests.cs
@@ -24,13 +24,13 @@ namespace UniVRM10.Test
         {
             using (var loader = new Vrm10Importer(parser, vrm))
             {
-                loader.Load();
+                var loaded = loader.Load();
                 if (showMesh)
                 {
-                    loader.ShowMeshes();
+                    loaded.ShowMeshes();
                 }
-                loader.EnableUpdateWhenOffscreen();
-                return loader.DisposeOnGameObjectDestroyed().gameObject;
+                loaded.EnableUpdateWhenOffscreen();
+                return loaded.gameObject;
             }
         }
 

--- a/Assets/VRMShaders/GLTF/IO/Runtime/IResponsibilityForDestroyObjects.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/IResponsibilityForDestroyObjects.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace VRMShaders
 {
-    public delegate bool TakeResponsibilityForDestroyObjectFunc(UnityEngine.Object obj);
+    public delegate bool TakeResponsibilityForDestroyObjectFunc(SubAssetKey key, UnityEngine.Object obj);
 
     /// <summary>
     /// UnityObjectを破棄する責務。

--- a/Assets/VRMShaders/GLTF/IO/Runtime/IResponsibilityForDestroyObjects.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/IResponsibilityForDestroyObjects.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace VRMShaders
 {
-    public delegate bool TakeResponsibilityForDestroyObjectFunc(SubAssetKey key, UnityEngine.Object obj);
+    public delegate void TakeResponsibilityForDestroyObjectFunc(SubAssetKey key, UnityEngine.Object obj);
 
     /// <summary>
     /// UnityObjectを破棄する責務。

--- a/Assets/VRMShaders/GLTF/IO/Runtime/IResponsibilityForDestroyObjects.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/IResponsibilityForDestroyObjects.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace VRMShaders
+{
+    public delegate bool TakeResponsibilityForDestroyObjectFunc(UnityEngine.Object obj);
+
+    /// <summary>
+    /// UnityObjectを破棄する責務。
+    /// 
+    /// この interface を実装するクラスは、利用後に破棄すべき UnityObject を保持する可能性があるので
+    /// Dispose により解放すること。
+    /// 
+    /// TransferOwnership により、破棄責任を移譲することができる。
+    /// 
+    /// </summary>
+    public interface IResponsibilityForDestroyObjects : IDisposable
+    {
+        void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take);
+    }
+}

--- a/Assets/VRMShaders/GLTF/IO/Runtime/IResponsibilityForDestroyObjects.cs.meta
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/IResponsibilityForDestroyObjects.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93ab2216c7e8c684d84873bd2ae72c6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRMShaders/GLTF/IO/Runtime/KeyValuePariExtensions.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/KeyValuePariExtensions.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace VRMShaders
+{
+    public static class KeyValuePariExtensions
+    {
+        public static void Deconstruct<T, U>(this KeyValuePair<T, U> pair, out T key, out U value)
+        {
+            key = pair.Key;
+            value = pair.Value;
+        }
+    }
+}

--- a/Assets/VRMShaders/GLTF/IO/Runtime/KeyValuePariExtensions.cs.meta
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/KeyValuePariExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7dd6ef3302d21eb4b83c4f8f2c1e47cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRMShaders/GLTF/IO/Runtime/MaterialFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/MaterialFactory.cs
@@ -9,7 +9,7 @@ namespace VRMShaders
 {
     public delegate Task<Texture> GetTextureAsyncFunc(TextureDescriptor texDesc);
 
-    public class MaterialFactory : IDisposable
+    public class MaterialFactory : IResponsibilityForDestroyObjects
     {
         private readonly IReadOnlyDictionary<SubAssetKey, Material> m_externalMap;
 
@@ -79,7 +79,7 @@ namespace VRMShaders
         ///
         /// </summary>
         /// <param name="take"></param>
-        public void TransferOwnership(Func<UnityEngine.Object, bool> take)
+        public void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
             var list = new List<Material>();
             foreach (var x in m_materials)

--- a/Assets/VRMShaders/GLTF/IO/Runtime/MaterialFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/MaterialFactory.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -66,7 +65,7 @@ namespace VRMShaders
 #if VRM_DEVELOP
                     // Debug.Log($"Destroy {x.Asset}");
 #endif
-                    UnityEngine.Object.DestroyImmediate(x.Asset, false);
+                    UnityObjectDestoyer.DestroyRuntimeOrEditor(x.Asset);
                 }
             }
         }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/MaterialFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/MaterialFactory.cs
@@ -30,13 +30,15 @@ namespace VRMShaders
 
         public struct MaterialLoadInfo
         {
+            public SubAssetKey Key;
             public readonly Material Asset;
             public readonly bool UseExternal;
 
             public bool IsSubAsset => !UseExternal;
 
-            public MaterialLoadInfo(Material asset, bool useExternal)
+            public MaterialLoadInfo(SubAssetKey key, Material asset, bool useExternal)
             {
+                Key = key;
                 Asset = asset;
                 UseExternal = useExternal;
             }
@@ -87,7 +89,7 @@ namespace VRMShaders
                 if (!x.UseExternal)
                 {
                     // 外部の '.asset' からロードしていない
-                    if (take(x.Asset))
+                    if (take(x.Key, x.Asset))
                     {
                         list.Add(x.Asset);
                     }
@@ -110,7 +112,7 @@ namespace VRMShaders
         {
             if (m_externalMap.TryGetValue(matDesc.SubAssetKey, out Material material))
             {
-                m_materials.Add(new MaterialLoadInfo(material, true));
+                m_materials.Add(new MaterialLoadInfo(matDesc.SubAssetKey, material, true));
                 return material;
             }
 
@@ -174,7 +176,7 @@ namespace VRMShaders
                 action(material);
             }
 
-            m_materials.Add(new MaterialLoadInfo(material, false));
+            m_materials.Add(new MaterialLoadInfo(matDesc.SubAssetKey, material, false));
 
             return material;
         }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/MaterialFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/MaterialFactory.cs
@@ -82,21 +82,14 @@ namespace VRMShaders
         /// <param name="take"></param>
         public void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
-            var list = new List<Material>();
-            foreach (var x in m_materials)
+            foreach (var x in m_materials.ToArray())
             {
                 if (!x.UseExternal)
                 {
                     // 外部の '.asset' からロードしていない
-                    if (take(x.Key, x.Asset))
-                    {
-                        list.Add(x.Asset);
-                    }
+                    take(x.Key, x.Asset);
+                    m_materials.Remove(x);
                 }
-            }
-            foreach (var x in list)
-            {
-                Remove(x);
             }
         }
 

--- a/Assets/VRMShaders/GLTF/IO/Runtime/SubAssetKey.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/SubAssetKey.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace VRMShaders
@@ -7,15 +6,16 @@ namespace VRMShaders
     /// <summary>
     /// UnityEditor.Experimental.AssetImporter.SourceAssetIdentifier に対応する
     ///
-    /// * SourceAssetIdentifier が UnityEditor なので、 Runtime でも使えるように
+    /// * SourceAssetIdentifier が UnityEditor なので、 Runtime でも使えるように作成
     /// * Type が違うが Name が同じだと警告が出る。例えば、Material と 同じ名前の Texture がある場合。
     /// Identifier uniqueness violation: 'Alicia_body'. Scripted Importers do not guarantee that subsequent imports of this asset will properly re-link to these targets.
-    /// * なので、SourceAssetIdentifier は、$"{Type.Name}.{UnityObject.name}" のように強制的に Unique にするのが良さそう
-    /// * 一方で、Extract したファイル名に $"{Type.Name}." が付属するのは煩わしいのでこれは無しにしたい。
     ///
     /// public void AddRemap(SourceAssetIdentifier identifier, UnityEngine.Object externalObject);
-    ///
-    /// の呼び出し時に、identifier.name と externalObject.name が同じでない運用にしてみる。
+    /// scriptedImporter.GetExternalObjectMap
+    /// 
+    /// に関係する。
+    /// 
+    /// SubAssetKey を新しく作る場所は集約して、不一致が起こらないように注意する
     ///
     /// </summary>
     public readonly struct SubAssetKey : IEquatable<SubAssetKey>
@@ -46,6 +46,11 @@ namespace VRMShaders
 
             Type = MaterialType;
             Name = obj.name;
+        }
+
+        public static SubAssetKey Create<T>(T obj) where T : UnityEngine.Object
+        {
+            return new SubAssetKey(typeof(T), obj.name);
         }
 
         public SubAssetKey(Type type, string name)

--- a/Assets/VRMShaders/GLTF/IO/Runtime/TextureFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/TextureFactory.cs
@@ -46,11 +46,11 @@ namespace VRMShaders
         public void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
             var transferredAssets = new HashSet<SubAssetKey>();
-            foreach (var x in _textureCache)
+            foreach (var (k, v) in _textureCache)
             {
-                if (take(x.Value))
+                if (take(k, v))
                 {
-                    transferredAssets.Add(x.Key);
+                    transferredAssets.Add(k);
                 }
             }
 

--- a/Assets/VRMShaders/GLTF/IO/Runtime/TextureFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/TextureFactory.cs
@@ -45,18 +45,10 @@ namespace VRMShaders
         /// <param name="take"></param>
         public void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
-            var transferredAssets = new HashSet<SubAssetKey>();
-            foreach (var (k, v) in _textureCache)
+            foreach (var (k, v) in _textureCache.ToArray())
             {
-                if (take(k, v))
-                {
-                    transferredAssets.Add(k);
-                }
-            }
-
-            foreach (var key in transferredAssets)
-            {
-                _textureCache.Remove(key);
+                take(k, v);
+                _textureCache.Remove(k);
             }
         }
 

--- a/Assets/VRMShaders/GLTF/IO/Runtime/TextureFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/TextureFactory.cs
@@ -33,7 +33,7 @@ namespace VRMShaders
         {
             foreach (var kv in _temporaryTextures)
             {
-                DestroyResource(kv.Value);
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(kv.Value);
             }
             _temporaryTextures.Clear();
             _textureCache.Clear();
@@ -81,80 +81,68 @@ namespace VRMShaders
             switch (texDesc.TextureType)
             {
                 case TextureImportTypes.NormalMap:
-                {
-                    // no conversion. Unity's normal map is same with glTF's.
-                    //
-                    // > contrary to Unity’s usual convention of using Y as “up”
-                    // https://docs.unity3d.com/2018.4/Documentation/Manual/StandardShaderMaterialParameterNormalMap.html
-                    var data0 = await texDesc.Index0();
-                    var rawTexture = await _textureDeserializer.LoadTextureAsync(data0, texDesc.Sampler.EnableMipMap, ColorSpace.Linear);
-                    rawTexture.name = subAssetKey.Name;
-                    rawTexture.SetSampler(texDesc.Sampler);
-                    _textureCache.Add(subAssetKey, rawTexture);
-                    return rawTexture;
-                }
+                    {
+                        // no conversion. Unity's normal map is same with glTF's.
+                        //
+                        // > contrary to Unity’s usual convention of using Y as “up”
+                        // https://docs.unity3d.com/2018.4/Documentation/Manual/StandardShaderMaterialParameterNormalMap.html
+                        var data0 = await texDesc.Index0();
+                        var rawTexture = await _textureDeserializer.LoadTextureAsync(data0, texDesc.Sampler.EnableMipMap, ColorSpace.Linear);
+                        rawTexture.name = subAssetKey.Name;
+                        rawTexture.SetSampler(texDesc.Sampler);
+                        _textureCache.Add(subAssetKey, rawTexture);
+                        return rawTexture;
+                    }
 
                 case TextureImportTypes.StandardMap:
-                {
-                    Texture2D metallicRoughnessTexture = default;
-                    Texture2D occlusionTexture = default;
-
-                    if (texDesc.Index0 != null)
                     {
-                        var data0 = await texDesc.Index0();
-                        metallicRoughnessTexture = await _textureDeserializer.LoadTextureAsync(data0, texDesc.Sampler.EnableMipMap, ColorSpace.Linear);
-                    }
-                    if (texDesc.Index1 != null)
-                    {
-                        var data1 = await texDesc.Index1();
-                        occlusionTexture = await _textureDeserializer.LoadTextureAsync(data1, texDesc.Sampler.EnableMipMap, ColorSpace.Linear);
-                    }
+                        Texture2D metallicRoughnessTexture = default;
+                        Texture2D occlusionTexture = default;
 
-                    var combinedTexture = OcclusionMetallicRoughnessConverter.Import(metallicRoughnessTexture,
-                        texDesc.MetallicFactor, texDesc.RoughnessFactor, occlusionTexture);
-                    combinedTexture.name = subAssetKey.Name;
-                    combinedTexture.SetSampler(texDesc.Sampler);
-                    _textureCache.Add(subAssetKey, combinedTexture);
-                    DestroyResource(metallicRoughnessTexture);
-                    DestroyResource(occlusionTexture);
-                    return combinedTexture;
-                }
+                        if (texDesc.Index0 != null)
+                        {
+                            var data0 = await texDesc.Index0();
+                            metallicRoughnessTexture = await _textureDeserializer.LoadTextureAsync(data0, texDesc.Sampler.EnableMipMap, ColorSpace.Linear);
+                        }
+                        if (texDesc.Index1 != null)
+                        {
+                            var data1 = await texDesc.Index1();
+                            occlusionTexture = await _textureDeserializer.LoadTextureAsync(data1, texDesc.Sampler.EnableMipMap, ColorSpace.Linear);
+                        }
+
+                        var combinedTexture = OcclusionMetallicRoughnessConverter.Import(metallicRoughnessTexture,
+                            texDesc.MetallicFactor, texDesc.RoughnessFactor, occlusionTexture);
+                        combinedTexture.name = subAssetKey.Name;
+                        combinedTexture.SetSampler(texDesc.Sampler);
+                        _textureCache.Add(subAssetKey, combinedTexture);
+                        UnityObjectDestoyer.DestroyRuntimeOrEditor(metallicRoughnessTexture);
+                        UnityObjectDestoyer.DestroyRuntimeOrEditor(occlusionTexture);
+                        return combinedTexture;
+                    }
 
                 case TextureImportTypes.sRGB:
-                {
-                    var data0 = await texDesc.Index0();
-                    var rawTexture = await _textureDeserializer.LoadTextureAsync(data0, texDesc.Sampler.EnableMipMap, ColorSpace.sRGB);
-                    rawTexture.name = subAssetKey.Name;
-                    rawTexture.SetSampler(texDesc.Sampler);
-                    _textureCache.Add(subAssetKey, rawTexture);
-                    return rawTexture;
-                }
+                    {
+                        var data0 = await texDesc.Index0();
+                        var rawTexture = await _textureDeserializer.LoadTextureAsync(data0, texDesc.Sampler.EnableMipMap, ColorSpace.sRGB);
+                        rawTexture.name = subAssetKey.Name;
+                        rawTexture.SetSampler(texDesc.Sampler);
+                        _textureCache.Add(subAssetKey, rawTexture);
+                        return rawTexture;
+                    }
                 case TextureImportTypes.Linear:
-                {
-                    var data0 = await texDesc.Index0();
-                    var rawTexture = await _textureDeserializer.LoadTextureAsync(data0, texDesc.Sampler.EnableMipMap, ColorSpace.Linear);
-                    rawTexture.name = subAssetKey.Name;
-                    rawTexture.SetSampler(texDesc.Sampler);
-                    _textureCache.Add(subAssetKey, rawTexture);
-                    return rawTexture;
-                }
+                    {
+                        var data0 = await texDesc.Index0();
+                        var rawTexture = await _textureDeserializer.LoadTextureAsync(data0, texDesc.Sampler.EnableMipMap, ColorSpace.Linear);
+                        rawTexture.name = subAssetKey.Name;
+                        rawTexture.SetSampler(texDesc.Sampler);
+                        _textureCache.Add(subAssetKey, rawTexture);
+                        return rawTexture;
+                    }
                 default:
                     throw new ArgumentOutOfRangeException();
             }
 
             throw new NotImplementedException();
-        }
-
-        private static void DestroyResource(UnityEngine.Object o)
-        {
-            if (Application.isPlaying)
-            {
-                UnityEngine.Object.Destroy(o);
-            }
-            else
-            {
-                UnityEngine.Object.DestroyImmediate(o);
-            }
         }
     }
 }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/TextureFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/TextureFactory.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace VRMShaders
 {
-    public class TextureFactory : IDisposable
+    public class TextureFactory : IResponsibilityForDestroyObjects
     {
         private readonly ITextureDeserializer _textureDeserializer;
         private readonly IReadOnlyDictionary<SubAssetKey, Texture> _externalMap;
@@ -43,7 +43,7 @@ namespace VRMShaders
         /// 所有権(Dispose権)を移譲する
         /// </summary>
         /// <param name="take"></param>
-        public void TransferOwnership(Func<UnityEngine.Object, bool> take)
+        public void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take)
         {
             var transferredAssets = new HashSet<SubAssetKey>();
             foreach (var x in _textureCache)

--- a/Assets/VRMShaders/GLTF/IO/Runtime/UnityObjectDestroyer.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/UnityObjectDestroyer.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace VRMShaders
+{
+    public static class UnityObjectDestoyer
+    {
+        public static void DestroyRuntimeOrEditor(UnityEngine.Object o)
+        {
+            if (Application.isPlaying)
+            {
+                UnityEngine.Object.Destroy(o);
+            }
+            else
+            {
+                UnityEngine.Object.DestroyImmediate(o);
+            }
+        }
+    }
+}

--- a/Assets/VRMShaders/GLTF/IO/Runtime/UnityObjectDestroyer.cs.meta
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/UnityObjectDestroyer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b4d1043455aa2c489e9ad8250a80fc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#1018

* DisposeOnGameObjectDestroyed を廃止して、Load 関数から UnityObjectManager が返るようになった。これを Destroy することで 関連リソースは開放される。
* 引き換えに ScriptedImporter のときのみ、UnityObjectManager  から AssetImporter に移動するようになった

新しい使い方は以下のような感じ。
```cs
            // import
            using (var context = new ImporterContext(parser))
            using (var loaded = context.Load()) // すぐ削除する場合。
            {
                loaded.ShowMeshes(); // ImorterContext から移動した
                loaded.EnableUpdateWhenOffscreen(); // ImorterContext から移動した
            }
```

インタフェース。デストロイすべき UnityEngine.Object をため込む

```cs
    public interface IResponsibilityForDestroyObjects : IDisposable
    {
        void TransferOwnership(TakeResponsibilityForDestroyObjectFunc take);
    }
```