### PR TITLE
Define GlbBinaryParser

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbBinaryParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbBinaryParser.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace UniGLTF
+{
+    public sealed class GlbBinaryParser
+    {
+        private readonly byte[] _data;
+        private readonly string _name;
+        
+        public GlbBinaryParser(byte[] data, string uniqueName)
+        {
+            _data = data;
+
+            if (string.IsNullOrWhiteSpace(uniqueName))
+            {
+                _name = Guid.NewGuid().ToString();
+            }
+            else
+            {
+                _name = uniqueName;
+            }
+        }
+
+        public GltfData Parse()
+        {
+            return new GlbLowLevelParser(_name, _data).Parse();
+        }
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbBinaryParser.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbBinaryParser.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ba0fe1be89e041138d2937dc07e9fdca
+timeCreated: 1629885479


### PR DESCRIPTION
Glb バイナリを扱う Parser が `GlbLowLevelParser` となっており、API 上不親切。
明示的に新設。