### PR TITLE
Use GUID in asmdefs

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF.Editor.asmdef
+++ b/Assets/UniGLTF/Editor/UniGLTF.Editor.asmdef
@@ -1,11 +1,10 @@
 {
     "name": "UniGLTF.Editor",
     "references": [
-        "UniGLTF",
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.GLTF.IO.Editor"
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:7da8a75dcade2144aab699032d7d7987"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -14,5 +13,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF.asmdef
+++ b/Assets/UniGLTF/Runtime/UniGLTF.asmdef
@@ -1,15 +1,16 @@
 {
     "name": "UniGLTF",
     "references": [
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.GLTF.UniUnlit.Runtime"
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:60c8346e00a8ddd4cafc5a02eceeec57"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/UniGLTF/Tests/UniGLTF.Tests.asmdef
+++ b/Assets/UniGLTF/Tests/UniGLTF.Tests.asmdef
@@ -1,25 +1,28 @@
 {
     "name": "UniGLTF.Tests",
     "references": [
-        "UniGLTF",
-        "UniGLTF.Editor",
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.GLTF.IO.Editor"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:5f875fdc81c40184c8333b9d63c6ddd5",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:7da8a75dcade2144aab699032d7d7987",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [
+        "nunit.framework.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
-    ]
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/UniGLTF/Tests/UniGLTF.Tests.asmdef
+++ b/Assets/UniGLTF/Tests/UniGLTF.Tests.asmdef
@@ -15,12 +15,10 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
-        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
     ],
     "versionDefines": [],

--- a/Assets/UniGLTF/UniHumanoid/Editor/Tests/UniHumanoid.Editor.Tests.asmdef
+++ b/Assets/UniGLTF/UniHumanoid/Editor/Tests/UniHumanoid.Editor.Tests.asmdef
@@ -1,19 +1,24 @@
 {
     "name": "UniHumanoid.Editor.Tests",
     "references": [
-        "VRM",
-        "UniHumanoid"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "GUID:05dd262a0c0a2f841b8252c8c3815582",
+        "GUID:b7aa47b240b57de44a4b2021c143c9bf",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/UniGLTF/UniHumanoid/Editor/UniHumanoid.Editor.asmdef
+++ b/Assets/UniGLTF/UniHumanoid/Editor/UniHumanoid.Editor.asmdef
@@ -1,10 +1,9 @@
 {
     "name": "UniHumanoid.Editor",
     "references": [
-        "VRM",
-        "UniHumanoid"
+        "GUID:05dd262a0c0a2f841b8252c8c3815582",
+        "GUID:b7aa47b240b57de44a4b2021c143c9bf"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -13,5 +12,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/UniGLTF/UniHumanoid/UniHumanoid.asmdef
+++ b/Assets/UniGLTF/UniHumanoid/UniHumanoid.asmdef
@@ -1,12 +1,13 @@
 {
     "name": "UniHumanoid",
     "references": [],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM.Samples/Editor/Tests/VRM.Samples.Editor.Tests.asmdef
+++ b/Assets/VRM.Samples/Editor/Tests/VRM.Samples.Editor.Tests.asmdef
@@ -18,12 +18,10 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
-        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
     ],
     "versionDefines": [],

--- a/Assets/VRM.Samples/Editor/Tests/VRM.Samples.Editor.Tests.asmdef
+++ b/Assets/VRM.Samples/Editor/Tests/VRM.Samples.Editor.Tests.asmdef
@@ -1,28 +1,31 @@
 {
     "name": "VRM.Samples.Editor.Tests",
     "references": [
-        "VRM",
-        "VRM.Samples",
-        "UniGLTF",
-        "UniVRM.Editor",
-        "VRM.Tests",
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.GLTF.IO.Editor"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "GUID:05dd262a0c0a2f841b8252c8c3815582",
+        "GUID:627491ce4646ac8469d7689ab146358b",
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:f7b2dd4e5e1e7264089dc065c45db910",
+        "GUID:0eadcadee644f4e4cb96f0c11df10d89",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:7da8a75dcade2144aab699032d7d7987",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [
+        "nunit.framework.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
-    ]
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM.Samples/VRM.Samples.asmdef
+++ b/Assets/VRM.Samples/VRM.Samples.asmdef
@@ -1,17 +1,18 @@
 {
     "name": "VRM.Samples",
     "references": [
-        "VRM",
-        "UniHumanoid",
-        "UniGLTF",
-        "VRMShaders.GLTF.IO.Runtime"
+        "GUID:05dd262a0c0a2f841b8252c8c3815582",
+        "GUID:b7aa47b240b57de44a4b2021c143c9bf",
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:da3e51d19d51a544fa14d43fee843098"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM/Editor/VRM.Editor.asmdef
+++ b/Assets/VRM/Editor/VRM.Editor.asmdef
@@ -1,15 +1,14 @@
 {
     "name": "UniVRM.Editor",
     "references": [
-        "VRM",
-        "UniHumanoid",
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.GLTF.IO.Editor",
-        "UniGLTF",
-        "UniGLTF.Editor",
-        "VRMShaders.VRM.IO.Runtime"
+        "GUID:05dd262a0c0a2f841b8252c8c3815582",
+        "GUID:b7aa47b240b57de44a4b2021c143c9bf",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:7da8a75dcade2144aab699032d7d7987",
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:5f875fdc81c40184c8333b9d63c6ddd5",
+        "GUID:301b251fd9834274c9228e0532f444f7"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -18,5 +17,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM/Runtime/VRM.asmdef
+++ b/Assets/VRM/Runtime/VRM.asmdef
@@ -1,18 +1,19 @@
 {
     "name": "VRM",
     "references": [
-        "UniHumanoid",
-        "UniGLTF",
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.VRM.IO.Runtime",
-        "MToon"
+        "GUID:b7aa47b240b57de44a4b2021c143c9bf",
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:301b251fd9834274c9228e0532f444f7",
+        "GUID:a9bc101fb0471f94a8f99fd242fdd934"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM/Tests/VRM.Tests.asmdef
+++ b/Assets/VRM/Tests/VRM.Tests.asmdef
@@ -17,12 +17,10 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
-        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
     ],
     "versionDefines": [],

--- a/Assets/VRM/Tests/VRM.Tests.asmdef
+++ b/Assets/VRM/Tests/VRM.Tests.asmdef
@@ -1,27 +1,30 @@
 {
     "name": "VRM.Tests",
     "references": [
-        "VRM",
-        "UniVRM.Editor",
-        "UniGLTF",
-        "UniGLTF.Editor",
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.GLTF.IO.Editor"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "GUID:05dd262a0c0a2f841b8252c8c3815582",
+        "GUID:f7b2dd4e5e1e7264089dc065c45db910",
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:5f875fdc81c40184c8333b9d63c6ddd5",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:7da8a75dcade2144aab699032d7d7987",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [
+        "nunit.framework.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
-    ]
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM10.Samples/Runtime/VRM10.Samples.Runtime.asmdef
+++ b/Assets/VRM10.Samples/Runtime/VRM10.Samples.Runtime.asmdef
@@ -1,17 +1,18 @@
 {
     "name": "VRM10.Samples.Runtime",
     "references": [
-        "UniGLTF",
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRM10",
-        "UniHumanoid"
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:e47c917724578cc43b5506c17a27e9a0",
+        "GUID:b7aa47b240b57de44a4b2021c143c9bf"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM10/Editor/VRM10.Editor.asmdef
+++ b/Assets/VRM10/Editor/VRM10.Editor.asmdef
@@ -1,14 +1,13 @@
 {
     "name": "VRM10.Editor",
     "references": [
-        "VRM10",
-        "VrmLib",
-        "UniGLTF.Editor",
-        "UniGLTF",
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.GLTF.IO.Editor"
+        "GUID:e47c917724578cc43b5506c17a27e9a0",
+        "GUID:2ef84b520212e174a94668c7a0862d3b",
+        "GUID:5f875fdc81c40184c8333b9d63c6ddd5",
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:7da8a75dcade2144aab699032d7d7987"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -17,5 +16,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM10/Runtime/VRM10.asmdef
+++ b/Assets/VRM10/Runtime/VRM10.asmdef
@@ -1,20 +1,21 @@
 {
     "name": "VRM10",
     "references": [
-        "VrmLib",
-        "MToon",
-        "UniGLTF",
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.VRM10.Format.Runtime",
-        "VRMShaders.VRM10.MToon10.Runtime",
-        "UniHumanoid"
+        "GUID:2ef84b520212e174a94668c7a0862d3b",
+        "GUID:a9bc101fb0471f94a8f99fd242fdd934",
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:bce005214fa49654d93927908c15b1f2",
+        "GUID:0aaf403bd13871a44b7127aef2695ff8",
+        "GUID:b7aa47b240b57de44a4b2021c143c9bf"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM10/Tests.PlayMode/VRM10.Tests.PlayMode.asmdef
+++ b/Assets/VRM10/Tests.PlayMode/VRM10.Tests.PlayMode.asmdef
@@ -1,23 +1,26 @@
 {
     "name": "VRM10.Tests.PlayMode",
     "references": [
-        "VrmLib",
-        "VRM10",
-        "UniGLTF",
-        "VRMShaders.GLTF.IO.Runtime"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "GUID:2ef84b520212e174a94668c7a0862d3b",
+        "GUID:e47c917724578cc43b5506c17a27e9a0",
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [
+        "nunit.framework.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
-    ]
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM10/Tests.PlayMode/VRM10.Tests.PlayMode.asmdef
+++ b/Assets/VRM10/Tests.PlayMode/VRM10.Tests.PlayMode.asmdef
@@ -13,12 +13,10 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
-        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
     ],
     "versionDefines": [],

--- a/Assets/VRM10/Tests/VRM10.Tests.asmdef
+++ b/Assets/VRM10/Tests/VRM10.Tests.asmdef
@@ -20,7 +20,6 @@
     ],
     "autoReferenced": false,
     "defineConstraints": [
-        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
     ],
     "versionDefines": [],

--- a/Assets/VRM10/Tests/VRM10.Tests.asmdef
+++ b/Assets/VRM10/Tests/VRM10.Tests.asmdef
@@ -1,24 +1,28 @@
 {
     "name": "VRM10.Tests",
     "references": [
-        "VrmLib",
-        "VRM10",
-        "UniGLTF",
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.GLTF.IO.Editor"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "GUID:2ef84b520212e174a94668c7a0862d3b",
+        "GUID:e47c917724578cc43b5506c17a27e9a0",
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:7da8a75dcade2144aab699032d7d7987",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
     "autoReferenced": false,
     "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
-    ]
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM10/vrmlib/Runtime/VrmLib.asmdef
+++ b/Assets/VRM10/vrmlib/Runtime/VrmLib.asmdef
@@ -1,14 +1,15 @@
 {
     "name": "VrmLib",
     "references": [
-        "UniGLTF"
+        "GUID:8d76e605759c3f64a957d63ef96ada7c"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM10/vrmlib/Tests/VrmLib.Tests.asmdef
+++ b/Assets/VRM10/vrmlib/Tests/VrmLib.Tests.asmdef
@@ -1,20 +1,24 @@
 {
     "name": "VrmLibTests",
     "references": [
-        "VrmLib"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "GUID:2ef84b520212e174a94668c7a0862d3b",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
     "autoReferenced": false,
     "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
-    ]
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRM10/vrmlib/Tests/VrmLib.Tests.asmdef
+++ b/Assets/VRM10/vrmlib/Tests/VrmLib.Tests.asmdef
@@ -16,7 +16,6 @@
     ],
     "autoReferenced": false,
     "defineConstraints": [
-        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
     ],
     "versionDefines": [],

--- a/Assets/VRMShaders/GLTF/IO/Editor/VRMShaders.GLTF.IO.Editor.asmdef
+++ b/Assets/VRMShaders/GLTF/IO/Editor/VRMShaders.GLTF.IO.Editor.asmdef
@@ -1,9 +1,8 @@
 {
     "name": "VRMShaders.GLTF.IO.Editor",
     "references": [
-        "VRMShaders.GLTF.IO.Runtime"
+        "GUID:da3e51d19d51a544fa14d43fee843098"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,5 +11,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/VRMShaders.GLTF.IO.Runtime.asmdef
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/VRMShaders.GLTF.IO.Runtime.asmdef
@@ -1,14 +1,15 @@
 {
     "name": "VRMShaders.GLTF.IO.Runtime",
     "references": [
-        "VRMShaders.GLTF.UniUnlit.Runtime"
+        "GUID:60c8346e00a8ddd4cafc5a02eceeec57"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRMShaders/GLTF/IO/Tests/VRMShaders.GLTF.IO.Tests.asmdef
+++ b/Assets/VRMShaders/GLTF/IO/Tests/VRMShaders.GLTF.IO.Tests.asmdef
@@ -1,23 +1,26 @@
 {
     "name": "VRMShaders.GLTF.IO.Tests",
     "references": [
-        "VRMShaders.GLTF.IO.Runtime",
-        "VRMShaders.GLTF.IO.Editor"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "GUID:da3e51d19d51a544fa14d43fee843098",
+        "GUID:7da8a75dcade2144aab699032d7d7987",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [
+        "nunit.framework.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
-    ]
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRMShaders/GLTF/IO/Tests/VRMShaders.GLTF.IO.Tests.asmdef
+++ b/Assets/VRMShaders/GLTF/IO/Tests/VRMShaders.GLTF.IO.Tests.asmdef
@@ -13,12 +13,10 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
-        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
     ],
     "versionDefines": [],

--- a/Assets/VRMShaders/GLTF/UniUnlit/Editor/VRMShaders.GLTF.UniUnlit.Editor.asmdef
+++ b/Assets/VRMShaders/GLTF/UniUnlit/Editor/VRMShaders.GLTF.UniUnlit.Editor.asmdef
@@ -1,9 +1,8 @@
 {
     "name": "VRMShaders.GLTF.UniUnlit.Editor",
     "references": [
-        "VRMShaders.GLTF.UniUnlit.Runtime"
+        "GUID:60c8346e00a8ddd4cafc5a02eceeec57"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,5 +11,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRMShaders/GLTF/UniUnlit/Runtime/VRMShaders.GLTF.UniUnlit.Runtime.asmdef
+++ b/Assets/VRMShaders/GLTF/UniUnlit/Runtime/VRMShaders.GLTF.UniUnlit.Runtime.asmdef
@@ -1,12 +1,13 @@
 {
     "name": "VRMShaders.GLTF.UniUnlit.Runtime",
     "references": [],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRMShaders/VRM/IO/Editor/VRMShaders.VRM.IO.Editor.asmdef
+++ b/Assets/VRMShaders/VRM/IO/Editor/VRMShaders.VRM.IO.Editor.asmdef
@@ -1,9 +1,8 @@
 {
     "name": "VRMShaders.VRM.IO.Editor",
     "references": [
-        "VRMShaders.VRM.IO.Runtime"
+        "GUID:301b251fd9834274c9228e0532f444f7"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,5 +11,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRMShaders/VRM/IO/Runtime/VRMShaders.VRM.IO.Runtime.asmdef
+++ b/Assets/VRMShaders/VRM/IO/Runtime/VRMShaders.VRM.IO.Runtime.asmdef
@@ -1,12 +1,13 @@
 {
     "name": "VRMShaders.VRM.IO.Runtime",
     "references": [],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRMShaders/VRM10/Format/Runtime/VRMShaders.VRM10.Format.Runtime.asmdef
+++ b/Assets/VRMShaders/VRM10/Format/Runtime/VRMShaders.VRM10.Format.Runtime.asmdef
@@ -1,12 +1,13 @@
 {
     "name": "VRMShaders.VRM10.Format.Runtime",
     "references": [],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRMShaders/VRM10/MToon10/Editor/VRMShaders.VRM10.MToon10.Editor.asmdef
+++ b/Assets/VRMShaders/VRM10/MToon10/Editor/VRMShaders.VRM10.MToon10.Editor.asmdef
@@ -1,9 +1,8 @@
 {
     "name": "VRMShaders.VRM10.MToon10.Editor",
     "references": [
-        "VRMShaders.VRM10.MToon10.Runtime"
+        "GUID:0aaf403bd13871a44b7127aef2695ff8"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,5 +11,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/VRMShaders.VRM10.MToon10.Runtime.asmdef
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/VRMShaders.VRM10.MToon10.Runtime.asmdef
@@ -1,12 +1,13 @@
 {
     "name": "VRMShaders.VRM10.MToon10.Runtime",
     "references": [],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/VRMShaders/VRM10/MToon10/Tests/VRMShaders.VRM10.MToon10.Tests.asmdef
+++ b/Assets/VRMShaders/VRM10/MToon10/Tests/VRMShaders.VRM10.MToon10.Tests.asmdef
@@ -1,18 +1,23 @@
 {
     "name": "VRMShaders.VRM10.MToon10.Tests",
     "references": [
-        "VRMShaders.VRM10.MToon10.Runtime"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "GUID:0aaf403bd13871a44b7127aef2695ff8",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
     "autoReferenced": false,
-    "defineConstraints": []
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
Unity 2019 へのアップグレードに伴い、 asmdef の参照関係を名前から GUID 解決へと変更。
MToon も同様の対応をした v3.9 にアップデート。