### PR TITLE
[1.0] Fix MToon 1.0 bugs

### DIFF
--- a/Assets/VRM10/Runtime/Migration/MigrationMToon.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationMToon.cs
@@ -515,6 +515,7 @@ namespace UniVRM10
 
                 // Outline
                 const float centimeterToMeter = 0.01f;
+                const float oneHundredth = 0.01f;
                 switch (mtoon.Definition.Outline.OutlineWidthMode)
                 {
                     case OutlineWidthMode.None:
@@ -527,7 +528,7 @@ namespace UniVRM10
                         break;
                     case OutlineWidthMode.ScreenCoordinates:
                         dst.OutlineWidthMode = UniGLTF.Extensions.VRMC_materials_mtoon.OutlineWidthMode.screenCoordinates;
-                        dst.OutlineWidthFactor = mtoon.Definition.Outline.OutlineWidthValue * centimeterToMeter;
+                        dst.OutlineWidthFactor = mtoon.Definition.Outline.OutlineWidthValue * oneHundredth;
                         break;
                     default:
                         throw new ArgumentOutOfRangeException($"OutlineWidthMode: {(int)mtoon.Definition.Outline.OutlineWidthMode}");

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon.shader
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon.shader
@@ -88,11 +88,11 @@ Shader "Hidden/VRM10/vrmc_materials_mtoon"
             #pragma multi_compile_fog
             #pragma multi_compile_instancing
 
-            #pragma multi_compile_local __ _ALPHATEST_ON _ALPHABLEND_ON
-            #pragma multi_compile_local __ _NORMALMAP
-            #pragma multi_compile_local __ _MTOON_EMISSIVEMAP
-            #pragma multi_compile_local __ _MTOON_RIMMAP
-            #pragma multi_compile_local __ _MTOON_PARAMETERMAP
+            #pragma multi_compile __ _ALPHATEST_ON _ALPHABLEND_ON
+            #pragma multi_compile __ _NORMALMAP
+            #pragma multi_compile __ _MTOON_EMISSIVEMAP
+            #pragma multi_compile __ _MTOON_RIMMAP
+            #pragma multi_compile __ _MTOON_PARAMETERMAP
 
             #pragma vertex MToonVertex
             #pragma fragment MToonFragment
@@ -123,17 +123,17 @@ Shader "Hidden/VRM10/vrmc_materials_mtoon"
             #pragma multi_compile_fog
             #pragma multi_compile_instancing
 
-            #pragma multi_compile_local __ _ALPHATEST_ON _ALPHABLEND_ON
-            #pragma multi_compile_local __ _NORMALMAP
-            #pragma multi_compile_local __ _MTOON_EMISSIVEMAP
-            #pragma multi_compile_local __ _MTOON_RIMMAP
-            #pragma multi_compile_local __ _MTOON_PARAMETERMAP
-            #pragma multi_compile_local __ _MTOON_OUTLINE_WORLD _MTOON_OUTLINE_SCREEN
-
-            #define MTOON_PASS_OUTLINE
+            #pragma multi_compile __ _ALPHATEST_ON _ALPHABLEND_ON
+            #pragma multi_compile __ _NORMALMAP
+            #pragma multi_compile __ _MTOON_EMISSIVEMAP
+            #pragma multi_compile __ _MTOON_RIMMAP
+            #pragma multi_compile __ _MTOON_PARAMETERMAP
+            #pragma multi_compile __ _MTOON_OUTLINE_WORLD _MTOON_OUTLINE_SCREEN
 
             #pragma vertex MToonVertex
             #pragma fragment MToonFragment
+
+            #define MTOON_PASS_OUTLINE
 
             #include "./vrmc_materials_mtoon_forward_vertex.hlsl"
             #include "./vrmc_materials_mtoon_forward_fragment.hlsl"
@@ -161,11 +161,11 @@ Shader "Hidden/VRM10/vrmc_materials_mtoon"
             #pragma multi_compile_fog
             #pragma multi_compile_instancing
 
-            #pragma multi_compile_local __ _ALPHATEST_ON _ALPHABLEND_ON
-            #pragma multi_compile_local __ _NORMALMAP
-            #pragma multi_compile_local __ _MTOON_EMISSIVEMAP
-            #pragma multi_compile_local __ _MTOON_RIMMAP
-            #pragma multi_compile_local __ _MTOON_PARAMETERMAP
+            #pragma multi_compile __ _ALPHATEST_ON _ALPHABLEND_ON
+            #pragma multi_compile __ _NORMALMAP
+            #pragma multi_compile __ _MTOON_EMISSIVEMAP
+            #pragma multi_compile __ _MTOON_RIMMAP
+            #pragma multi_compile __ _MTOON_PARAMETERMAP
 
             #pragma vertex MToonVertex
             #pragma fragment MToonFragment
@@ -192,7 +192,7 @@ Shader "Hidden/VRM10/vrmc_materials_mtoon"
             #pragma multi_compile_shadowcaster nolightmap nodynlightmap nodirlightmap novertexlight
             #pragma multi_compile_instancing
 
-            #pragma multi_compile_local __ _ALPHATEST_ON _ALPHABLEND_ON
+            #pragma multi_compile __ _ALPHATEST_ON _ALPHABLEND_ON
 
             // Use unity standard shadow implementation.
             // internal usage:

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon.shader
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon.shader
@@ -20,8 +20,6 @@ Shader "Hidden/VRM10/vrmc_materials_mtoon"
         _ShadingShiftTex ("mtoon.shadingShiftTexture", 2D) = "black" {} // channel R
         _ShadingShiftTexScale ("mtoon.shadingShiftTexture.scale", Float) = 1
         _ShadingToonyFactor ("mtoon.shadingToonyFactor", Range(0, 1)) = 0.9
-//        _ShadingToonyTex ("mtoon.shadingToonyTexture", 2D) = "black" {} // parameter texture // need?
-//        _ShadingToonyTexScale ("mtoon.shadingToonyTexture.scale", Float) = 1 // need?
 
         // GI
         _GiEqualization ("mtoon.giEqualizationFactor", Range(0, 1)) = 0.9

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon.shader
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon.shader
@@ -112,6 +112,7 @@ Shader "Hidden/VRM10/vrmc_materials_mtoon"
             Blend [_M_SrcBlend] [_M_DstBlend]
             ZWrite [_M_ZWrite]
             ZTest LEqual
+            Offset 1, 1
             BlendOp Add, Max
             AlphaToMask [_M_AlphaToMask]
 

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_vertex.hlsl
@@ -17,6 +17,8 @@ Varyings MToonVertex(const Attributes v) // v is UnityCG macro specified name.
     UNITY_TRANSFER_INSTANCE_ID(v, output);
     UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
+    output.uv = TRANSFORM_TEX(v.texcoord0, _MainTex);
+
     if (MToon_IsOutlinePass())
     {
         const VertexPositionInfo position = MToon_GetOutlineVertex(v.vertex.xyz, normalize(v.normalOS), output.uv);
@@ -31,7 +33,6 @@ Varyings MToonVertex(const Attributes v) // v is UnityCG macro specified name.
     }
 
     output.normalWS = UnityObjectToWorldNormal(v.normalOS);
-    output.uv = TRANSFORM_TEX(v.texcoord0, _MainTex);
     output.viewDirWS = MToon_GetWorldSpaceNormalizedViewDir(output.positionWS);
 
 #if defined(_NORMALMAP)

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_lighting_mtoon.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_lighting_mtoon.hlsl
@@ -87,9 +87,16 @@ inline half3 GetMToonLighting_GlobalIllumination(const UnityLighting unityLight,
 
 inline half3 GetMToonLighting_Emissive(const MToonInput input)
 {
-    if (MToon_IsForwardBasePass() && MToon_IsEmissiveMapOn())
+    if (MToon_IsForwardBasePass())
     {
-        return UNITY_SAMPLE_TEX2D(_EmissionMap, input.uv).rgb * _EmissionColor.rgb;
+        if (MToon_IsEmissiveMapOn())
+        {
+            return UNITY_SAMPLE_TEX2D(_EmissionMap, input.uv).rgb * _EmissionColor.rgb;
+        }
+        else
+        {
+            return _EmissionColor.rgb;
+        }
     }
     else
     {


### PR DESCRIPTION
bugs
- Couldn't compile on Unity 2018.4.
- EmissionColor was not considered when emissionMap is null.
- OutlineWidthTexture doesn't reference uv correctly.