### PR TITLE
Disable "AutoReferenced" in all asmdefs.

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF.Editor.asmdef
+++ b/Assets/UniGLTF/Editor/UniGLTF.Editor.asmdef
@@ -2,11 +2,10 @@
     "name": "UniGLTF.Editor",
     "references": [
         "UniGLTF",
-        "MeshUtility",
-        "MeshUtility.Editor",
         "VRMShaders.GLTF.IO.Runtime",
         "VRMShaders.GLTF.IO.Editor"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -14,8 +13,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "autoReferenced": false,
+    "defineConstraints": []
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF.asmdef
+++ b/Assets/UniGLTF/Runtime/UniGLTF.asmdef
@@ -4,13 +4,12 @@
         "VRMShaders.GLTF.IO.Runtime",
         "VRMShaders.GLTF.UniUnlit.Runtime"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "autoReferenced": false,
+    "defineConstraints": []
 }

--- a/Assets/UniGLTF/Tests/UniGLTF.Tests.asmdef
+++ b/Assets/UniGLTF/Tests/UniGLTF.Tests.asmdef
@@ -14,7 +14,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
+    "overrideReferences": false,
     "precompiledReferences": [
         "nunit.framework.dll"
     ],

--- a/Assets/UniGLTF/UniHumanoid/Editor/Tests/UniHumanoid.Editor.Tests.asmdef
+++ b/Assets/UniGLTF/UniHumanoid/Editor/Tests/UniHumanoid.Editor.Tests.asmdef
@@ -11,5 +11,9 @@
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": []
 }

--- a/Assets/UniGLTF/UniHumanoid/Editor/UniHumanoid.Editor.asmdef
+++ b/Assets/UniGLTF/UniHumanoid/Editor/UniHumanoid.Editor.asmdef
@@ -9,5 +9,9 @@
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": []
 }

--- a/Assets/UniGLTF/UniHumanoid/UniHumanoid.asmdef
+++ b/Assets/UniGLTF/UniHumanoid/UniHumanoid.asmdef
@@ -1,3 +1,12 @@
-﻿{
-	"name": "UniHumanoid"
+{
+    "name": "UniHumanoid",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": []
 }

--- a/Assets/VRM.Samples/Editor/Tests/VRM.Samples.Editor.Tests.asmdef
+++ b/Assets/VRM.Samples/Editor/Tests/VRM.Samples.Editor.Tests.asmdef
@@ -3,7 +3,6 @@
     "references": [
         "VRM",
         "VRM.Samples",
-        "MeshUtility",
         "UniGLTF",
         "UniVRM.Editor",
         "VRM.Tests",
@@ -18,7 +17,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
+    "overrideReferences": false,
     "precompiledReferences": [
         "nunit.framework.dll"
     ],

--- a/Assets/VRM.Samples/VRM.Samples.asmdef
+++ b/Assets/VRM.Samples/VRM.Samples.asmdef
@@ -12,6 +12,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": []
 }

--- a/Assets/VRM/Editor/VRM.Editor.asmdef
+++ b/Assets/VRM/Editor/VRM.Editor.asmdef
@@ -3,13 +3,12 @@
     "references": [
         "VRM",
         "UniHumanoid",
-        "MeshUtility",
-        "MeshUtility.Editor",
         "VRMShaders.GLTF.IO.Runtime",
         "VRMShaders.GLTF.IO.Editor",
         "UniGLTF",
         "UniGLTF.Editor"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -17,8 +16,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "autoReferenced": false,
+    "defineConstraints": []
 }

--- a/Assets/VRM/Runtime/VRM.asmdef
+++ b/Assets/VRM/Runtime/VRM.asmdef
@@ -13,6 +13,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": []
 }

--- a/Assets/VRM/Tests/VRM.Tests.asmdef
+++ b/Assets/VRM/Tests/VRM.Tests.asmdef
@@ -16,7 +16,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
+    "overrideReferences": false,
     "precompiledReferences": [
         "nunit.framework.dll"
     ],

--- a/Assets/VRM10.Samples/Runtime/VRM10.Samples.Runtime.asmdef
+++ b/Assets/VRM10.Samples/Runtime/VRM10.Samples.Runtime.asmdef
@@ -6,13 +6,12 @@
         "VRM10",
         "UniHumanoid"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }

--- a/Assets/VRM10/Editor/VRM10.Editor.asmdef
+++ b/Assets/VRM10/Editor/VRM10.Editor.asmdef
@@ -3,13 +3,12 @@
     "references": [
         "VRM10",
         "VrmLib",
-        "MeshUtility",
-        "MeshUtility.Editor",
         "UniGLTF.Editor",
         "UniGLTF",
         "VRMShaders.GLTF.IO.Runtime",
         "VRMShaders.GLTF.IO.Editor"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -17,8 +16,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "autoReferenced": false,
+    "defineConstraints": []
 }

