### PR TITLE
VRM10Controllerの変数管理を修正

### DIFF
--- a/Assets/VRM10/Editor/Components/LookAt/LookAtEditor.cs
+++ b/Assets/VRM10/Editor/Components/LookAt/LookAtEditor.cs
@@ -9,35 +9,34 @@ namespace UniVRM10
         {
 
         }
-        
-        public static void Draw3D(VRM10Controller target)
+
+        public static void Draw3D(VRM10Controller target, Transform head)
         {
-            if(target==null)
+            if (target == null)
             {
                 return;
             }
-            OnSceneGUIOffset(target);
+            if (head == null)
+            {
+                return;
+            }
+
+            OnSceneGUIOffset(target, head);
             if (!Application.isPlaying)
             {
                 // offset
                 var p = target.LookAt.OffsetFromHead;
-                Handles.Label(target.Head.position, $"fromHead: [{p.x:0.00}, {p.y:0.00}, {p.z:0.00}]");
+                Handles.Label(head.position, $"fromHead: [{p.x:0.00}, {p.y:0.00}, {p.z:0.00}]");
             }
             else
             {
-                target.LookAt.OnSceneGUILookAt(target.Head);
+                target.LookAt.OnSceneGUILookAt(head);
             }
         }
 
-        static void OnSceneGUIOffset(VRM10Controller m_target)
+        static void OnSceneGUIOffset(VRM10Controller m_target, Transform head)
         {
             if (!m_target.LookAt.DrawGizmo)
-            {
-                return;
-            }
-
-            var head = m_target.Head;
-            if (head == null)
             {
                 return;
             }

--- a/Assets/VRM10/Editor/Components/VRM10ControllerEditor.cs
+++ b/Assets/VRM10/Editor/Components/VRM10ControllerEditor.cs
@@ -75,12 +75,6 @@ namespace UniVRM10
                 EditorGUILayout.Separator();
             }
 
-            // Setup runtime function.
-            if (UnityEngine.Application.isPlaying)
-            {
-                m_target.Setup();
-            }
-
             serializedObject.Update();
             switch (_tab)
             {

--- a/Assets/VRM10/Editor/Components/VRM10Window.cs
+++ b/Assets/VRM10/Editor/Components/VRM10Window.cs
@@ -62,10 +62,14 @@ namespace UniVRM10
                 }
                 m_root = id;
                 m_so = value != null ? new SerializedObject(value) : null;
-
                 m_constraints = null;
+
+                var animator = Root.GetComponent<Animator>();
+                m_head = animator.GetBoneTransform(HumanBodyBones.Head);
             }
         }
+
+        Transform m_head;
 
         public VRM10Constraint[] m_constraints;
 
@@ -105,7 +109,7 @@ namespace UniVRM10
 
                 case VRMSceneUI.LookAt:
                     Tools.hidden = true;
-                    LookAtEditor.Draw3D(Root);
+                    LookAtEditor.Draw3D(Root, m_head);
                     break;
 
                 case VRMSceneUI.SpringBone:

--- a/Assets/VRM10/Runtime/Components/VRM10Controller.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Controller.cs
@@ -58,27 +58,6 @@ namespace UniVRM10
             }
         }
 
-        VRM10Constraint[] m_constraints;
-
-        Transform m_head;
-        public Transform Head
-        {
-            get
-            {
-                if (m_head == null)
-                {
-                    m_head = GetComponent<Animator>().GetBoneTransform(HumanBodyBones.Head);
-                }
-                return m_head;
-            }
-        }
-
-        void Reset()
-        {
-            var animator = GetComponent<Animator>();
-            m_head = animator.GetBoneTransform(HumanBodyBones.Head);
-        }
-
         private void OnValidate()
         {
             if (LookAt != null)
@@ -90,65 +69,22 @@ namespace UniVRM10
             }
         }
 
