### PR TITLE
[1.0] Expression の仕様更新に追随

### DIFF
--- a/Assets/UniGLTF/Editor/Generator/FormatWriter.cs
+++ b/Assets/UniGLTF/Editor/Generator/FormatWriter.cs
@@ -136,6 +136,10 @@ namespace GenerateUniGLTFSerialization
                         {
                             // WriteObject(ext);
                         }
+                        else if (schema is DictionaryJsonSchema dict)
+                        {
+                            WriteObject((ObjectJsonSchema)dict.AdditionalProperties, rootName);
+                        }
                         else
                         {
                             throw new Exception();

--- a/Assets/UniGLTF/Editor/JsonSchema/JsonSchemaParser.cs
+++ b/Assets/UniGLTF/Editor/JsonSchema/JsonSchemaParser.cs
@@ -190,6 +190,10 @@ namespace UniGLTF.JsonSchema
                             var key = prop.Key.GetString();
                             var propJsonPath = $"{jsonPath}.{key}";
                             var propSchema = Parse(prop.Value, propJsonPath);
+                            if (string.IsNullOrEmpty(propSchema.title))
+                            {
+                                propSchema.title = key.ToUpperCamel();
+                            }
                             if (propSchema is null)
                             {
                                 if (source.baseSchema is null)

--- a/Assets/UniGLTF/Editor/JsonSchema/Schemas/DictionaryJsonSchema.cs
+++ b/Assets/UniGLTF/Editor/JsonSchema/Schemas/DictionaryJsonSchema.cs
@@ -48,9 +48,9 @@ namespace UniGLTF.JsonSchema.Schemas
 public static $0 $2(JsonNode parsed)
 {
     var value = new $1();
-    foreach(var (k, v) in parsed.ObjectItems())
+    foreach(var kv in parsed.ObjectItems())
     {
-        value.Add($3);
+        value.Add(kv.Key.GetString(), $3);
     }
 	return value;
 } 
@@ -58,7 +58,7 @@ public static $0 $2(JsonNode parsed)
     .Replace("$0", ValueType)
     .Replace("$1", ValueType)
     .Replace("$2", callName)
-    .Replace("$3", AdditionalProperties.GenerateDeserializerCall(itemCallName, "v"))
+    .Replace("$3", AdditionalProperties.GenerateDeserializerCall(itemCallName, "kv.Value"))
     );
 
             }
@@ -83,13 +83,13 @@ public static void {callName}(JsonFormatter f, {ValueType} value)
 {{
     f.BeginMap();
 
-    foreach(var (k, v) in value)
+    foreach(var kv in value)
     {{
-        f.Key(k);
+        f.Key(kv.Key);
     "
 );
 
-            writer.Write($"{AdditionalProperties.GenerateSerializerCall(itemCallName, "v")};\n");
+            writer.Write($"{AdditionalProperties.GenerateSerializerCall(itemCallName, "kv.Value")};\n");
 
             writer.Write(@"
     }

--- a/Assets/UniGLTF/Editor/JsonSchema/Schemas/ObjectJsonSchema.cs
+++ b/Assets/UniGLTF/Editor/JsonSchema/Schemas/ObjectJsonSchema.cs
@@ -25,6 +25,11 @@ namespace UniGLTF.JsonSchema.Schemas
                     throw new NotImplementedException();
                 }
 
+                if (string.IsNullOrEmpty(prop.Title))
+                {
+                    prop.Title = kv.Key.ToUpperCamel();
+                }
+
                 var key = kv.Key;
                 Properties.Add(key, prop);
             }

--- a/Assets/VRM10.Samples/Runtime/AIUEO.cs
+++ b/Assets/VRM10.Samples/Runtime/AIUEO.cs
@@ -26,7 +26,7 @@ namespace UniVRM10.Samples
             }
         }
 
-        IEnumerator RoutineNest(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset preset, float velocity, float wait)
+        IEnumerator RoutineNest(ExpressionPreset preset, float velocity, float wait)
         {
             for (var value = 0.0f; value <= 1.0f; value += velocity)
             {
@@ -52,11 +52,11 @@ namespace UniVRM10.Samples
 
                 var velocity = 0.1f;
 
-                yield return RoutineNest(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.aa, velocity, m_wait);
-                yield return RoutineNest(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ih, velocity, m_wait);
-                yield return RoutineNest(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ou, velocity, m_wait);
-                yield return RoutineNest(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ee, velocity, m_wait);
-                yield return RoutineNest(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.oh, velocity, m_wait);
+                yield return RoutineNest(ExpressionPreset.aa, velocity, m_wait);
+                yield return RoutineNest(ExpressionPreset.ih, velocity, m_wait);
+                yield return RoutineNest(ExpressionPreset.ou, velocity, m_wait);
+                yield return RoutineNest(ExpressionPreset.ee, velocity, m_wait);
+                yield return RoutineNest(ExpressionPreset.oh, velocity, m_wait);
             }
         }
 

--- a/Assets/VRM10.Samples/Runtime/Blinker.cs
+++ b/Assets/VRM10.Samples/Runtime/Blinker.cs
@@ -72,10 +72,10 @@ namespace UniVRM10.Samples
                         break;
                     }
 
-                    m_controller.Vrm.Expression.SetWeight(ExpressionKey.CreateFromPreset(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blink), value);
+                    m_controller.Vrm.Expression.SetWeight(ExpressionKey.CreateFromPreset(ExpressionPreset.blink), value);
                     yield return null;
                 }
-                m_controller.Vrm.Expression.SetWeight(ExpressionKey.CreateFromPreset(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blink), 1.0f);
+                m_controller.Vrm.Expression.SetWeight(ExpressionKey.CreateFromPreset(ExpressionPreset.blink), 1.0f);
 
                 // wait...
                 yield return new WaitForSeconds(ClosingTime);
@@ -91,10 +91,10 @@ namespace UniVRM10.Samples
                         break;
                     }
 
-                    m_controller.Vrm.Expression.SetWeight(ExpressionKey.CreateFromPreset(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blink), value);
+                    m_controller.Vrm.Expression.SetWeight(ExpressionKey.CreateFromPreset(ExpressionPreset.blink), value);
                     yield return null;
                 }
-                m_controller.Vrm.Expression.SetWeight(ExpressionKey.CreateFromPreset(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blink), 0);
+                m_controller.Vrm.Expression.SetWeight(ExpressionKey.CreateFromPreset(ExpressionPreset.blink), 0);
             }
         }
 

--- a/Assets/VRM10/Editor/GeneratorMenu.cs
+++ b/Assets/VRM10/Editor/GeneratorMenu.cs
@@ -29,46 +29,74 @@ namespace UniVRM10
         }
 #endif
 
+        struct GenerateInfo
+        {
+            public string JsonSchema;
+            public string FormatDir;
+            public string SerializerDir;
+
+            public GenerateInfo(string jsonSchema, string formatDir, string serializerDir)
+            {
+                JsonSchema = jsonSchema;
+                FormatDir = formatDir;
+                SerializerDir = serializerDir;
+            }
+        }
+
         static void Run(bool debug)
         {
             var projectRoot = new DirectoryInfo(Path.GetFullPath(Path.Combine(Application.dataPath, "../")));
 
             var gltf = new FileInfo(Path.Combine(projectRoot.FullName, "glTF/specification/2.0/schema/glTF.schema.json"));
 
-            var args = new string[]
+            var args = new GenerateInfo[]
             {
-                // VRMC_vrm
-                "vrm-specification/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json",
-                "Assets/VRM10/Runtime/Format/Vrm", // format
-                "Assets/VRM10/Runtime/Format/Vrm", // serializer
                 // VRMC_hdr_emissiveMultiplier
-                "vrm-specification/specification/VRMC_materials_hdr_emissiveMultiplier-1.0_draft/schema/VRMC_materials_hdr_emissiveMultiplier.json",
-                "Assets/VRMShaders/VRM10/Format/Runtime/EmissiveMultiplier", // format
-                "Assets/VRM10/Runtime/Format/EmissiveMultiplier", // serializer
+                new GenerateInfo(
+                    "vrm-specification/specification/VRMC_materials_hdr_emissiveMultiplier-1.0_draft/schema/VRMC_materials_hdr_emissiveMultiplier.json",
+                    "Assets/VRMShaders/VRM10/Format/Runtime/EmissiveMultiplier",
+                    "Assets/VRM10/Runtime/Format/EmissiveMultiplier"
+                ),
+
+                // VRMC_vrm
+                new GenerateInfo(
+                    "vrm-specification/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json",
+                    "Assets/VRM10/Runtime/Format/Vrm",
+                    "Assets/VRM10/Runtime/Format/Vrm"
+                ),
+
                 // VRMC_materials_mtoon
-                "vrm-specification/specification/VRMC_materials_mtoon-1.0_draft/schema/VRMC_materials_mtoon.schema.json",
-                "Assets/VRMShaders/VRM10/Format/Runtime/MaterialsMToon", // format
-                "Assets/VRM10/Runtime/Format/MaterialsMToon", // serializer
+                new GenerateInfo(
+                    "vrm-specification/specification/VRMC_materials_mtoon-1.0_draft/schema/VRMC_materials_mtoon.schema.json",
+                    "Assets/VRMShaders/VRM10/Format/Runtime/MaterialsMToon",
+                    "Assets/VRM10/Runtime/Format/MaterialsMToon"
+                ),
+
                 // VRMC_springBone
-                "vrm-specification/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json",
-                "Assets/VRM10/Runtime/Format/SpringBone", // format
-                "Assets/VRM10/Runtime/Format/SpringBone", // serializer
+                new GenerateInfo(
+                    "vrm-specification/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json",
+                    "Assets/VRM10/Runtime/Format/SpringBone",
+                    "Assets/VRM10/Runtime/Format/SpringBone"
+                ),
+
                 // VRMC_node_constraint
-                "vrm-specification/specification/VRMC_node_constraint-1.0_draft/schema/VRMC_node_constraint.schema.json",
-                "Assets/VRM10/Runtime/Format/Constraints", // format
-                "Assets/VRM10/Runtime/Format/Constraints", // serializer
+                new GenerateInfo(
+                    "vrm-specification/specification/VRMC_node_constraint-1.0_draft/schema/VRMC_node_constraint.schema.json",
+                    "Assets/VRM10/Runtime/Format/Constraints",
+                    "Assets/VRM10/Runtime/Format/Constraints"
+                ),
             };
 
-            for (int i = 0; i < args.Length; i += 3)
+            foreach (var arg in args)
             {
-                var extensionSchemaPath = new FileInfo(Path.Combine(projectRoot.FullName, args[i]));
+                var extensionSchemaPath = new FileInfo(Path.Combine(projectRoot.FullName, arg.JsonSchema));
                 var parser = new UniGLTF.JsonSchema.JsonSchemaParser(gltf.Directory, extensionSchemaPath.Directory);
                 var extensionSchema = parser.Load(extensionSchemaPath, "");
 
-                var formatDst = new DirectoryInfo(Path.Combine(projectRoot.FullName, args[i + 1]));
+                var formatDst = new DirectoryInfo(Path.Combine(projectRoot.FullName, arg.FormatDir));
                 Debug.Log($"Format.g Dir: {formatDst}");
-                
-                var serializerDst = new DirectoryInfo(Path.Combine(projectRoot.FullName, args[i + 2]));
+
+                var serializerDst = new DirectoryInfo(Path.Combine(projectRoot.FullName, arg.SerializerDir));
                 Debug.Log($"Serializer/Deserializer.g Dir: {serializerDst}");
 
                 if (debug)

--- a/Assets/VRM10/Editor/GeneratorMenu.cs
+++ b/Assets/VRM10/Editor/GeneratorMenu.cs
@@ -41,6 +41,10 @@ namespace UniVRM10
                 FormatDir = formatDir;
                 SerializerDir = serializerDir;
             }
+
+            public GenerateInfo(string jsonSchema, string formatDir) : this(jsonSchema, formatDir, formatDir)
+            {
+            }
         }
 
         static void Run(bool debug)
