### PR TITLE
Export 時に default 値の TRS を出力しない

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF/Serialization/SerializerGenerator.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/Serialization/SerializerGenerator.cs
@@ -16,6 +16,7 @@ namespace UniGLTF
         const string Begin = @"using System;
 using System.Collections.Generic;
 using UniJSON;
+using System.Linq;
 
 namespace UniGLTF {
 
@@ -34,7 +35,7 @@ namespace UniGLTF {
             get
             {
                 return Path.Combine(UnityEngine.Application.dataPath,
-                "UniGLTF/UniGLTF/Scripts/IO/GltfSerializer.g.cs");
+                "UniGLTF/Runtime/UniGLTF/Format/GltfSerializer.g.cs");
             }
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/GltfSerializer.g.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/GltfSerializer.g.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UniJSON;
+using System.Linq;
 
 namespace UniGLTF {
 
@@ -1121,7 +1122,7 @@ public static void Serialize_gltf_nodes_ITEM(JsonFormatter f, glTFNode value)
         Serialize_gltf_nodes__matrix(f, value.matrix);
     }
 
-    if(value.translation!=null&&value.translation.Length>=3){
+    if(value.translation!=null&&value.translation.Length>=3&&!value.translation.SequenceEqual(new float[]{0, 0, 0})){
         f.Key("translation");                
         Serialize_gltf_nodes__translation(f, value.translation);
     }

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/GltfSerializer.g.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/GltfSerializer.g.cs
@@ -1127,12 +1127,12 @@ public static void Serialize_gltf_nodes_ITEM(JsonFormatter f, glTFNode value)
         Serialize_gltf_nodes__translation(f, value.translation);
     }
 
-    if(value.rotation!=null&&value.rotation.Length>=4){
+    if(value.rotation!=null&&value.rotation.Length>=4&&!value.rotation.SequenceEqual(new float[]{0, 0, 0, 1})){
         f.Key("rotation");                
         Serialize_gltf_nodes__rotation(f, value.rotation);
     }
 
-    if(value.scale!=null&&value.scale.Length>=3){
+    if(value.scale!=null&&value.scale.Length>=3&&!value.scale.SequenceEqual(new float[]{1, 1, 1})){
         f.Key("scale");                
         Serialize_gltf_nodes__scale(f, value.scale);
     }

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/glTFNode.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/glTFNode.cs
@@ -17,7 +17,7 @@ namespace UniGLTF
         [JsonSchema(MinItems = 16, MaxItems = 16)]
         public float[] matrix;
 
-        [JsonSchema(MinItems = 3, MaxItems = 3)]
+        [JsonSchema(MinItems = 3, MaxItems = 3, SerializationConditions = new string[] { "!value.translation.SequenceEqual(new float[]{0, 0, 0})" })]
         public float[] translation;
 
         [JsonSchema(MinItems = 4, MaxItems = 4)]

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/glTFNode.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/glTFNode.cs
@@ -20,11 +20,11 @@ namespace UniGLTF
         [JsonSchema(MinItems = 3, MaxItems = 3, SerializationConditions = new string[] { "!value.translation.SequenceEqual(new float[]{0, 0, 0})" })]
         public float[] translation;
 
-        [JsonSchema(MinItems = 4, MaxItems = 4)]
+        [JsonSchema(MinItems = 4, MaxItems = 4, SerializationConditions = new string[] { "!value.rotation.SequenceEqual(new float[]{0, 0, 0, 1})" })]
         [ItemJsonSchema(Minimum = -1.0, Maximum = 1.0)]
         public float[] rotation;
 
-        [JsonSchema(MinItems = 3, MaxItems = 3)]
+        [JsonSchema(MinItems = 3, MaxItems = 3, SerializationConditions = new string[] { "!value.scale.SequenceEqual(new float[]{1, 1, 1})" })]
         public float[] scale;
 
         [JsonSchema(Minimum = 0, ExplicitIgnorableValue = -1)]


### PR DESCRIPTION
#1059

```json
    {
      "name": "1",
      "translation": [
        0,
        0,
        0
      ],
      "rotation": [
        0,
        0,
        0,
        1
      ],
      "scale": [
        1,
        1,
        1
      ]
    }
```

👇

```json
    {
      "name": "1"
    }
```