--- a/Assets/VRM10/Runtime/VRM10.asmdef
+++ b/Assets/VRM10/Runtime/VRM10.asmdef
@@ -15,6 +15,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": []
 }

--- a/Assets/VRM10/Tests.PlayMode/VRM10.Tests.PlayMode.asmdef
+++ b/Assets/VRM10/Tests.PlayMode/VRM10.Tests.PlayMode.asmdef
@@ -12,7 +12,7 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
+    "overrideReferences": false,
     "precompiledReferences": [
         "nunit.framework.dll"
     ],

--- a/Assets/VRM10/Tests/VRM10.Tests.asmdef
+++ b/Assets/VRM10/Tests/VRM10.Tests.asmdef
@@ -15,13 +15,10 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "overrideReferences": false,
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
-        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
     ]
 }

--- a/Assets/VRM10/vrmlib/Runtime/VrmLib.asmdef
+++ b/Assets/VRM10/vrmlib/Runtime/VrmLib.asmdef
@@ -9,6 +9,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": []
 }

--- a/Assets/VRM10/vrmlib/Tests/VrmLib.Tests.asmdef
+++ b/Assets/VRM10/vrmlib/Tests/VrmLib.Tests.asmdef
@@ -11,7 +11,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
+    "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Assets/VRMShaders/GLTF/IO/Tests/VRMShaders.GLTF.IO.Tests.asmdef
+++ b/Assets/VRMShaders/GLTF/IO/Tests/VRMShaders.GLTF.IO.Tests.asmdef
@@ -12,7 +12,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
+    "overrideReferences": false,
     "precompiledReferences": [
         "nunit.framework.dll"
     ],

--- a/Assets/VRMShaders/GLTF/UniUnlit/Editor/VRMShaders.GLTF.UniUnlit.Editor.asmdef
+++ b/Assets/VRMShaders/GLTF/UniUnlit/Editor/VRMShaders.GLTF.UniUnlit.Editor.asmdef
@@ -3,6 +3,7 @@
     "references": [
         "VRMShaders.GLTF.UniUnlit.Runtime"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -11,7 +12,5 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }

--- a/Assets/VRMShaders/GLTF/UniUnlit/Runtime/VRMShaders.GLTF.UniUnlit.Runtime.asmdef
+++ b/Assets/VRMShaders/GLTF/UniUnlit/Runtime/VRMShaders.GLTF.UniUnlit.Runtime.asmdef
@@ -1,13 +1,12 @@
 {
     "name": "VRMShaders.GLTF.UniUnlit.Runtime",
     "references": [],
+    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }

--- a/Assets/VRMShaders/VRM/IO/Editor/VRMShaders.VRM.IO.Editor.asmdef
+++ b/Assets/VRMShaders/VRM/IO/Editor/VRMShaders.VRM.IO.Editor.asmdef
@@ -3,6 +3,7 @@
     "references": [
         "VRMShaders.VRM.IO.Runtime"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -11,7 +12,5 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }

--- a/Assets/VRMShaders/VRM/IO/Runtime/VRMShaders.VRM.IO.Runtime.asmdef
+++ b/Assets/VRMShaders/VRM/IO/Runtime/VRMShaders.VRM.IO.Runtime.asmdef
@@ -1,13 +1,12 @@
 {
     "name": "VRMShaders.VRM.IO.Runtime",
     "references": [],
+    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }

--- a/Assets/VRMShaders/VRM10/Format/Runtime/VRMShaders.VRM10.Format.Runtime.asmdef
+++ b/Assets/VRMShaders/VRM10/Format/Runtime/VRMShaders.VRM10.Format.Runtime.asmdef
@@ -1,13 +1,12 @@
 {
     "name": "VRMShaders.VRM10.Format.Runtime",
     "references": [],
+    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }

--- a/Assets/VRMShaders/VRM10/MToon10/Editor/VRMShaders.VRM10.MToon10.Editor.asmdef
+++ b/Assets/VRMShaders/VRM10/MToon10/Editor/VRMShaders.VRM10.MToon10.Editor.asmdef
@@ -3,6 +3,7 @@
     "references": [
         "VRMShaders.VRM10.MToon10.Runtime"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -11,7 +12,5 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/VRMShaders.VRM10.MToon10.Runtime.asmdef
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/VRMShaders.VRM10.MToon10.Runtime.asmdef
@@ -1,13 +1,12 @@
 {
     "name": "VRMShaders.VRM10.MToon10.Runtime",
     "references": [],
+    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }


### PR DESCRIPTION
AutoReferenced を Disable にすることで、モジュールの参照関係が逆転するなどの事故を防ぐ