@@ -54,14 +58,12 @@ namespace UniVRM10
                 // VRMC_hdr_emissiveMultiplier
                 new GenerateInfo(
                     "vrm-specification/specification/VRMC_materials_hdr_emissiveMultiplier-1.0_draft/schema/VRMC_materials_hdr_emissiveMultiplier.json",
-                    "Assets/VRMShaders/VRM10/Format/Runtime/EmissiveMultiplier",
-                    "Assets/VRM10/Runtime/Format/EmissiveMultiplier"
+                    "Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/EmissiveMultiplier"
                 ),
 
                 // VRMC_vrm
                 new GenerateInfo(
                     "vrm-specification/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json",
-                    "Assets/VRM10/Runtime/Format/Vrm",
                     "Assets/VRM10/Runtime/Format/Vrm"
                 ),
 
@@ -75,14 +77,12 @@ namespace UniVRM10
                 // VRMC_springBone
                 new GenerateInfo(
                     "vrm-specification/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json",
-                    "Assets/VRM10/Runtime/Format/SpringBone",
                     "Assets/VRM10/Runtime/Format/SpringBone"
                 ),
 
                 // VRMC_node_constraint
                 new GenerateInfo(
                     "vrm-specification/specification/VRMC_node_constraint-1.0_draft/schema/VRMC_node_constraint.schema.json",
-                    "Assets/VRM10/Runtime/Format/Constraints",
                     "Assets/VRM10/Runtime/Format/Constraints"
                 ),
             };

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterEditorGUI.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterEditorGUI.cs
@@ -4,6 +4,8 @@ using UniGLTF;
 using System.IO;
 using UniGLTF.MeshUtility;
 using System.Linq;
+using System.Collections.Generic;
+using VRMShaders;
 #if UNITY_2020_2_OR_NEWER
 using UnityEditor.AssetImporters;
 #else
@@ -24,6 +26,31 @@ namespace UniVRM10
 
         Vrm10Parser.Result m_result;
 
+        IEnumerable<SubAssetKey> EnumerateExpressinKeys(UniGLTF.Extensions.VRMC_vrm.Expressions expressions)
+        {
+            if (expressions?.Preset?.Happy != null) yield return ExpressionKey.Happy.SubAssetKey;
+            if (expressions?.Preset?.Angry != null) yield return ExpressionKey.Angry.SubAssetKey;
+            if (expressions?.Preset?.Sad != null) yield return ExpressionKey.Sad.SubAssetKey;
+            if (expressions?.Preset?.Relaxed != null) yield return ExpressionKey.Relaxed.SubAssetKey;
+            if (expressions?.Preset?.Surprised != null) yield return ExpressionKey.Surprised.SubAssetKey;
+            if (expressions?.Preset?.Aa != null) yield return ExpressionKey.Aa.SubAssetKey;
+            if (expressions?.Preset?.Ih != null) yield return ExpressionKey.Ih.SubAssetKey;
+            if (expressions?.Preset?.Ou != null) yield return ExpressionKey.Ou.SubAssetKey;
+            if (expressions?.Preset?.Ee != null) yield return ExpressionKey.Ee.SubAssetKey;
+            if (expressions?.Preset?.Oh != null) yield return ExpressionKey.Oh.SubAssetKey;
+            if (expressions?.Preset?.Blink != null) yield return ExpressionKey.Blink.SubAssetKey;
+            if (expressions?.Preset?.BlinkLeft != null) yield return ExpressionKey.BlinkLeft.SubAssetKey;
+            if (expressions?.Preset?.BlinkRight != null) yield return ExpressionKey.BlinkRight.SubAssetKey;
+            if (expressions?.Preset?.LookUp != null) yield return ExpressionKey.LookUp.SubAssetKey;
+            if (expressions?.Preset?.LookDown != null) yield return ExpressionKey.LookDown.SubAssetKey;
+            if (expressions?.Preset?.LookLeft != null) yield return ExpressionKey.LookLeft.SubAssetKey;
+            if (expressions?.Preset?.LookRight != null) yield return ExpressionKey.LookRight.SubAssetKey;
+            foreach (var kv in expressions.Custom)
+            {
+                yield return ExpressionKey.CreateCustom(kv.Key).SubAssetKey;
+            }
+        }
+
         public override void OnEnable()
         {
             base.OnEnable();
@@ -42,8 +69,7 @@ namespace UniVRM10
             var materialKeys = m_result.Data.GLTF.materials.Select((x, i) => generator.Get(m_result.Data, i).SubAssetKey);
             var textureKeys = new GltfTextureDescriptorGenerator(m_result.Data).Get().GetEnumerable().Select(x => x.SubAssetKey);
             m_materialEditor = new RemapEditorMaterial(materialKeys.Concat(textureKeys), GetEditorMap, SetEditorMap);
-            var expressionSubAssetKeys = m_result.Vrm.Expressions.Select(x => ExpressionKey.CreateFromVrm10(x).SubAssetKey);
-            m_vrmEditor = new RemapEditorVrm(new[] { VRM10Object.SubAssetKey }.Concat(expressionSubAssetKeys), GetEditorMap, SetEditorMap);
+            m_vrmEditor = new RemapEditorVrm(new[] { VRM10Object.SubAssetKey }.Concat(EnumerateExpressinKeys(m_result.Vrm.Expressions)), GetEditorMap, SetEditorMap);
         }
 
         enum Tabs

--- a/Assets/VRM10/Runtime/Components/Expression/ExpressionKey.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/ExpressionKey.cs
@@ -11,8 +11,8 @@ namespace UniVRM10
         /// <summary>
         /// Enum.ToString() のGC回避用キャッシュ
         /// </summary>
-        private static readonly Dictionary<UniGLTF.Extensions.VRMC_vrm.ExpressionPreset, string> PresetNameDictionary =
-            new Dictionary<UniGLTF.Extensions.VRMC_vrm.ExpressionPreset, string>();
+        private static readonly Dictionary<ExpressionPreset, string> PresetNameDictionary =
+            new Dictionary<ExpressionPreset, string>();
 
         /// <summary>
         ///  ExpressionPreset と同名の名前を持つ独自に追加した Expression を区別するための prefix
@@ -22,7 +22,7 @@ namespace UniVRM10
         /// <summary>
         /// Preset of this ExpressionKey.
         /// </summary>
-        public readonly UniGLTF.Extensions.VRMC_vrm.ExpressionPreset Preset;
+        public readonly ExpressionPreset Preset;
 
         /// <summary>
         /// Custom Name of this ExpressionKey.
