### PR TITLE
Fix bug of unarchiving stored file in zip.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ZipArchiveStorage.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ZipArchiveStorage.cs
@@ -371,7 +371,9 @@ namespace UniGLTF.Zip
                     return new ArraySegment<byte>(Extract(found));
 
                 case CompressionMethod.Stored:
-                    return new ArraySegment<byte>(found.Bytes, found.RelativeOffsetOfLocalFileHeader, found.CompressedSize);
+                    var local = new LocalFileHeader(found.Bytes, found.RelativeOffsetOfLocalFileHeader);
+                    var pos = local.Offset + local.Length;
+                    return new ArraySegment<byte>(local.Bytes, pos, local.CompressedSize);
             }
 
             throw new NotImplementedException(found.CompressionMethod.ToString());


### PR DESCRIPTION
`Stored` なファイルを展開する際に、ファイル本体ではなく Local File Header の位置を指して展開していたのを修正。