### PR TITLE
fix MissingReferenceException

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs
@@ -66,7 +66,10 @@ namespace UniGLTF
 
         public void Dispose()
         {
-            UnityObjectDestoyer.DestroyRuntimeOrEditor(this.gameObject);
+            if (this != null && this.gameObject != null)
+            {
+                UnityObjectDestoyer.DestroyRuntimeOrEditor(this.gameObject);
+            }
         }
     }
 }


### PR DESCRIPTION
すでに `RuntmeGltfInstance` コンポーネントや gameobject が破壊されていた場合に Dispose を呼ぶと `MissingReferenceException` が出るのを修正