### PR TITLE
Fix failing extracting vrm meta file in vrm 1.0 (rarely)

### DIFF
--- a/Assets/VRM10/Editor/ScriptedImporter/EditorVrm.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/EditorVrm.cs
@@ -68,7 +68,7 @@ namespace UniVRM10
 
             // meta
             {
-                var path = GetAndCreateFolder(importer.assetPath, ".vrm1.Meta");
+                var path = GetAndCreateFolder(importer.assetPath, ".vrm1.MetaObject");
                 foreach (var (key, asset) in importer.GetSubAssets<VRM10MetaObject>(importer.assetPath))
                 {
                     asset.ExtractSubAsset($"{path}/{asset.name}.asset", false);


### PR DESCRIPTION
When extracting VRM Meta file, Unity sometimes find `{importer.assetPath}.vrm1` file 's `.meta` file rarely (because Unity's cache strategy?).

So VRM Meta file directory will be named to `{importer.assetPath}.vrm1.MetaObject` .
This name follows vrm 0.x.