### PR TITLE
Make asmdef's auto-referenced true.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF.asmdef
+++ b/Assets/UniGLTF/Runtime/UniGLTF.asmdef
@@ -10,6 +10,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": []
 }

--- a/Assets/UniGLTF/UniHumanoid/UniHumanoid.asmdef
+++ b/Assets/UniGLTF/UniHumanoid/UniHumanoid.asmdef
@@ -7,6 +7,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": []
 }

--- a/Assets/VRM/Runtime/VRM.asmdef
+++ b/Assets/VRM/Runtime/VRM.asmdef
@@ -13,6 +13,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": []
 }

--- a/Assets/VRM10/Runtime/VRM10.asmdef
+++ b/Assets/VRM10/Runtime/VRM10.asmdef
@@ -15,6 +15,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": []
 }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/VRMShaders.GLTF.IO.Runtime.asmdef
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/VRMShaders.GLTF.IO.Runtime.asmdef
@@ -9,6 +9,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": []
 }


### PR DESCRIPTION
https://github.com/vrm-c/UniVRM/issues/1107

ユーザが `ImporterContext` などの公開 API を使用するのに必要な asmdef の `Auto Referenced` を `true` に変更。