### PR TITLE
Allow referencing additional chunks.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/glbTypes.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/glbTypes.cs
@@ -52,26 +52,28 @@ namespace UniGLTF
 
     public struct GlbChunk
     {
-        public GlbChunkType ChunkType;
+        public GlbChunkType ChunkType => ChunkTypeString.ToChunkType();
+
+        public string ChunkTypeString;
         public ArraySegment<Byte> Bytes;
 
         public GlbChunk(string json) : this(
-            GlbChunkType.JSON,
+            GlbChunkType.JSON.ToChunkTypeString(),
             new ArraySegment<byte>(Encoding.UTF8.GetBytes(json))
             )
         {
         }
 
         public GlbChunk(ArraySegment<Byte> bytes) : this(
-            GlbChunkType.BIN,
+            GlbChunkType.BIN.ToChunkTypeString(),
             bytes
             )
         {
         }
 
-        public GlbChunk(GlbChunkType type, ArraySegment<Byte> bytes)
+        public GlbChunk(string chunkTypeString, ArraySegment<Byte> bytes)
         {
-            ChunkType = type;
+            ChunkTypeString = chunkTypeString;
             Bytes = bytes;
         }
 
@@ -82,12 +84,12 @@ namespace UniGLTF
 
         public static GlbChunk CreateJson(ArraySegment<byte> bytes)
         {
-            return new GlbChunk(GlbChunkType.JSON, bytes);
+            return new GlbChunk(GlbChunkType.JSON.ToChunkTypeString(), bytes);
         }
 
         public static GlbChunk CreateBin(ArraySegment<Byte> bytes)
         {
-            return new GlbChunk(GlbChunkType.BIN, bytes);
+            return new GlbChunk(GlbChunkType.BIN.ToChunkTypeString(), bytes);
         }
 
         byte GetPaddingByte()
@@ -152,7 +154,7 @@ namespace UniGLTF
     }
 
     /// <summary>
-    /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification 
+    /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification
     /// </summary>
     public struct Glb
     {
@@ -267,12 +269,11 @@ namespace UniGLTF
                     //var type = (GlbChunkType)BitConverter.ToUInt32(bytes, pos);
                     var chunkTypeBytes = bytes.Slice(pos, 4).Where(x => x != 0).ToArray();
                     var chunkTypeStr = Encoding.ASCII.GetString(chunkTypeBytes);
-                    var type = ToChunkType(chunkTypeStr);
                     pos += 4;
 
                     chunks.Add(new GlbChunk
                     {
-                        ChunkType = type,
+                        ChunkTypeString = chunkTypeStr,
                         Bytes = bytes.Slice(pos, chunkDataSize)
                     });
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfParser.cs
@@ -86,7 +86,7 @@ namespace UniGLTF
         {
             var chunks = glbImporter.ParseGlbChunks(bytes);
 
-            if (chunks.Count != 2)
+            if (chunks.Count < 2)
             {
                 throw new Exception("unknown chunk count: " + chunks.Count);
             }
@@ -106,6 +106,8 @@ namespace UniGLTF
                 var jsonBytes = chunks[0].Bytes;
                 ParseJson(Encoding.UTF8.GetString(jsonBytes.Array, jsonBytes.Offset, jsonBytes.Count),
                     new SimpleStorage(chunks[1].Bytes));
+
+                ParseExternalChunks(bytes, chunks);
             }
             catch (StackOverflowException ex)
             {
@@ -115,6 +117,11 @@ namespace UniGLTF
             {
                 throw;
             }
+        }
+
+        protected virtual void ParseExternalChunks(byte[] bytes, IReadOnlyList<GlbChunk> chunks)
+        {
+
         }
 
         public virtual void ParseJson(string json, IStorage storage)

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/glbImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/glbImporter.cs
@@ -12,7 +12,7 @@ namespace UniGLTF
         public const string GLB_MAGIC = "glTF";
         public const float GLB_VERSION = 2.0f;
 
-        public static GlbChunkType ToChunkType(string src)
+        public static GlbChunkType ToChunkType(this string src)
         {
             switch(src)
             {
@@ -24,6 +24,19 @@ namespace UniGLTF
 
                 default:
                     throw new FormatException("unknown chunk type: " + src);
+            }
+        }
+
+        public static string ToChunkTypeString(this GlbChunkType type)
+        {
+            switch (type)
+            {
+                case GlbChunkType.JSON:
+                    return "JSON";
+                case GlbChunkType.BIN:
+                    return "BIN";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
             }
         }
 
@@ -67,12 +80,11 @@ namespace UniGLTF
                 //var type = (GlbChunkType)BitConverter.ToUInt32(bytes, pos);
                 var chunkTypeBytes = bytes.Skip(pos).Take(4).Where(x => x != 0).ToArray();
                 var chunkTypeStr = Encoding.ASCII.GetString(chunkTypeBytes);
-                var type = ToChunkType(chunkTypeStr);
                 pos += 4;
 
                 chunks.Add(new GlbChunk
                 {
-                    ChunkType = type,
+                    ChunkTypeString = chunkTypeStr,
                     Bytes = new ArraySegment<byte>(bytes, (int)pos, (int)chunkDataSize)
                 });
 


### PR DESCRIPTION
Because glTF specification says

> Client implementations must ignore chunks with unknown types to enable glTF extensions to reference additional chunks with new types following the first two chunks.

https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#chunks