@@ -41,9 +41,9 @@ namespace UniVRM10
             {
                 switch (Preset)
                 {
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blink:
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blinkLeft:
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blinkRight:
+                    case ExpressionPreset.blink:
+                    case ExpressionPreset.blinkLeft:
+                    case ExpressionPreset.blinkRight:
                         return true;
                 }
                 return false;
@@ -56,10 +56,10 @@ namespace UniVRM10
             {
                 switch (Preset)
                 {
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookUp:
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookDown:
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookLeft:
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookRight:
+                    case ExpressionPreset.lookUp:
+                    case ExpressionPreset.lookDown:
+                    case ExpressionPreset.lookLeft:
+                    case ExpressionPreset.lookRight:
                         return true;
                 }
                 return false;
@@ -72,11 +72,11 @@ namespace UniVRM10
             {
                 switch (Preset)
                 {
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.aa:
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ih:
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ou:
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ee:
-                    case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.oh:
+                    case ExpressionPreset.aa:
+                    case ExpressionPreset.ih:
+                    case ExpressionPreset.ou:
+                    case ExpressionPreset.ee:
+                    case ExpressionPreset.oh:
                         return true;
                 }
                 return false;
@@ -85,11 +85,11 @@ namespace UniVRM10
 
         public bool IsProcedual => IsBlink || IsLookAt || IsMouth;
 
-        public ExpressionKey(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset preset, string customName = null)
+        public ExpressionKey(ExpressionPreset preset, string customName = null)
         {
             Preset = preset;
 
-            if (Preset != UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.custom)
+            if (Preset != ExpressionPreset.custom)
             {
                 if (PresetNameDictionary.ContainsKey((Preset)))
                 {
@@ -105,7 +105,7 @@ namespace UniVRM10
             {
                 if (string.IsNullOrEmpty(customName))
                 {
-                    throw new ArgumentException("name is required for UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.Custom");
+                    throw new ArgumentException("name is required for ExpressionPreset.Custom");
                 }
 
                 _id = $"{UnknownPresetPrefix}{customName}";
@@ -115,10 +115,10 @@ namespace UniVRM10
 
         public static ExpressionKey CreateCustom(String key)
         {
-            return new ExpressionKey(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.custom, key);
+            return new ExpressionKey(ExpressionPreset.custom, key);
         }
 
-        public static ExpressionKey CreateFromPreset(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset preset)
+        public static ExpressionKey CreateFromPreset(ExpressionPreset preset)
         {
             return new ExpressionKey(preset);
         }
@@ -133,17 +133,25 @@ namespace UniVRM10
             return new ExpressionKey(clip.Preset, clip.ExpressionName);
         }
 
-        public static ExpressionKey CreateFromVrm10(UniGLTF.Extensions.VRMC_vrm.Expression expression)
-        {
-            if (expression.Preset == UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.custom)
-            {
-                return ExpressionKey.CreateCustom(expression.Name);
-            }
-            else
-            {
-                return ExpressionKey.CreateFromPreset(expression.Preset);
-            }
-        }
+        public static ExpressionKey Happy => CreateFromPreset(ExpressionPreset.happy);
+        public static ExpressionKey Angry => CreateFromPreset(ExpressionPreset.angry);
+        public static ExpressionKey Sad => CreateFromPreset(ExpressionPreset.sad);
+        public static ExpressionKey Relaxed => CreateFromPreset(ExpressionPreset.relaxed);
+        public static ExpressionKey Surprised => CreateFromPreset(ExpressionPreset.surprised);
+        public static ExpressionKey Aa => CreateFromPreset(ExpressionPreset.aa);
+        public static ExpressionKey Ih => CreateFromPreset(ExpressionPreset.ih);
+        public static ExpressionKey Ou => CreateFromPreset(ExpressionPreset.ou);
+        public static ExpressionKey Ee => CreateFromPreset(ExpressionPreset.ee);
+        public static ExpressionKey Oh => CreateFromPreset(ExpressionPreset.oh);
+        public static ExpressionKey Blink => CreateFromPreset(ExpressionPreset.blink);
+        public static ExpressionKey BlinkLeft => CreateFromPreset(ExpressionPreset.blinkLeft);
+        public static ExpressionKey BlinkRight => CreateFromPreset(ExpressionPreset.blinkRight);
+        public static ExpressionKey LookUp => CreateFromPreset(ExpressionPreset.lookUp);
+        public static ExpressionKey LookDown => CreateFromPreset(ExpressionPreset.lookDown);
+        public static ExpressionKey LookLeft => CreateFromPreset(ExpressionPreset.lookLeft);
+        public static ExpressionKey LookRight => CreateFromPreset(ExpressionPreset.lookRight);
+        public static ExpressionKey Neutral => CreateFromPreset(ExpressionPreset.neutral);
+
 
         public override string ToString()
         {

--- a/Assets/VRM10/Runtime/Components/Expression/ExpressionPreset.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/ExpressionPreset.cs
@@ -1,0 +1,25 @@
+namespace UniVRM10
+{
+    public enum ExpressionPreset
+    {
+        custom,
+        happy,
+        angry,
+        sad,
+        relaxed,
+        surprised,
+        aa,
+        ih,
+        ou,
+        ee,
+        oh,
+        blink,
+        blinkLeft,
+        blinkRight,
+        lookUp,
+        lookDown,
+        lookLeft,
+        lookRight,
+        neutral,
+    }
+}

--- a/Assets/VRM10/Runtime/Components/Expression/ExpressionPreset.cs.meta
+++ b/Assets/VRM10/Runtime/Components/Expression/ExpressionPreset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 959cd7efa29185648bb7996d11eb2a14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM10/Runtime/Components/Expression/VRM10Expression.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/VRM10Expression.cs
@@ -16,7 +16,7 @@ namespace UniVRM10
         /// ExpressionPreset を識別する。 Unknown の場合は、 ExpressionName で識別する
         /// </summary>
         [SerializeField]
-        public UniGLTF.Extensions.VRMC_vrm.ExpressionPreset Preset;
+        public ExpressionPreset Preset;
 
         /// <summary>
         /// 対象メッシュの Expression を操作する
@@ -67,7 +67,7 @@ namespace UniVRM10
 
         void OnValidate()
         {
-            if (Preset == UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.custom)
+            if (Preset == ExpressionPreset.custom)
             {
                 if (string.IsNullOrEmpty(ExpressionName))
                 {

--- a/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectExpression.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectExpression.cs
@@ -104,24 +104,24 @@ namespace UniVRM10
         {
             switch (clip.Preset)
             {
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.happy: Happy = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.angry: Angry = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.sad: Sad = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.relaxed: Relaxed = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.surprised: Surprised = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.aa: Aa = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ih: Ih = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ou: Ou = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ee: Ee = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.oh: Oh = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blink: Blink = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blinkLeft: BlinkLeft = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blinkRight: BlinkRight = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookUp: LookUp = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookDown: LookDown = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookLeft: LookLeft = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookRight: LookRight = clip; break;
-                case UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.neutral: Neutral = clip; break;
+                case ExpressionPreset.happy: Happy = clip; break;
+                case ExpressionPreset.angry: Angry = clip; break;
+                case ExpressionPreset.sad: Sad = clip; break;
+                case ExpressionPreset.relaxed: Relaxed = clip; break;
+                case ExpressionPreset.surprised: Surprised = clip; break;
+                case ExpressionPreset.aa: Aa = clip; break;
+                case ExpressionPreset.ih: Ih = clip; break;
+                case ExpressionPreset.ou: Ou = clip; break;
+                case ExpressionPreset.ee: Ee = clip; break;
+                case ExpressionPreset.oh: Oh = clip; break;
+                case ExpressionPreset.blink: Blink = clip; break;
+                case ExpressionPreset.blinkLeft: BlinkLeft = clip; break;
+                case ExpressionPreset.blinkRight: BlinkRight = clip; break;
+                case ExpressionPreset.lookUp: LookUp = clip; break;
+                case ExpressionPreset.lookDown: LookDown = clip; break;
+                case ExpressionPreset.lookLeft: LookLeft = clip; break;
+                case ExpressionPreset.lookRight: LookRight = clip; break;
+                case ExpressionPreset.neutral: Neutral = clip; break;
                 default: CustomClips.Add(clip); break;
             }
         }
@@ -242,8 +242,8 @@ namespace UniVRM10
         // /// </summary>
         // public void CreateDefaultPreset()
         // {
-        //     foreach (var preset in ((UniGLTF.Extensions.VRMC_vrm.ExpressionPreset[])Enum.GetValues(typeof(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset)))
-        //         .Where(x => x != UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.custom)
+        //     foreach (var preset in ((ExpressionPreset[])Enum.GetValues(typeof(ExpressionPreset)))
+        //         .Where(x => x != ExpressionPreset.custom)
         //         )
         //     {
         //         CreateDefaultPreset(preset);

--- a/Assets/VRM10/Runtime/Format/Constraints/Deserializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/Constraints/Deserializer.g.cs
@@ -47,6 +47,11 @@ public static VRMC_node_constraint Deserialize(JsonNode parsed)
             continue;
         }
 
+        if(key=="specVersion"){
+            value.SpecVersion = kv.Value.GetString();
+            continue;
+        }
+
         if(key=="constraint"){
             value.Constraint = Deserialize_Constraint(kv.Value);
             continue;

--- a/Assets/VRM10/Runtime/Format/Constraints/Format.g.cs
+++ b/Assets/VRM10/Runtime/Format/Constraints/Format.g.cs
@@ -128,6 +128,9 @@ namespace UniGLTF.Extensions.VRMC_node_constraint
         // Application-specific data.
         public object Extras;
 
+        // Specification version of VRMC_node_constraint
+        public string SpecVersion;
+
         // Contains position, rotation, or aim
         public Constraint Constraint;
     }

--- a/Assets/VRM10/Runtime/Format/Constraints/Serializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/Constraints/Serializer.g.cs
@@ -43,6 +43,11 @@ public static void Serialize(JsonFormatter f, VRMC_node_constraint value)
         (value.Extras as glTFExtension).Serialize(f);
     }
 
+    if(!string.IsNullOrEmpty(value.SpecVersion)){
+        f.Key("specVersion");                
+        f.Value(value.SpecVersion);
+    }
+
     if(value.Constraint!=null){
         f.Key("constraint");                
         Serialize_Constraint(f, value.Constraint);

--- a/Assets/VRM10/Runtime/Format/MaterialsMToon/Deserializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/MaterialsMToon/Deserializer.g.cs
@@ -47,8 +47,8 @@ public static VRMC_materials_mtoon Deserialize(JsonNode parsed)
             continue;
         }
 
-        if(key=="version"){
-            value.Version = kv.Value.GetString();
+        if(key=="specVersion"){
+            value.SpecVersion = kv.Value.GetString();
             continue;
         }
 

--- a/Assets/VRM10/Runtime/Format/MaterialsMToon/Serializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/MaterialsMToon/Serializer.g.cs
@@ -43,9 +43,9 @@ public static void Serialize(JsonFormatter f, VRMC_materials_mtoon value)
         (value.Extras as glTFExtension).Serialize(f);
     }
 
-    if(!string.IsNullOrEmpty(value.Version)){
-        f.Key("version");                
-        f.Value(value.Version);
+    if(!string.IsNullOrEmpty(value.SpecVersion)){
+        f.Key("specVersion");                
+        f.Value(value.SpecVersion);
     }
 
     if(value.TransparentWithZWrite.HasValue){

--- a/Assets/VRM10/Runtime/Format/SpringBone/Deserializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/SpringBone/Deserializer.g.cs
@@ -47,6 +47,11 @@ public static VRMC_springBone Deserialize(JsonNode parsed)
             continue;
         }
 
+        if(key=="specVersion"){
+            value.SpecVersion = kv.Value.GetString();
+            continue;
+        }
+
         if(key=="colliders"){
             value.Colliders = Deserialize_Colliders(kv.Value);
             continue;

--- a/Assets/VRM10/Runtime/Format/SpringBone/Format.g.cs
+++ b/Assets/VRM10/Runtime/Format/SpringBone/Format.g.cs
@@ -124,6 +124,9 @@ namespace UniGLTF.Extensions.VRMC_springBone
         // Application-specific data.
         public object Extras;
 
+        // Specification version of VRMC_springBone
+        public string SpecVersion;
+
         // An array of colliders.
         public List<Collider> Colliders;
 

--- a/Assets/VRM10/Runtime/Format/SpringBone/Serializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/SpringBone/Serializer.g.cs
@@ -43,17 +43,22 @@ public static void Serialize(JsonFormatter f, VRMC_springBone value)
         (value.Extras as glTFExtension).Serialize(f);
     }
 
-    if(value.Colliders!=null&&value.Colliders.Count()>=0){
+    if(!string.IsNullOrEmpty(value.SpecVersion)){
+        f.Key("specVersion");                
+        f.Value(value.SpecVersion);
+    }
+
+    if(value.Colliders!=null&&value.Colliders.Count()>=1){
         f.Key("colliders");                
         Serialize_Colliders(f, value.Colliders);
     }
 
-    if(value.ColliderGroups!=null&&value.ColliderGroups.Count()>=0){
+    if(value.ColliderGroups!=null&&value.ColliderGroups.Count()>=1){
         f.Key("colliderGroups");                
         Serialize_ColliderGroups(f, value.ColliderGroups);
     }
 
-    if(value.Springs!=null&&value.Springs.Count()>=0){
+    if(value.Springs!=null&&value.Springs.Count()>=1){
         f.Key("springs");                
         Serialize_Springs(f, value.Springs);
     }
@@ -290,12 +295,12 @@ public static void Serialize_Springs_ITEM(JsonFormatter f, Spring value)
         f.Value(value.Name);
     }
 
-    if(value.Joints!=null&&value.Joints.Count()>=0){
+    if(value.Joints!=null&&value.Joints.Count()>=1){
         f.Key("joints");                
         __springs_ITEM_Serialize_Joints(f, value.Joints);
     }
 
-    if(value.ColliderGroups!=null&&value.ColliderGroups.Count()>=0){
+    if(value.ColliderGroups!=null&&value.ColliderGroups.Count()>=1){
         f.Key("colliderGroups");                
         __springs_ITEM_Serialize_ColliderGroups(f, value.ColliderGroups);
     }

--- a/Assets/VRM10/Runtime/Format/Vrm/Deserializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/Vrm/Deserializer.g.cs
@@ -139,6 +139,11 @@ public static Meta Deserialize_Meta(JsonNode parsed)
             continue;
         }
 
+        if(key=="licenseUrl"){
+            value.LicenseUrl = kv.Value.GetString();
+            continue;
+        }
+
         if(key=="avatarPermission"){
             value.AvatarPermission = (AvatarPermissionType)Enum.Parse(typeof(AvatarPermissionType), kv.Value.GetString(), true);
             continue;
@@ -2272,17 +2277,136 @@ public static LookAtRangeMap __lookAt_Deserialize_RangeMapVerticalUp(JsonNode pa
     return value;
 }
 
-public static List<Expression> Deserialize_Expressions(JsonNode parsed)
+public static Expressions Deserialize_Expressions(JsonNode parsed)
 {
-    var value = new List<Expression>();
-    foreach(var x in parsed.ArrayItems())
-    {
-        value.Add(Deserialize_Expressions_ITEM(x));
-    }
-	return value;
-} 
+    var value = new Expressions();
 
-public static Expression Deserialize_Expressions_ITEM(JsonNode parsed)
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="preset"){
+            value.Preset = __expressions_Deserialize_Preset(kv.Value);
+            continue;
+        }
+
+        if(key=="custom"){
+            value.Custom = __expressions_Deserialize_Custom(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static Preset  __expressions_Deserialize_Preset(JsonNode parsed)
+{
+    var value = new Preset();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="happy"){
+            value.Happy = __expressions__preset_Deserialize_Happy(kv.Value);
+            continue;
+        }
+
+        if(key=="angry"){
+            value.Angry = __expressions__preset_Deserialize_Angry(kv.Value);
+            continue;
+        }
+
+        if(key=="sad"){
+            value.Sad = __expressions__preset_Deserialize_Sad(kv.Value);
+            continue;
+        }
+
+        if(key=="relaxed"){
+            value.Relaxed = __expressions__preset_Deserialize_Relaxed(kv.Value);
+            continue;
+        }
+
+        if(key=="surprised"){
+            value.Surprised = __expressions__preset_Deserialize_Surprised(kv.Value);
+            continue;
+        }
+
+        if(key=="aa"){
+            value.Aa = __expressions__preset_Deserialize_Aa(kv.Value);
+            continue;
+        }
+
+        if(key=="ih"){
+            value.Ih = __expressions__preset_Deserialize_Ih(kv.Value);
+            continue;
+        }
+
+        if(key=="ou"){
+            value.Ou = __expressions__preset_Deserialize_Ou(kv.Value);
+            continue;
+        }
+
+        if(key=="ee"){
+            value.Ee = __expressions__preset_Deserialize_Ee(kv.Value);
+            continue;
+        }
+
+        if(key=="oh"){
+            value.Oh = __expressions__preset_Deserialize_Oh(kv.Value);
+            continue;
+        }
+
+        if(key=="blink"){
+            value.Blink = __expressions__preset_Deserialize_Blink(kv.Value);
+            continue;
+        }
+
+        if(key=="blinkLeft"){
+            value.BlinkLeft = __expressions__preset_Deserialize_BlinkLeft(kv.Value);
+            continue;
+        }
+
+        if(key=="blinkRight"){
+            value.BlinkRight = __expressions__preset_Deserialize_BlinkRight(kv.Value);
+            continue;
+        }
+
+        if(key=="lookUp"){
+            value.LookUp = __expressions__preset_Deserialize_LookUp(kv.Value);
+            continue;
+        }
+
+        if(key=="lookDown"){
+            value.LookDown = __expressions__preset_Deserialize_LookDown(kv.Value);
+            continue;
+        }
+
+        if(key=="lookLeft"){
+            value.LookLeft = __expressions__preset_Deserialize_LookLeft(kv.Value);
+            continue;
+        }
+
+        if(key=="lookRight"){
+            value.LookRight = __expressions__preset_Deserialize_LookRight(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static Expression __expressions__preset_Deserialize_Happy(JsonNode parsed)
 {
     var value = new Expression();
 
@@ -2300,28 +2424,18 @@ public static Expression Deserialize_Expressions_ITEM(JsonNode parsed)
             continue;
         }
 
-        if(key=="name"){
-            value.Name = kv.Value.GetString();
-            continue;
-        }
-
-        if(key=="preset"){
-            value.Preset = (ExpressionPreset)Enum.Parse(typeof(ExpressionPreset), kv.Value.GetString(), true);
-            continue;
-        }
-
         if(key=="morphTargetBinds"){
-            value.MorphTargetBinds = __expressions_ITEM_Deserialize_MorphTargetBinds(kv.Value);
+            value.MorphTargetBinds = __expressions__preset__happy_Deserialize_MorphTargetBinds(kv.Value);
             continue;
         }
 
         if(key=="materialColorBinds"){
-            value.MaterialColorBinds = __expressions_ITEM_Deserialize_MaterialColorBinds(kv.Value);
+            value.MaterialColorBinds = __expressions__preset__happy_Deserialize_MaterialColorBinds(kv.Value);
             continue;
         }
 
         if(key=="textureTransformBinds"){
-            value.TextureTransformBinds = __expressions_ITEM_Deserialize_TextureTransformBinds(kv.Value);
+            value.TextureTransformBinds = __expressions__preset__happy_Deserialize_TextureTransformBinds(kv.Value);
             continue;
         }
 
@@ -2349,17 +2463,17 @@ public static Expression Deserialize_Expressions_ITEM(JsonNode parsed)
     return value;
 }
 
-public static List<MorphTargetBind> __expressions_ITEM_Deserialize_MorphTargetBinds(JsonNode parsed)
+public static List<MorphTargetBind> __expressions__preset__happy_Deserialize_MorphTargetBinds(JsonNode parsed)
 {
     var value = new List<MorphTargetBind>();
     foreach(var x in parsed.ArrayItems())
     {
-        value.Add(__expressions_ITEM_Deserialize_MorphTargetBinds_ITEM(x));
+        value.Add(__expressions__preset__happy_Deserialize_MorphTargetBinds_ITEM(x));
     }
 	return value;
 } 
 
-public static MorphTargetBind __expressions_ITEM_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+public static MorphTargetBind __expressions__preset__happy_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
 {
     var value = new MorphTargetBind();
 
@@ -2396,17 +2510,17 @@ public static MorphTargetBind __expressions_ITEM_Deserialize_MorphTargetBinds_IT
     return value;
 }
 
-public static List<MaterialColorBind> __expressions_ITEM_Deserialize_MaterialColorBinds(JsonNode parsed)
+public static List<MaterialColorBind> __expressions__preset__happy_Deserialize_MaterialColorBinds(JsonNode parsed)
 {
     var value = new List<MaterialColorBind>();
     foreach(var x in parsed.ArrayItems())
     {
-        value.Add(__expressions_ITEM_Deserialize_MaterialColorBinds_ITEM(x));
+        value.Add(__expressions__preset__happy_Deserialize_MaterialColorBinds_ITEM(x));
     }
 	return value;
 } 
 
-public static MaterialColorBind __expressions_ITEM_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+public static MaterialColorBind __expressions__preset__happy_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
 {
     var value = new MaterialColorBind();
 
@@ -2435,7 +2549,7 @@ public static MaterialColorBind __expressions_ITEM_Deserialize_MaterialColorBind
         }
 
         if(key=="targetValue"){
-            value.TargetValue = __expressions_ITEM__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            value.TargetValue = __expressions__preset__happy__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
             continue;
         }
 
@@ -2443,7 +2557,7 @@ public static MaterialColorBind __expressions_ITEM_Deserialize_MaterialColorBind
     return value;
 }
 
-public static float[] __expressions_ITEM__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+public static float[] __expressions__preset__happy__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
 {
     var value = new float[parsed.GetArrayCount()];
     int i=0;
@@ -2454,17 +2568,17 @@ public static float[] __expressions_ITEM__materialColorBinds_ITEM_Deserialize_Ta
 	return value;
 } 
 
-public static List<TextureTransformBind> __expressions_ITEM_Deserialize_TextureTransformBinds(JsonNode parsed)
+public static List<TextureTransformBind> __expressions__preset__happy_Deserialize_TextureTransformBinds(JsonNode parsed)
 {
     var value = new List<TextureTransformBind>();
     foreach(var x in parsed.ArrayItems())
     {
-        value.Add(__expressions_ITEM_Deserialize_TextureTransformBinds_ITEM(x));
+        value.Add(__expressions__preset__happy_Deserialize_TextureTransformBinds_ITEM(x));
     }
 	return value;
 } 
 
-public static TextureTransformBind __expressions_ITEM_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+public static TextureTransformBind __expressions__preset__happy_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
 {
     var value = new TextureTransformBind();
 
@@ -2488,12 +2602,12 @@ public static TextureTransformBind __expressions_ITEM_Deserialize_TextureTransfo
         }
 
         if(key=="scale"){
-            value.Scale = __expressions_ITEM__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            value.Scale = __expressions__preset__happy__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
             continue;
         }
 
         if(key=="offset"){
-            value.Offset = __expressions_ITEM__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            value.Offset = __expressions__preset__happy__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
             continue;
         }
 
@@ -2501,7 +2615,7 @@ public static TextureTransformBind __expressions_ITEM_Deserialize_TextureTransfo
     return value;
 }
 
-public static float[] __expressions_ITEM__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+public static float[] __expressions__preset__happy__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
 {
     var value = new float[parsed.GetArrayCount()];
     int i=0;
@@ -2512,7 +2626,3944 @@ public static float[] __expressions_ITEM__textureTransformBinds_ITEM_Deserialize
 	return value;
 } 
 
-public static float[] __expressions_ITEM__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+public static float[] __expressions__preset__happy__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_Angry(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__angry_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__angry_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__angry_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__angry_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__angry_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__angry_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__angry_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__angry_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__angry_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__angry__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__angry__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__angry_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__angry_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__angry_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__angry__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__angry__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__angry__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__angry__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_Sad(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__sad_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__sad_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__sad_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__sad_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__sad_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__sad_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__sad_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__sad_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__sad_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__sad__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__sad__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__sad_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__sad_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__sad_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__sad__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__sad__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__sad__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__sad__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_Relaxed(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__relaxed_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__relaxed_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__relaxed_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__relaxed_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__relaxed_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__relaxed_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__relaxed_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__relaxed_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__relaxed_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__relaxed__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__relaxed__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__relaxed_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__relaxed_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__relaxed_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__relaxed__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__relaxed__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__relaxed__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__relaxed__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_Surprised(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__surprised_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__surprised_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__surprised_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__surprised_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__surprised_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__surprised_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__surprised_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__surprised_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__surprised_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__surprised__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__surprised__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__surprised_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__surprised_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__surprised_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__surprised__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__surprised__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__surprised__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__surprised__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_Aa(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__aa_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__aa_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__aa_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__aa_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__aa_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__aa_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__aa_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__aa_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__aa_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__aa__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__aa__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__aa_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__aa_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__aa_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__aa__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__aa__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__aa__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__aa__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_Ih(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__ih_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__ih_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__ih_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__ih_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__ih_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__ih_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__ih_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__ih_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__ih_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__ih__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__ih__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__ih_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__ih_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__ih_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__ih__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__ih__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__ih__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__ih__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_Ou(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__ou_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__ou_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__ou_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__ou_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__ou_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__ou_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__ou_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__ou_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__ou_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__ou__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__ou__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__ou_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__ou_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__ou_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__ou__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__ou__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__ou__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__ou__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_Ee(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__ee_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__ee_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__ee_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__ee_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__ee_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__ee_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__ee_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__ee_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__ee_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__ee__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__ee__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__ee_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__ee_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__ee_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__ee__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__ee__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__ee__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__ee__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_Oh(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__oh_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__oh_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__oh_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__oh_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__oh_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__oh_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__oh_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__oh_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__oh_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__oh__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__oh__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__oh_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__oh_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__oh_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__oh__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__oh__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__oh__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__oh__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_Blink(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__blink_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__blink_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__blink_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__blink_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__blink_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__blink_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__blink_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__blink_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__blink_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__blink__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__blink__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__blink_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__blink_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__blink_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__blink__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__blink__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__blink__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__blink__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_BlinkLeft(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__blinkLeft_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__blinkLeft_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__blinkLeft_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__blinkLeft_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__blinkLeft_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__blinkLeft_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__blinkLeft_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__blinkLeft_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__blinkLeft_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__blinkLeft__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__blinkLeft__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__blinkLeft_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__blinkLeft_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__blinkLeft_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__blinkLeft__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__blinkLeft__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__blinkLeft__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__blinkLeft__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_BlinkRight(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__blinkRight_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__blinkRight_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__blinkRight_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__blinkRight_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__blinkRight_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__blinkRight_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__blinkRight_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__blinkRight_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__blinkRight_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__blinkRight__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__blinkRight__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__blinkRight_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__blinkRight_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__blinkRight_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__blinkRight__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__blinkRight__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__blinkRight__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__blinkRight__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_LookUp(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__lookUp_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__lookUp_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__lookUp_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__lookUp_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookUp_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__lookUp_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__lookUp_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookUp_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__lookUp_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__lookUp__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__lookUp__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__lookUp_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookUp_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__lookUp_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__lookUp__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__lookUp__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__lookUp__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__lookUp__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_LookDown(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__lookDown_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__lookDown_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__lookDown_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__lookDown_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookDown_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__lookDown_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__lookDown_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookDown_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__lookDown_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__lookDown__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__lookDown__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__lookDown_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookDown_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__lookDown_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__lookDown__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__lookDown__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__lookDown__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__lookDown__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_LookLeft(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__lookLeft_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__lookLeft_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__lookLeft_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__lookLeft_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookLeft_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__lookLeft_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__lookLeft_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookLeft_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__lookLeft_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__lookLeft__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__lookLeft__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__lookLeft_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookLeft_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__lookLeft_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__lookLeft__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__lookLeft__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__lookLeft__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__lookLeft__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Expression __expressions__preset_Deserialize_LookRight(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__preset__lookRight_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__preset__lookRight_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__preset__lookRight_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__preset__lookRight_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookRight_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__preset__lookRight_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__preset__lookRight_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookRight_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__preset__lookRight_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__preset__lookRight__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__lookRight__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__preset__lookRight_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__preset__lookRight_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__preset__lookRight_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__preset__lookRight__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__preset__lookRight__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__preset__lookRight__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__preset__lookRight__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static Dictionary<string, Expression> __expressions_Deserialize_Custom(JsonNode parsed)
+{
+    var value = new Dictionary<string, Expression>();
+    foreach(var kv in parsed.ObjectItems())
+    {
+        value.Add(kv.Key.GetString(), __expressions_Deserialize_Custom_ITEM(kv.Value));
+    }
+	return value;
+} 
+
+public static Expression __expressions_Deserialize_Custom_ITEM(JsonNode parsed)
+{
+    var value = new Expression();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="morphTargetBinds"){
+            value.MorphTargetBinds = __expressions__custom_PROP_Deserialize_MorphTargetBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="materialColorBinds"){
+            value.MaterialColorBinds = __expressions__custom_PROP_Deserialize_MaterialColorBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="textureTransformBinds"){
+            value.TextureTransformBinds = __expressions__custom_PROP_Deserialize_TextureTransformBinds(kv.Value);
+            continue;
+        }
+
+        if(key=="isBinary"){
+            value.IsBinary = kv.Value.GetBoolean();
+            continue;
+        }
+
+        if(key=="overrideBlink"){
+            value.OverrideBlink = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideLookAt"){
+            value.OverrideLookAt = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="overrideMouth"){
+            value.OverrideMouth = (ExpressionOverrideType)Enum.Parse(typeof(ExpressionOverrideType), kv.Value.GetString(), true);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MorphTargetBind> __expressions__custom_PROP_Deserialize_MorphTargetBinds(JsonNode parsed)
+{
+    var value = new List<MorphTargetBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__custom_PROP_Deserialize_MorphTargetBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MorphTargetBind __expressions__custom_PROP_Deserialize_MorphTargetBinds_ITEM(JsonNode parsed)
+{
+    var value = new MorphTargetBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="node"){
+            value.Node = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="index"){
+            value.Index = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="weight"){
+            value.Weight = kv.Value.GetSingle();
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static List<MaterialColorBind> __expressions__custom_PROP_Deserialize_MaterialColorBinds(JsonNode parsed)
+{
+    var value = new List<MaterialColorBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__custom_PROP_Deserialize_MaterialColorBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static MaterialColorBind __expressions__custom_PROP_Deserialize_MaterialColorBinds_ITEM(JsonNode parsed)
+{
+    var value = new MaterialColorBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="type"){
+            value.Type = (MaterialColorType)Enum.Parse(typeof(MaterialColorType), kv.Value.GetString(), true);
+            continue;
+        }
+
+        if(key=="targetValue"){
+            value.TargetValue = __expressions__custom_PROP__materialColorBinds_ITEM_Deserialize_TargetValue(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__custom_PROP__materialColorBinds_ITEM_Deserialize_TargetValue(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static List<TextureTransformBind> __expressions__custom_PROP_Deserialize_TextureTransformBinds(JsonNode parsed)
+{
+    var value = new List<TextureTransformBind>();
+    foreach(var x in parsed.ArrayItems())
+    {
+        value.Add(__expressions__custom_PROP_Deserialize_TextureTransformBinds_ITEM(x));
+    }
+	return value;
+} 
+
+public static TextureTransformBind __expressions__custom_PROP_Deserialize_TextureTransformBinds_ITEM(JsonNode parsed)
+{
+    var value = new TextureTransformBind();
+
+    foreach(var kv in parsed.ObjectItems())
+    {
+        var key = kv.Key.GetString();
+
+        if(key=="extensions"){
+            value.Extensions = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="extras"){
+            value.Extras = new glTFExtensionImport(kv.Value);
+            continue;
+        }
+
+        if(key=="material"){
+            value.Material = kv.Value.GetInt32();
+            continue;
+        }
+
+        if(key=="scale"){
+            value.Scale = __expressions__custom_PROP__textureTransformBinds_ITEM_Deserialize_Scale(kv.Value);
+            continue;
+        }
+
+        if(key=="offset"){
+            value.Offset = __expressions__custom_PROP__textureTransformBinds_ITEM_Deserialize_Offset(kv.Value);
+            continue;
+        }
+
+    }
+    return value;
+}
+
+public static float[] __expressions__custom_PROP__textureTransformBinds_ITEM_Deserialize_Scale(JsonNode parsed)
+{
+    var value = new float[parsed.GetArrayCount()];
+    int i=0;
+    foreach(var x in parsed.ArrayItems())
+    {
+        value[i++] = x.GetSingle();
+    }
+	return value;
+} 
+
+public static float[] __expressions__custom_PROP__textureTransformBinds_ITEM_Deserialize_Offset(JsonNode parsed)
 {
     var value = new float[parsed.GetArrayCount()];
     int i=0;

--- a/Assets/VRM10/Runtime/Format/Vrm/Deserializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/Vrm/Deserializer.g.cs
@@ -2309,7 +2309,7 @@ public static Expressions Deserialize_Expressions(JsonNode parsed)
     return value;
 }
 
-public static Preset  __expressions_Deserialize_Preset(JsonNode parsed)
+public static Preset __expressions_Deserialize_Preset(JsonNode parsed)
 {
     var value = new Preset();
 

--- a/Assets/VRM10/Runtime/Format/Vrm/Format.g.cs
+++ b/Assets/VRM10/Runtime/Format/Vrm/Format.g.cs
@@ -69,6 +69,9 @@ namespace UniGLTF.Extensions.VRMC_vrm
         // The index to the thumbnail image of the model in gltf.images
         public int? ThumbnailImage;
 
+        // A URL towards the license document this model refers to
+        public string LicenseUrl;
+
         // A person who can perform as an avatar with this model
         public AvatarPermissionType AvatarPermission;
 
@@ -346,7 +349,7 @@ namespace UniGLTF.Extensions.VRMC_vrm
         // Yaw and pitch angles  ( degrees )  between the head bone forward vector and the eye gaze LookAt vector
         public float? InputMaxValue;
 
-        // Degree for LookAtType.bone ,  Weight for LookAtType.blendShape
+        // Degree for type.bone, Weight for type.expressions
         public float? OutputScale;
     }
 
@@ -374,30 +377,6 @@ namespace UniGLTF.Extensions.VRMC_vrm
 
         // Vertical upward movement. Both eyes move downwards
         public LookAtRangeMap RangeMapVerticalUp;
-    }
-
-    public enum ExpressionPreset
-    {
-        custom,
-        happy,
-        angry,
-        sad,
-        relaxed,
-        surprised,
-        aa,
-        ih,
-        ou,
-        ee,
-        oh,
-        blink,
-        blinkLeft,
-        blinkRight,
-        lookUp,
-        lookDown,
-        lookLeft,
-        lookRight,
-        neutral,
-
     }
 
     public class MorphTargetBind
@@ -479,12 +458,6 @@ namespace UniGLTF.Extensions.VRMC_vrm
         // Application-specific data.
         public object Extras;
 
-        // Use only if the preset is custom. Unique within the model
-        public string Name;
-
-        // Functions of Expression
-        public ExpressionPreset Preset;
-
         // Specify a morph target
         public List<MorphTargetBind> MorphTargetBinds;
 
@@ -507,6 +480,75 @@ namespace UniGLTF.Extensions.VRMC_vrm
         public ExpressionOverrideType OverrideMouth;
     }
 
+    public class Preset
+    {
+        // Definition of expression by weighted animation
+        public Expression Happy;
+
+        // Definition of expression by weighted animation
+        public Expression Angry;
+
+        // Definition of expression by weighted animation
+        public Expression Sad;
+
+        // Definition of expression by weighted animation
+        public Expression Relaxed;
+
+        // Definition of expression by weighted animation
+        public Expression Surprised;
+
+        // Definition of expression by weighted animation
+        public Expression Aa;
+
+        // Definition of expression by weighted animation
+        public Expression Ih;
+
+        // Definition of expression by weighted animation
+        public Expression Ou;
+
+        // Definition of expression by weighted animation
+        public Expression Ee;
+
+        // Definition of expression by weighted animation
+        public Expression Oh;
+
+        // Definition of expression by weighted animation
+        public Expression Blink;
+
+        // Definition of expression by weighted animation
+        public Expression BlinkLeft;
+
+        // Definition of expression by weighted animation
+        public Expression BlinkRight;
+
+        // Definition of expression by weighted animation
+        public Expression LookUp;
+
+        // Definition of expression by weighted animation
+        public Expression LookDown;
+
+        // Definition of expression by weighted animation
+        public Expression LookLeft;
+
+        // Definition of expression by weighted animation
+        public Expression LookRight;
+    }
+
+    public class Expressions
+    {
+        // Dictionary object with extension-specific objects.
+        public object Extensions;
+
+        // Application-specific data.
+        public object Extras;
+
+        // Preset expressions
+        public Preset Preset;
+
+        // Custom expressions
+        public Dictionary<string, Expression> Custom;
+    }
+
     public class VRMC_vrm
     {
         public const string ExtensionName = "VRMC_vrm";
@@ -517,7 +559,7 @@ namespace UniGLTF.Extensions.VRMC_vrm
         // Application-specific data.
         public object Extras;
 
-        // Specification version of the VRM
+        // Specification version of VRMC_vrm
         public string SpecVersion;
 
         // Meta informations of the VRM model
@@ -532,7 +574,7 @@ namespace UniGLTF.Extensions.VRMC_vrm
         // Eye gaze control
         public LookAt LookAt;
 
-        // Definitions of expressions
-        public List<Expression> Expressions;
+        // Definition of expressions
+        public Expressions Expressions;
     }
 }

--- a/Assets/VRM10/Runtime/Format/Vrm/Serializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/Vrm/Serializer.g.cs
@@ -68,7 +68,7 @@ public static void Serialize(JsonFormatter f, VRMC_vrm value)
         Serialize_LookAt(f, value.LookAt);
     }
 
-    if(value.Expressions!=null&&value.Expressions.Count()>=0){
+    if(value.Expressions!=null){
         f.Key("expressions");                
         Serialize_Expressions(f, value.Expressions);
     }
@@ -116,7 +116,7 @@ public static void Serialize_Meta(JsonFormatter f, Meta value)
         f.Value(value.ContactInformation);
     }
 
-    if(value.References!=null&&value.References.Count()>=0){
+    if(value.References!=null&&value.References.Count()>=1){
         f.Key("references");                
         __meta_Serialize_References(f, value.References);
     }
@@ -129,6 +129,11 @@ public static void Serialize_Meta(JsonFormatter f, Meta value)
     if(value.ThumbnailImage.HasValue){
         f.Key("thumbnailImage");                
         f.Value(value.ThumbnailImage.GetValueOrDefault());
+    }
+
+    if(!string.IsNullOrEmpty(value.LicenseUrl)){
+        f.Key("licenseUrl");                
+        f.Value(value.LicenseUrl);
     }
 
     if(true){
@@ -1794,7 +1799,7 @@ public static void Serialize_FirstPerson(JsonFormatter f, FirstPerson value)
         (value.Extras as glTFExtension).Serialize(f);
     }
 
-    if(value.MeshAnnotations!=null&&value.MeshAnnotations.Count()>=0){
+    if(value.MeshAnnotations!=null&&value.MeshAnnotations.Count()>=1){
         f.Key("meshAnnotations");                
         __firstPerson_Serialize_MeshAnnotations(f, value.MeshAnnotations);
     }
@@ -1857,7 +1862,7 @@ public static void Serialize_LookAt(JsonFormatter f, LookAt value)
         (value.Extras as glTFExtension).Serialize(f);
     }
 
-    if(value.OffsetFromHeadBone!=null&&value.OffsetFromHeadBone.Count()>=0){
+    if(value.OffsetFromHeadBone!=null&&value.OffsetFromHeadBone.Count()>=3){
         f.Key("offsetFromHeadBone");                
         __lookAt_Serialize_OffsetFromHeadBone(f, value.OffsetFromHeadBone);
     }
@@ -2014,19 +2019,7 @@ public static void __lookAt_Serialize_RangeMapVerticalUp(JsonFormatter f, LookAt
     f.EndMap();
 }
 
-public static void Serialize_Expressions(JsonFormatter f, List<Expression> value)
-{
-    f.BeginList();
-
-    foreach(var item in value)
-    {
-    Serialize_Expressions_ITEM(f, item);
-
-    }
-    f.EndList();
-}
-
-public static void Serialize_Expressions_ITEM(JsonFormatter f, Expression value)
+public static void Serialize_Expressions(JsonFormatter f, Expressions value)
 {
     f.BeginMap();
 
@@ -2041,29 +2034,140 @@ public static void Serialize_Expressions_ITEM(JsonFormatter f, Expression value)
         (value.Extras as glTFExtension).Serialize(f);
     }
 
-    if(!string.IsNullOrEmpty(value.Name)){
-        f.Key("name");                
-        f.Value(value.Name);
-    }
-
-    if(true){
+    if(value.Preset!=null){
         f.Key("preset");                
-        f.Value(value.Preset.ToString());
+        __expressions_Serialize_Preset(f, value.Preset);
     }
 
-    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=0){
+    if(value.Custom!=null&&value.Custom.Count()>0){
+        f.Key("custom");                
+        __expressions_Serialize_Custom(f, value.Custom);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions_Serialize_Preset(JsonFormatter f, Preset value)
+{
+    f.BeginMap();
+
+
+    if(value.Happy!=null){
+        f.Key("happy");                
+        __expressions__preset_Serialize_Happy(f, value.Happy);
+    }
+
+    if(value.Angry!=null){
+        f.Key("angry");                
+        __expressions__preset_Serialize_Angry(f, value.Angry);
+    }
+
+    if(value.Sad!=null){
+        f.Key("sad");                
+        __expressions__preset_Serialize_Sad(f, value.Sad);
+    }
+
+    if(value.Relaxed!=null){
+        f.Key("relaxed");                
+        __expressions__preset_Serialize_Relaxed(f, value.Relaxed);
+    }
+
+    if(value.Surprised!=null){
+        f.Key("surprised");                
+        __expressions__preset_Serialize_Surprised(f, value.Surprised);
+    }
+
+    if(value.Aa!=null){
+        f.Key("aa");                
+        __expressions__preset_Serialize_Aa(f, value.Aa);
+    }
+
+    if(value.Ih!=null){
+        f.Key("ih");                
+        __expressions__preset_Serialize_Ih(f, value.Ih);
+    }
+
+    if(value.Ou!=null){
+        f.Key("ou");                
+        __expressions__preset_Serialize_Ou(f, value.Ou);
+    }
+
+    if(value.Ee!=null){
+        f.Key("ee");                
+        __expressions__preset_Serialize_Ee(f, value.Ee);
+    }
+
+    if(value.Oh!=null){
+        f.Key("oh");                
+        __expressions__preset_Serialize_Oh(f, value.Oh);
+    }
+
+    if(value.Blink!=null){
+        f.Key("blink");                
+        __expressions__preset_Serialize_Blink(f, value.Blink);
+    }
+
+    if(value.BlinkLeft!=null){
+        f.Key("blinkLeft");                
+        __expressions__preset_Serialize_BlinkLeft(f, value.BlinkLeft);
+    }
+
+    if(value.BlinkRight!=null){
+        f.Key("blinkRight");                
+        __expressions__preset_Serialize_BlinkRight(f, value.BlinkRight);
+    }
+
+    if(value.LookUp!=null){
+        f.Key("lookUp");                
+        __expressions__preset_Serialize_LookUp(f, value.LookUp);
+    }
+
+    if(value.LookDown!=null){
+        f.Key("lookDown");                
+        __expressions__preset_Serialize_LookDown(f, value.LookDown);
+    }
+
+    if(value.LookLeft!=null){
+        f.Key("lookLeft");                
+        __expressions__preset_Serialize_LookLeft(f, value.LookLeft);
+    }
+
+    if(value.LookRight!=null){
+        f.Key("lookRight");                
+        __expressions__preset_Serialize_LookRight(f, value.LookRight);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset_Serialize_Happy(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
         f.Key("morphTargetBinds");                
-        __expressions_ITEM_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+        __expressions__preset__happy_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
     }
 
-    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=0){
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
         f.Key("materialColorBinds");                
-        __expressions_ITEM_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+        __expressions__preset__happy_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
     }
 
-    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=0){
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
         f.Key("textureTransformBinds");                
-        __expressions_ITEM_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+        __expressions__preset__happy_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
     }
 
     if(value.IsBinary.HasValue){
@@ -2089,19 +2193,19 @@ public static void Serialize_Expressions_ITEM(JsonFormatter f, Expression value)
     f.EndMap();
 }
 
-public static void __expressions_ITEM_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+public static void __expressions__preset__happy_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
 {
     f.BeginList();
 
     foreach(var item in value)
     {
-    __expressions_ITEM_Serialize_MorphTargetBinds_ITEM(f, item);
+    __expressions__preset__happy_Serialize_MorphTargetBinds_ITEM(f, item);
 
     }
     f.EndList();
 }
 
-public static void __expressions_ITEM_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+public static void __expressions__preset__happy_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
 {
     f.BeginMap();
 
@@ -2134,19 +2238,19 @@ public static void __expressions_ITEM_Serialize_MorphTargetBinds_ITEM(JsonFormat
     f.EndMap();
 }
 
-public static void __expressions_ITEM_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+public static void __expressions__preset__happy_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
 {
     f.BeginList();
 
     foreach(var item in value)
     {
-    __expressions_ITEM_Serialize_MaterialColorBinds_ITEM(f, item);
+    __expressions__preset__happy_Serialize_MaterialColorBinds_ITEM(f, item);
 
     }
     f.EndList();
 }
 
-public static void __expressions_ITEM_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+public static void __expressions__preset__happy_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
 {
     f.BeginMap();
 
@@ -2173,13 +2277,13 @@ public static void __expressions_ITEM_Serialize_MaterialColorBinds_ITEM(JsonForm
 
     if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
         f.Key("targetValue");                
-        __expressions_ITEM__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+        __expressions__preset__happy__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
     }
 
     f.EndMap();
 }
 
-public static void __expressions_ITEM__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+public static void __expressions__preset__happy__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
 {
     f.BeginList();
 
@@ -2191,19 +2295,19 @@ public static void __expressions_ITEM__materialColorBinds_ITEM_Serialize_TargetV
     f.EndList();
 }
 
-public static void __expressions_ITEM_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+public static void __expressions__preset__happy_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
 {
     f.BeginList();
 
     foreach(var item in value)
     {
-    __expressions_ITEM_Serialize_TextureTransformBinds_ITEM(f, item);
+    __expressions__preset__happy_Serialize_TextureTransformBinds_ITEM(f, item);
 
     }
     f.EndList();
 }
 
-public static void __expressions_ITEM_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+public static void __expressions__preset__happy_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
 {
     f.BeginMap();
 
@@ -2225,18 +2329,18 @@ public static void __expressions_ITEM_Serialize_TextureTransformBinds_ITEM(JsonF
 
     if(value.Scale!=null&&value.Scale.Count()>=2){
         f.Key("scale");                
-        __expressions_ITEM__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+        __expressions__preset__happy__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
     }
 
     if(value.Offset!=null&&value.Offset.Count()>=2){
         f.Key("offset");                
-        __expressions_ITEM__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+        __expressions__preset__happy__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
     }
 
     f.EndMap();
 }
 
-public static void __expressions_ITEM__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+public static void __expressions__preset__happy__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
 {
     f.BeginList();
 
@@ -2248,7 +2352,3828 @@ public static void __expressions_ITEM__textureTransformBinds_ITEM_Serialize_Scal
     f.EndList();
 }
 
-public static void __expressions_ITEM__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+public static void __expressions__preset__happy__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_Angry(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__angry_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__angry_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__angry_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__angry_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__angry_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__angry_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__angry_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__angry_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__angry_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__angry__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__angry__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__angry_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__angry_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__angry_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__angry__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__angry__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__angry__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__angry__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_Sad(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__sad_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__sad_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__sad_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__sad_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__sad_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__sad_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__sad_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__sad_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__sad_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__sad__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__sad__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__sad_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__sad_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__sad_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__sad__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__sad__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__sad__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__sad__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_Relaxed(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__relaxed_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__relaxed_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__relaxed_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__relaxed_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__relaxed_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__relaxed_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__relaxed_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__relaxed_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__relaxed_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__relaxed__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__relaxed__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__relaxed_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__relaxed_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__relaxed_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__relaxed__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__relaxed__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__relaxed__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__relaxed__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_Surprised(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__surprised_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__surprised_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__surprised_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__surprised_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__surprised_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__surprised_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__surprised_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__surprised_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__surprised_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__surprised__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__surprised__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__surprised_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__surprised_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__surprised_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__surprised__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__surprised__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__surprised__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__surprised__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_Aa(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__aa_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__aa_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__aa_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__aa_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__aa_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__aa_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__aa_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__aa_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__aa_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__aa__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__aa__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__aa_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__aa_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__aa_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__aa__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__aa__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__aa__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__aa__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_Ih(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__ih_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__ih_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__ih_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ih_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__ih_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ih_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ih_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__ih_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ih_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__ih__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ih__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ih_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__ih_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ih_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__ih__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__ih__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ih__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ih__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_Ou(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__ou_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__ou_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__ou_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ou_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__ou_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ou_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ou_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__ou_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ou_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__ou__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ou__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ou_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__ou_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ou_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__ou__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__ou__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ou__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ou__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_Ee(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__ee_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__ee_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__ee_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ee_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__ee_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ee_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ee_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__ee_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ee_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__ee__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ee__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ee_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__ee_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ee_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__ee__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__ee__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__ee__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__ee__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_Oh(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__oh_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__oh_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__oh_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__oh_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__oh_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__oh_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__oh_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__oh_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__oh_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__oh__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__oh__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__oh_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__oh_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__oh_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__oh__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__oh__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__oh__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__oh__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_Blink(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__blink_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__blink_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__blink_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blink_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__blink_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blink_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blink_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__blink_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blink_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__blink__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blink__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blink_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__blink_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blink_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__blink__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__blink__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blink__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blink__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_BlinkLeft(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__blinkLeft_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__blinkLeft_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__blinkLeft_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blinkLeft_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__blinkLeft_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blinkLeft_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blinkLeft_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__blinkLeft_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blinkLeft_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__blinkLeft__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blinkLeft__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blinkLeft_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__blinkLeft_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blinkLeft_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__blinkLeft__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__blinkLeft__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blinkLeft__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blinkLeft__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_BlinkRight(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__blinkRight_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__blinkRight_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__blinkRight_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blinkRight_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__blinkRight_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blinkRight_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blinkRight_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__blinkRight_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blinkRight_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__blinkRight__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blinkRight__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blinkRight_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__blinkRight_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blinkRight_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__blinkRight__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__blinkRight__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__blinkRight__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__blinkRight__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_LookUp(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__lookUp_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__lookUp_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__lookUp_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookUp_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookUp_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookUp_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookUp_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookUp_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookUp_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__lookUp__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookUp__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookUp_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookUp_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookUp_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__lookUp__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__lookUp__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookUp__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookUp__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_LookDown(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__lookDown_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__lookDown_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__lookDown_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookDown_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookDown_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookDown_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookDown_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookDown_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookDown_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__lookDown__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookDown__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookDown_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookDown_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookDown_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__lookDown__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__lookDown__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookDown__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookDown__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_LookLeft(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__lookLeft_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__lookLeft_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__lookLeft_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookLeft_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookLeft_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookLeft_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookLeft_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookLeft_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookLeft_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__lookLeft__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookLeft__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookLeft_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookLeft_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookLeft_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__lookLeft__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__lookLeft__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookLeft__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookLeft__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset_Serialize_LookRight(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__preset__lookRight_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__preset__lookRight_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__preset__lookRight_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookRight_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookRight_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookRight_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookRight_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookRight_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookRight_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__preset__lookRight__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookRight__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookRight_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__preset__lookRight_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookRight_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__preset__lookRight__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__preset__lookRight__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__preset__lookRight__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__preset__lookRight__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions_Serialize_Custom(JsonFormatter f, Dictionary<string, Expression> value)
+{
+    f.BeginMap();
+
+    foreach(var kv in value)
+    {
+        f.Key(kv.Key);
+    __expressions_Serialize_Custom_ITEM(f, kv.Value);
+
+    }
+    f.EndMap();
+}
+
+public static void __expressions_Serialize_Custom_ITEM(JsonFormatter f, Expression value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.MorphTargetBinds!=null&&value.MorphTargetBinds.Count()>=1){
+        f.Key("morphTargetBinds");                
+        __expressions__custom_PROP_Serialize_MorphTargetBinds(f, value.MorphTargetBinds);
+    }
+
+    if(value.MaterialColorBinds!=null&&value.MaterialColorBinds.Count()>=1){
+        f.Key("materialColorBinds");                
+        __expressions__custom_PROP_Serialize_MaterialColorBinds(f, value.MaterialColorBinds);
+    }
+
+    if(value.TextureTransformBinds!=null&&value.TextureTransformBinds.Count()>=1){
+        f.Key("textureTransformBinds");                
+        __expressions__custom_PROP_Serialize_TextureTransformBinds(f, value.TextureTransformBinds);
+    }
+
+    if(value.IsBinary.HasValue){
+        f.Key("isBinary");                
+        f.Value(value.IsBinary.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("overrideBlink");                
+        f.Value(value.OverrideBlink.ToString());
+    }
+
+    if(true){
+        f.Key("overrideLookAt");                
+        f.Value(value.OverrideLookAt.ToString());
+    }
+
+    if(true){
+        f.Key("overrideMouth");                
+        f.Value(value.OverrideMouth.ToString());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__custom_PROP_Serialize_MorphTargetBinds(JsonFormatter f, List<MorphTargetBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__custom_PROP_Serialize_MorphTargetBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__custom_PROP_Serialize_MorphTargetBinds_ITEM(JsonFormatter f, MorphTargetBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Node.HasValue){
+        f.Key("node");                
+        f.Value(value.Node.GetValueOrDefault());
+    }
+
+    if(value.Index.HasValue){
+        f.Key("index");                
+        f.Value(value.Index.GetValueOrDefault());
+    }
+
+    if(value.Weight.HasValue){
+        f.Key("weight");                
+        f.Value(value.Weight.GetValueOrDefault());
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__custom_PROP_Serialize_MaterialColorBinds(JsonFormatter f, List<MaterialColorBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__custom_PROP_Serialize_MaterialColorBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__custom_PROP_Serialize_MaterialColorBinds_ITEM(JsonFormatter f, MaterialColorBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(true){
+        f.Key("type");                
+        f.Value(value.Type.ToString());
+    }
+
+    if(value.TargetValue!=null&&value.TargetValue.Count()>=4){
+        f.Key("targetValue");                
+        __expressions__custom_PROP__materialColorBinds_ITEM_Serialize_TargetValue(f, value.TargetValue);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__custom_PROP__materialColorBinds_ITEM_Serialize_TargetValue(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__custom_PROP_Serialize_TextureTransformBinds(JsonFormatter f, List<TextureTransformBind> value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    __expressions__custom_PROP_Serialize_TextureTransformBinds_ITEM(f, item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__custom_PROP_Serialize_TextureTransformBinds_ITEM(JsonFormatter f, TextureTransformBind value)
+{
+    f.BeginMap();
+
+
+    if(value.Extensions!=null){
+        f.Key("extensions");                
+        (value.Extensions as glTFExtension).Serialize(f);
+    }
+
+    if(value.Extras!=null){
+        f.Key("extras");                
+        (value.Extras as glTFExtension).Serialize(f);
+    }
+
+    if(value.Material.HasValue){
+        f.Key("material");                
+        f.Value(value.Material.GetValueOrDefault());
+    }
+
+    if(value.Scale!=null&&value.Scale.Count()>=2){
+        f.Key("scale");                
+        __expressions__custom_PROP__textureTransformBinds_ITEM_Serialize_Scale(f, value.Scale);
+    }
+
+    if(value.Offset!=null&&value.Offset.Count()>=2){
+        f.Key("offset");                
+        __expressions__custom_PROP__textureTransformBinds_ITEM_Serialize_Offset(f, value.Offset);
+    }
+
+    f.EndMap();
+}
+
+public static void __expressions__custom_PROP__textureTransformBinds_ITEM_Serialize_Scale(JsonFormatter f, float[] value)
+{
+    f.BeginList();
+
+    foreach(var item in value)
+    {
+    f.Value(item);
+
+    }
+    f.EndList();
+}
+
+public static void __expressions__custom_PROP__textureTransformBinds_ITEM_Serialize_Offset(JsonFormatter f, float[] value)
 {
     f.BeginList();
 

--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
@@ -10,6 +10,8 @@ namespace UniVRM10
 {
     public static class Vrm10MToonMaterialExporter
     {
+        const string MTOON_SPEC_VERSION = "1.0-draft";
+
         public static bool TryExportMaterialAsMToon(Material src, ITextureExporter textureExporter, out glTFMaterial dst)
         {
             try
@@ -30,7 +32,7 @@ namespace UniVRM10
 
                 // vrmc_materials_mtoon ext
                 var mtoon = new UniGLTF.Extensions.VRMC_materials_mtoon.VRMC_materials_mtoon();
-                mtoon.Version = "";
+                mtoon.SpecVersion = MTOON_SPEC_VERSION;
 
                 // Rendering
                 dst.alphaMode = ExportAlphaMode(context.AlphaMode);

--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -558,11 +558,11 @@ namespace UniVRM10
             };
         }
 
-        void ExportExpression(UniGLTF.Extensions.VRMC_vrm.VRMC_vrm vrm, VRM10Controller vrmController, Model model, ModelExporter converter)
+        UniGLTF.Extensions.VRMC_vrm.Expression ExportExpression(VRM10Expression e, VRM10Controller vrmController, Model model, ModelExporter converter)
         {
-            if (vrmController?.Vrm?.Expression?.Clips == null)
+            if (e == null)
             {
-                return;
+                return null;
             }
 
             Func<string, int> getIndexFromRelativePath = relativePath =>
@@ -570,6 +570,19 @@ namespace UniVRM10
                 var rendererNode = vrmController.transform.GetFromPath(relativePath);
                 var node = converter.Nodes[rendererNode.gameObject];
                 return model.Nodes.IndexOf(node);
+            };
+
+            var vrmExpression = new UniGLTF.Extensions.VRMC_vrm.Expression
+            {
+                // Preset = e.Preset,
+                // Name = e.ExpressionName,
+                IsBinary = e.IsBinary,
+                OverrideBlink = e.OverrideBlink,
+                OverrideLookAt = e.OverrideLookAt,
+                OverrideMouth = e.OverrideMouth,
+                MorphTargetBinds = new List<UniGLTF.Extensions.VRMC_vrm.MorphTargetBind>(),
+                MaterialColorBinds = new List<UniGLTF.Extensions.VRMC_vrm.MaterialColorBind>(),
+                TextureTransformBinds = new List<UniGLTF.Extensions.VRMC_vrm.TextureTransformBind>(),
             };
             Func<string, int> getIndexFromMaterialName = materialName =>
             {
@@ -584,56 +597,73 @@ namespace UniVRM10
                 throw new KeyNotFoundException();
             };
 
-            vrm.Expressions = new List<UniGLTF.Extensions.VRMC_vrm.Expression>();
-            foreach (var e in vrmController.Vrm.Expression.Clips)
+            foreach (var b in e.MorphTargetBindings)
             {
-                var vrmExpression = new UniGLTF.Extensions.VRMC_vrm.Expression
+                try
                 {
-                    Preset = e.Preset,
-                    Name = e.ExpressionName,
-                    IsBinary = e.IsBinary,
-                    OverrideBlink = e.OverrideBlink,
-                    OverrideLookAt = e.OverrideLookAt,
-                    OverrideMouth = e.OverrideMouth,
-                    MorphTargetBinds = new List<UniGLTF.Extensions.VRMC_vrm.MorphTargetBind>(),
-                    MaterialColorBinds = new List<UniGLTF.Extensions.VRMC_vrm.MaterialColorBind>(),
-                    TextureTransformBinds = new List<UniGLTF.Extensions.VRMC_vrm.TextureTransformBind>(),
-                };
-                foreach (var b in e.MorphTargetBindings)
-                {
-                    try
-                    {
-                        vrmExpression.MorphTargetBinds.Add(ExportMorphTargetBinding(b, getIndexFromRelativePath));
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.LogWarning(ex);
-                    }
+                    vrmExpression.MorphTargetBinds.Add(ExportMorphTargetBinding(b, getIndexFromRelativePath));
                 }
-                foreach (var b in e.MaterialColorBindings)
+                catch (Exception ex)
                 {
-                    try
-                    {
-                        vrmExpression.MaterialColorBinds.Add(ExportMaterialColorBinding(b, getIndexFromMaterialName));
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.LogWarning(ex);
-                    }
+                    Debug.LogWarning(ex);
                 }
-                foreach (var b in e.MaterialUVBindings)
-                {
-                    try
-                    {
-                        vrmExpression.TextureTransformBinds.Add(ExportTextureTransformBinding(b, getIndexFromMaterialName));
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.LogWarning(ex);
-                    }
-                }
-                vrm.Expressions.Add(vrmExpression);
             }
+            foreach (var b in e.MaterialColorBindings)
+            {
+                try
+                {
+                    vrmExpression.MaterialColorBinds.Add(ExportMaterialColorBinding(b, getIndexFromMaterialName));
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning(ex);
+                }
+            }
+            foreach (var b in e.MaterialUVBindings)
+            {
+                try
+                {
+                    vrmExpression.TextureTransformBinds.Add(ExportTextureTransformBinding(b, getIndexFromMaterialName));
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning(ex);
+                }
+            }
+            return vrmExpression;
+        }
+
+        void ExportExpression(UniGLTF.Extensions.VRMC_vrm.VRMC_vrm vrm, VRM10Controller vrmController, Model model, ModelExporter converter)
+        {
+            if (vrmController?.Vrm?.Expression?.Clips == null)
+            {
+                return;
+            }
+
+            vrm.Expressions = new UniGLTF.Extensions.VRMC_vrm.Expressions
+            {
+                Preset = new UniGLTF.Extensions.VRMC_vrm.Preset
+                {
+                    Happy = ExportExpression(vrmController.Vrm.Expression.Happy, vrmController, model, converter),
+                    Angry = ExportExpression(vrmController.Vrm.Expression.Angry, vrmController, model, converter),
+                    Sad = ExportExpression(vrmController.Vrm.Expression.Sad, vrmController, model, converter),
+                    Relaxed = ExportExpression(vrmController.Vrm.Expression.Relaxed, vrmController, model, converter),
+                    Surprised = ExportExpression(vrmController.Vrm.Expression.Surprised, vrmController, model, converter),
+                    Aa = ExportExpression(vrmController.Vrm.Expression.Aa, vrmController, model, converter),
+                    Ih = ExportExpression(vrmController.Vrm.Expression.Ih, vrmController, model, converter),
+                    Ou = ExportExpression(vrmController.Vrm.Expression.Ou, vrmController, model, converter),
+                    Ee = ExportExpression(vrmController.Vrm.Expression.Ee, vrmController, model, converter),
+                    Oh = ExportExpression(vrmController.Vrm.Expression.Oh, vrmController, model, converter),
+                    Blink = ExportExpression(vrmController.Vrm.Expression.Blink, vrmController, model, converter),
+                    BlinkLeft = ExportExpression(vrmController.Vrm.Expression.BlinkLeft, vrmController, model, converter),
+                    BlinkRight = ExportExpression(vrmController.Vrm.Expression.BlinkRight, vrmController, model, converter),
+                    LookUp = ExportExpression(vrmController.Vrm.Expression.LookUp, vrmController, model, converter),
+                    LookDown = ExportExpression(vrmController.Vrm.Expression.LookDown, vrmController, model, converter),
+                    LookLeft = ExportExpression(vrmController.Vrm.Expression.LookLeft, vrmController, model, converter),
+                    LookRight = ExportExpression(vrmController.Vrm.Expression.LookRight, vrmController, model, converter),
+                },
+                Custom = vrmController.Vrm.Expression.CustomClips.ToDictionary(c => c.ExpressionName, c => ExportExpression(c, vrmController, model, converter)),
+            };
         }
 
         int? ExportMeta(UniGLTF.Extensions.VRMC_vrm.VRMC_vrm vrm, VRM10ObjectMeta meta)

--- a/Assets/VRM10/Runtime/Migration/MigrationVrm.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrm.cs
@@ -45,7 +45,37 @@ namespace UniVRM10
                 // blendshape (optional)
                 if (vrm0.TryGet("blendShapeMaster", out JsonNode vrm0BlendShape))
                 {
-                    vrm1.Expressions = MigrationVrmExpression.Migrate(gltf, vrm0BlendShape).ToList();
+                    vrm1.Expressions = new UniGLTF.Extensions.VRMC_vrm.Expressions
+                    {
+                        Preset = new UniGLTF.Extensions.VRMC_vrm.Preset(),
+                        Custom = new Dictionary<string, UniGLTF.Extensions.VRMC_vrm.Expression>(),
+                    };
+                    foreach (var (preset, customName, expression) in MigrationVrmExpression.Migrate(gltf, vrm0BlendShape))
+                    {
+                        switch (preset)
+                        {
+                            case ExpressionPreset.happy: vrm1.Expressions.Preset.Happy = expression; break;
+                            case ExpressionPreset.angry: vrm1.Expressions.Preset.Angry = expression; break;
+                            case ExpressionPreset.sad: vrm1.Expressions.Preset.Sad = expression; break;
+                            case ExpressionPreset.relaxed: vrm1.Expressions.Preset.Relaxed = expression; break;
+                            case ExpressionPreset.surprised: vrm1.Expressions.Preset.Surprised = expression; break;
+                            case ExpressionPreset.aa: vrm1.Expressions.Preset.Aa = expression; break;
+                            case ExpressionPreset.ih: vrm1.Expressions.Preset.Ih = expression; break;
+                            case ExpressionPreset.ou: vrm1.Expressions.Preset.Ou = expression; break;
+                            case ExpressionPreset.ee: vrm1.Expressions.Preset.Ee = expression; break;
+                            case ExpressionPreset.oh: vrm1.Expressions.Preset.Oh = expression; break;
+                            case ExpressionPreset.blink: vrm1.Expressions.Preset.Blink = expression; break;
+                            case ExpressionPreset.blinkLeft: vrm1.Expressions.Preset.BlinkLeft = expression; break;
+                            case ExpressionPreset.blinkRight: vrm1.Expressions.Preset.BlinkRight = expression; break;
+                            case ExpressionPreset.lookUp: vrm1.Expressions.Preset.LookUp = expression; break;
+                            case ExpressionPreset.lookDown: vrm1.Expressions.Preset.LookDown = expression; break;
+                            case ExpressionPreset.lookLeft: vrm1.Expressions.Preset.LookLeft = expression; break;
+                            case ExpressionPreset.lookRight: vrm1.Expressions.Preset.LookRight = expression; break;
+                            case ExpressionPreset.neutral: vrm1.Expressions.Custom[customName] = expression; break;
+                            case ExpressionPreset.custom: vrm1.Expressions.Custom[customName] = expression; break;
+                            default: throw new NotImplementedException();
+                        }
+                    }
                 }
 
                 // lookat & firstperson (optional)

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmExpression.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmExpression.cs
@@ -7,35 +7,35 @@ namespace UniVRM10
 {
     public static class MigrationVrmExpression
     {
-        static UniGLTF.Extensions.VRMC_vrm.ExpressionPreset ToPreset(JsonNode json)
+        static ExpressionPreset ToPreset(JsonNode json)
         {
             switch (json.GetString().ToLower())
             {
-                case "unknown": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.custom;
+                case "unknown": return ExpressionPreset.custom;
 
                 // https://github.com/vrm-c/vrm-specification/issues/185
-                case "neutral": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.neutral;
+                case "neutral": return ExpressionPreset.neutral;
 
-                case "a": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.aa;
-                case "i": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ih;
-                case "u": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ou;
-                case "e": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.ee;
-                case "o": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.oh;
+                case "a": return ExpressionPreset.aa;
+                case "i": return ExpressionPreset.ih;
+                case "u": return ExpressionPreset.ou;
+                case "e": return ExpressionPreset.ee;
+                case "o": return ExpressionPreset.oh;
 
-                case "blink": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blink;
-                case "blink_l": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blinkLeft;
-                case "blink_r": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.blinkRight;
+                case "blink": return ExpressionPreset.blink;
+                case "blink_l": return ExpressionPreset.blinkLeft;
+                case "blink_r": return ExpressionPreset.blinkRight;
 
                 // https://github.com/vrm-c/vrm-specification/issues/163
-                case "joy": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.happy;
-                case "angry": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.angry;
-                case "sorrow": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.sad;
-                case "fun": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.relaxed;
+                case "joy": return ExpressionPreset.happy;
+                case "angry": return ExpressionPreset.angry;
+                case "sorrow": return ExpressionPreset.sad;
+                case "fun": return ExpressionPreset.relaxed;
 
-                case "lookup": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookUp;
-                case "lookdown": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookDown;
-                case "lookleft": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookLeft;
-                case "lookright": return UniGLTF.Extensions.VRMC_vrm.ExpressionPreset.lookRight;
+                case "lookup": return ExpressionPreset.lookUp;
+                case "lookdown": return ExpressionPreset.lookDown;
+                case "lookleft": return ExpressionPreset.lookLeft;
+                case "lookright": return ExpressionPreset.lookRight;
             }
 
             throw new NotImplementedException();
@@ -152,7 +152,7 @@ namespace UniVRM10
             }
         }
 
-        public static IEnumerable<UniGLTF.Extensions.VRMC_vrm.Expression> Migrate(UniGLTF.glTF gltf, JsonNode json)
+        public static IEnumerable<(ExpressionPreset, string, UniGLTF.Extensions.VRMC_vrm.Expression)> Migrate(UniGLTF.glTF gltf, JsonNode json)
         {
             foreach (var blendShapeClip in json["blendShapeGroups"].ArrayItems())
             {
@@ -162,10 +162,9 @@ namespace UniVRM10
                 {
                     isBinary = isBinaryNode.GetBoolean();
                 }
+                var preset = ToPreset(blendShapeClip["presetName"]);
                 var expression = new UniGLTF.Extensions.VRMC_vrm.Expression
                 {
-                    Name = name,
-                    Preset = ToPreset(blendShapeClip["presetName"]),
                     IsBinary = isBinary,
                     MorphTargetBinds = new List<UniGLTF.Extensions.VRMC_vrm.MorphTargetBind>(),
                     MaterialColorBinds = new List<UniGLTF.Extensions.VRMC_vrm.MaterialColorBind>(),
@@ -178,7 +177,7 @@ namespace UniVRM10
                     ToMaterialColorBinds(gltf, materialValues, expression);
                 }
 
-                yield return expression;
+                yield return (preset, name, expression);
             }
         }
     }

--- a/Assets/VRM10/Tests/SerializationTests.cs
+++ b/Assets/VRM10/Tests/SerializationTests.cs
@@ -211,7 +211,7 @@ namespace UniVRM10
                 var data = new UniGLTF.Extensions.VRMC_vrm.Expression();
                 data.OverrideBlink = UniGLTF.Extensions.VRMC_vrm.ExpressionOverrideType.block;
 
-                var json = Serialize(data, UniGLTF.Extensions.VRMC_vrm.GltfSerializer.Serialize_Expressions_ITEM);
+                var json = Serialize(data, UniGLTF.Extensions.VRMC_vrm.GltfSerializer.__expressions_Serialize_Custom_ITEM);
                 Assert.AreEqual($"{{{q}preset{q}:{q}custom{q},{q}overrideBlink{q}:{q}block{q},{q}overrideLookAt{q}:{q}none{q},{q}overrideMouth{q}:{q}none{q}}}", json);
             }
 
@@ -241,14 +241,14 @@ namespace UniVRM10
                 // foreach (var preset in Enum.GetValues(typeof(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset)) as UniGLTF.Extensions.VRMC_vrm.ExpressionPreset[])
                 // {
                 //     var expression = new UniGLTF.Extensions.VRMC_vrm.Expression(preset, "", false);
-                    
+
                 //     // expect no exception
                 //     var gltf = ExpressionAdapter.ToGltf(
                 //         expression, 
                 //         new List<UniGLTF.Extensions.VRMC_vrm.Node>(),
                 //         new List<UniGLTF.Extensions.VRMC_vrm.Material>());
                 // }
-                
+
                 // // import 
                 // foreach (var preset in Enum.GetValues(typeof(UniGLTF.Extensions.VRMC_vrm.ExpressionPreset)) as UniGLTF.Extensions.VRMC_vrm.ExpressionPreset[])
                 // {

--- a/Assets/VRMShaders/VRM10/Format/Runtime/MaterialsMToon/Format.g.cs
+++ b/Assets/VRMShaders/VRM10/Format/Runtime/MaterialsMToon/Format.g.cs
@@ -57,8 +57,8 @@ namespace UniGLTF.Extensions.VRMC_materials_mtoon
         // Application-specific data.
         public object Extras;
 
-        // Meta
-        public string Version;
+        // Specification version of VRMC_materials_mtoon
+        public string SpecVersion;
 
         // enable depth buffer when `alphaMode` is `BLEND`
         public bool? TransparentWithZWrite;


### PR DESCRIPTION
https://github.com/vrm-c/vrm-specification/pull/296

`Expression[]`

が

```
Expressions
{
  Preset{
    Happy Expression;
    Angly Expression;
    Aa Expression;
    // enum を固定メンバーに展開
  }
  Expression[] Custom;
}
```

のように enum 展開され、enum が消滅した。
