### PR TITLE
Add migration code about legacy roughness texture behaviour.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
@@ -25,6 +25,7 @@ namespace UniGLTF
         /// </summary>
         public IStorage Storage;
 
+        public MigrationFlags MigrationFlags = new MigrationFlags();
 
         #region Parse
         public void ParsePath(string path)
@@ -226,7 +227,7 @@ namespace UniGLTF
                 var gltfImage = GLTF.images[gltfTexture.source];
                 if (!string.IsNullOrEmpty(gltfImage.uri) && !gltfImage.uri.StartsWith("data:"))
                 {
-                    // from image uri                    
+                    // from image uri
                     gltfTexture.name = Path.GetFileNameWithoutExtension(gltfImage.uri);
                 }
                 if (string.IsNullOrEmpty(gltfTexture.name))
@@ -284,7 +285,7 @@ namespace UniGLTF
                 {
                     if (used.Add(material.name))
                     {
-#if VRM_DEVELOP                        
+#if VRM_DEVELOP
                         // Debug.Log($"Material: {material.name}");
 #endif
                         break;
@@ -327,7 +328,7 @@ namespace UniGLTF
                 {
                     if (used.Add(animation.name))
                     {
-#if VRM_DEVELOP                        
+#if VRM_DEVELOP
                         // Debug.Log($"Material: {material.name}");
 #endif
                         break;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -32,7 +32,8 @@ namespace UniGLTF
 
             TextureFactory = new TextureFactory(textureDeserializer, _externalObjectMap
                 .Where(x => x.Value is Texture)
-                .ToDictionary(x => x.Key, x => (Texture)x.Value));
+                .ToDictionary(x => x.Key, x => (Texture)x.Value),
+                Parser.MigrationFlags.IsRoughnessTextureValueSquared);
             MaterialFactory = new MaterialFactory(_externalObjectMap
                 .Where(x => x.Value is Material)
                 .ToDictionary(x => x.Key, x => (Material)x.Value));

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MigrationFlags.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MigrationFlags.cs
@@ -1,0 +1,10 @@
+﻿namespace UniGLTF
+{
+    public sealed class MigrationFlags
+    {
+        /// <summary>
+        /// Before UniGLTF v0.69, roughness value in the texture was invalid squared value.
+        /// </summary>
+        public bool IsRoughnessTextureValueSquared { get; set; } = false;
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MigrationFlags.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MigrationFlags.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8a9174a8f8ee45dc948d93c5e8af5714
+timeCreated: 1624359107

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Shaders/StandardMapImporter.shader
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Shaders/StandardMapImporter.shader
@@ -7,6 +7,7 @@
           _GltfRoughnessFactor ("glTF Roughness Factor", Float) = 0.0
           _GltfMetallicRoughnessTexture ("glTF Metallic Roughness Texture", 2D) = "black" {}
           _GltfOcclusionTexture ("glTF Occlusion Texture", 2D) = "black" {}
+          _IsLegacySquaredRoughness ("Is UniGLTF Legacy Squared Roughness", Float) = 0.0
      }
      SubShader
      {
@@ -46,6 +47,7 @@
                half _GltfRoughnessFactor;
                sampler2D _GltfMetallicRoughnessTexture;
                sampler2D _GltfOcclusionTexture;
+               half _IsLegacySquaredRoughness;
 
                fixed4 frag (v2f i) : SV_Target
                {
@@ -55,6 +57,12 @@
                     half occlusion = occlusionTex.r; // R: glTF Occlusion
                     half roughness = metallicRoughnessTex.g * _GltfRoughnessFactor; // G: glTF Roughness
                     half metallic = metallicRoughnessTex.b * _GltfMetallicFactor; // B: glTF Metallic
+
+                    // MIGRATION code: legacy behaviour
+                    if (_IsLegacySquaredRoughness == 1.0)
+                    {
+                         roughness = sqrt(roughness);
+                    }
 
                     fixed4 result;
                     result.r = metallic;  // R: Unity Metallic

--- a/Assets/VRMShaders/GLTF/IO/Runtime/OcclusionMetallicRoughnessConverter.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/OcclusionMetallicRoughnessConverter.cs
@@ -34,8 +34,14 @@ namespace VRMShaders
             }
         }
 
+        /// <summary>
+        /// Import glTF Metallic-Roughness texture to Unity Metallic-Smoothness-Occlusion texture.
+        ///
+        /// isLegacySquaredRoughness:
+        ///     Before UniGLTF v0.69, roughness value in the texture was invalid squared value.
+        /// </summary>
         public static Texture2D Import(Texture2D metallicRoughnessTexture,
-            float metallicFactor, float roughnessFactor, Texture2D occlusionTexture)
+            float metallicFactor, float roughnessFactor, Texture2D occlusionTexture, bool isLegacySquaredRoughness)
         {
             if (metallicRoughnessTexture == null && occlusionTexture == null)
             {
@@ -49,6 +55,7 @@ namespace VRMShaders
             Exporter.SetTexture("_GltfOcclusionTexture", occlusionTexture);
             Exporter.SetFloat("_GltfMetallicFactor", metallicFactor);
             Exporter.SetFloat("_GltfRoughnessFactor", roughnessFactor);
+            Exporter.SetFloat("_IsLegacySquaredRoughness", isLegacySquaredRoughness ? 1 : 0);
 
             var dst = TextureConverter.CopyTexture(src, ColorSpace.Linear, true, Exporter);
 
@@ -57,6 +64,7 @@ namespace VRMShaders
             Exporter.SetTexture("_GltfOcclusionTexture", null);
             Exporter.SetFloat("_GltfMetallicFactor", 0);
             Exporter.SetFloat("_GltfRoughnessFactor", 0);
+            Exporter.SetFloat("_IsLegacySquaredRoughness", 0);
 
             return dst;
         }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/TextureFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/TextureFactory.cs
@@ -10,6 +10,7 @@ namespace VRMShaders
     {
         private readonly ITextureDeserializer _textureDeserializer;
         private readonly IReadOnlyDictionary<SubAssetKey, Texture> _externalMap;
+        private readonly bool _isLegacySquaredRoughness;
         private readonly Dictionary<SubAssetKey, Texture> _temporaryTextures = new Dictionary<SubAssetKey, Texture>();
         private readonly Dictionary<SubAssetKey, Texture> _textureCache = new Dictionary<SubAssetKey, Texture>();
 
@@ -23,10 +24,14 @@ namespace VRMShaders
         /// </summary>
         public IReadOnlyDictionary<SubAssetKey, Texture> ExternalTextures => _externalMap;
 
-        public TextureFactory(ITextureDeserializer textureDeserializer, IReadOnlyDictionary<SubAssetKey, Texture> externalTextures)
+        public TextureFactory(
+            ITextureDeserializer textureDeserializer,
+            IReadOnlyDictionary<SubAssetKey, Texture> externalTextures,
+            bool isLegacySquaredRoughness)
         {
             _textureDeserializer = textureDeserializer;
             _externalMap = externalTextures;
+            _isLegacySquaredRoughness = isLegacySquaredRoughness;
         }
 
         public void Dispose()
@@ -103,7 +108,7 @@ namespace VRMShaders
                         }
 
                         var combinedTexture = OcclusionMetallicRoughnessConverter.Import(metallicRoughnessTexture,
-                            texDesc.MetallicFactor, texDesc.RoughnessFactor, occlusionTexture);
+                            texDesc.MetallicFactor, texDesc.RoughnessFactor, occlusionTexture, _isLegacySquaredRoughness);
                         combinedTexture.name = subAssetKey.Name;
                         combinedTexture.SetSampler(texDesc.Sampler);
                         _textureCache.Add(subAssetKey, combinedTexture);

--- a/Assets/VRMShaders/GLTF/IO/Tests/MetallicRoughnessConverterTests.cs
+++ b/Assets/VRMShaders/GLTF/IO/Tests/MetallicRoughnessConverterTests.cs
@@ -20,7 +20,8 @@ namespace VRMShaders
                 metallicRoughnessTexture,
                 metallicFactor,
                 roughnessFactor,
-                occlusionTexture
+                occlusionTexture,
+                false
             );
 
             var result = converted.GetPixels32()[0];


### PR DESCRIPTION
UniGLTF v0.69 未満の場合に Roughness Texture が二乗されて格納されていた。それを加味できるコードを追加。
実際には判定する材料が足りないので自動では行わない