-        public void Setup()
-        {
-            var animator = GetComponent<Animator>();
-            if (animator == null) return;
+        VRM10ControllerRuntime m_runtime;
 
-            m_head = animator.GetBoneTransform(HumanBodyBones.Head);
-            LookAt.Setup(animator, m_head);
-            Expression.Setup(transform, LookAt, LookAt.EyeDirectionApplicable);
-        }
-
-        /// <summary>
-        /// 毎フレーム関連コンポーネントを解決する
-        /// 
-        /// * Contraint
-        /// * Spring
-        /// * LookAt
-        /// * Expression
-        /// 
-        /// </summary>
-        public void Process()
+        VRM10ControllerRuntime GetOrCreate()
         {
-            // 
-            // constraint
-            //
-            if (m_constraints == null)
+            if (m_runtime == null)
             {
-                m_constraints = GetComponentsInChildren<VRM10Constraint>();
+                m_runtime = new VRM10ControllerRuntime(this);
             }
-            foreach (var constraint in m_constraints)
-            {
-                constraint.Process();
-            }
-
-            //
-            // spring
-            //
-            SpringBone.Process(Controller.SpringBoneCenter);
-
-            //
-            // gaze control
-            //
-            LookAt.Process();
-
-            //
-            // expression
-            //
-            Expression.Process();
-        }
-
-        private void Start()
-        {
-            Setup();
+            return m_runtime;
         }
 
         private void Update()
         {
             if (Controller.UpdateType == VRM10ControllerImpl.UpdateTypes.Update)
             {
-                Process();
+                GetOrCreate().Process();
             }
         }
 
@@ -156,7 +92,7 @@ namespace UniVRM10
         {
             if (Controller.UpdateType == VRM10ControllerImpl.UpdateTypes.LateUpdate)
             {
-                Process();
+                GetOrCreate().Process();
             }
         }
     }

--- a/Assets/VRM10/Runtime/Components/VRM10ControllerRuntime.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10ControllerRuntime.cs
@@ -1,0 +1,68 @@
+using System;
+using UnityEngine;
+
+namespace UniVRM10
+{
+    /// <summary>
+    /// Play時 と Editorからの参照情報置き場
+    /// </summary>
+    class VRM10ControllerRuntime
+    {
+        VRM10Controller m_target;
+        VRM10Constraint[] m_constraints;
+        Transform m_head;
+
+        public VRM10ControllerRuntime(VRM10Controller target)
+        {
+            m_target = target;
+            var animator = target.GetComponent<Animator>();
+            if (animator == null)
+            {
+                throw new Exception();
+            }
+            m_head = animator.GetBoneTransform(HumanBodyBones.Head);
+            target.LookAt.Setup(animator, m_head);
+            target.Expression.Setup(target.transform, target.LookAt, target.LookAt.EyeDirectionApplicable);
+
+            if (m_constraints == null)
+            {
+                m_constraints = target.GetComponentsInChildren<VRM10Constraint>();
+            }
+        }
+
+        /// <summary>
+        /// 毎フレーム関連コンポーネントを解決する
+        /// 
+        /// * Contraint
+        /// * Spring
+        /// * LookAt
+        /// * Expression
+        /// 
+        /// </summary>
+        public void Process()
+        {
+            // 
+            // constraint
+            //
+            foreach (var constraint in m_constraints)
+            {
+                constraint.Process();
+            }
+
+            //
+            // spring
+            //
+            m_target.SpringBone.Process(m_target.Controller.SpringBoneCenter);
+
+            //
+            // gaze control
+            //
+            m_target.LookAt.Process();
+
+            //
+            // expression
+            //
+            m_target.Expression.Process();
+        }
+    }
+}

--- a/Assets/VRM10/Runtime/Components/VRM10ControllerRuntime.cs.meta
+++ b/Assets/VRM10/Runtime/Components/VRM10ControllerRuntime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebbe3112f524c99438364defdc03e140
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* runtime 変数置き場を隔離して、初期化を遅延
* Editor 用の変数の初期化を分離。

VRM10Controller.Reset, Start, Setup を整理。
