### PR TITLE
VRMImporterContext に VrmData を導入

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -19,6 +19,14 @@ namespace UniGLTF
         public AnimationClipFactory AnimationClipFactory { get; }
         public IReadOnlyDictionary<SubAssetKey, UnityEngine.Object> ExternalObjectMap;
 
+        /// <summary>
+        /// UnityObject の 生成(LoadAsync) と 破棄(Dispose) を行う。
+        /// LoadAsync が成功した場合、返り値(RuntimeGltfInstance) に破棄する責務を移動させる。
+        /// </summary>
+        /// <param name="data">Jsonからデシリアライズされた GLTF 情報など</param>
+        /// <param name="externalObjectMap">外部オブジェクトのリスト(主にScriptedImporterのRemapで使う)</param>
+        /// <param name="textureDeserializer">Textureロードをカスタマイズする</param>
+        /// <param name="materialGenerator">Materialロードをカスタマイズする(URP向け)</param>
         public ImporterContext(
             GltfData data,
             IReadOnlyDictionary<SubAssetKey, UnityEngine.Object> externalObjectMap = null,

--- a/Assets/VRM/Editor/Format/VRMImporterMenu.cs
+++ b/Assets/VRM/Editor/Format/VRMImporterMenu.cs
@@ -46,8 +46,9 @@ namespace VRM
         {
             // load into scene
             var data = new GlbFileParser(path).Parse();
-
-            using (var context = new VRMImporterContext(data))
+            // VRM extension を parse します
+            var vrm = new VRMData(data);
+            using (var context = new VRMImporterContext(vrm))
             {
                 var loaded = context.Load();
                 loaded.EnableUpdateWhenOffscreen();
@@ -65,8 +66,8 @@ namespace VRM
             }
 
             // import as asset
-            // var prefabPath = UnityPath.FromUnityPath(prefabPath);
             var data = new GlbFileParser(path).Parse();
+            var vrm = new VRMData(data);
 
             Action<IEnumerable<UnityPath>> onCompleted = texturePaths =>
             {
@@ -78,7 +79,7 @@ namespace VRM
                     .Where(x => x != null)
                     .ToDictionary(x => new SubAssetKey(x), x => x as Object);
 
-                using (var context = new VRMImporterContext(data, externalObjectMap: map))
+                using (var context = new VRMImporterContext(vrm, externalObjectMap: map))
                 {
                     var editor = new VRMEditorImporterContext(context, prefabPath);
                     foreach (var textureInfo in editor.TextureDescriptorGenerator.Get().GetEnumerable())
@@ -90,7 +91,7 @@ namespace VRM
                 }
             };
 
-            using (var context = new VRMImporterContext(data))
+            using (var context = new VRMImporterContext(vrm))
             {
                 var editor = new VRMEditorImporterContext(context, prefabPath);
                 editor.ConvertAndExtractImages(onCompleted);

--- a/Assets/VRM/Editor/Format/VRMImporterMenu.cs
+++ b/Assets/VRM/Editor/Format/VRMImporterMenu.cs
@@ -78,7 +78,7 @@ namespace VRM
                     .Where(x => x != null)
                     .ToDictionary(x => new SubAssetKey(x), x => x as Object);
 
-                using (var context = new VRMImporterContext(data, map))
+                using (var context = new VRMImporterContext(data, externalObjectMap: map))
                 {
                     var editor = new VRMEditorImporterContext(context, prefabPath);
                     foreach (var textureInfo in editor.TextureDescriptorGenerator.Get().GetEnumerable())

--- a/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -55,7 +55,7 @@ namespace VRM
                     .Select(x => x.LoadAsset<Texture>())
                     .ToDictionary(x => new SubAssetKey(x), x => x as UnityEngine.Object);
 
-                using (var context = new VRMImporterContext(data, map))
+                using (var context = new VRMImporterContext(data, externalObjectMap: map))
                 {
                     var editor = new VRMEditorImporterContext(context, prefabPath);
                     foreach (var textureInfo in context.TextureDescriptorGenerator.Get().GetEnumerable())

--- a/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -30,7 +30,7 @@ namespace VRM
                     {
                         ImportVrm(UnityPath.FromUnityPath(path));
                     }
-                    catch (VRMImporterContext.NotVrm0Exception)
+                    catch (NotVrm0Exception)
                     {
                         // is not vrm0
                     }
@@ -46,6 +46,7 @@ namespace VRM
             }
 
             var data = new GlbFileParser(vrmPath.FullPath).Parse();
+            var vrm = new VRMData(data);
 
             var prefabPath = vrmPath.Parent.Child(vrmPath.FileNameWithoutExtension + ".prefab");
 
@@ -55,7 +56,7 @@ namespace VRM
                     .Select(x => x.LoadAsset<Texture>())
                     .ToDictionary(x => new SubAssetKey(x), x => x as UnityEngine.Object);
 
-                using (var context = new VRMImporterContext(data, externalObjectMap: map))
+                using (var context = new VRMImporterContext(vrm, externalObjectMap: map))
                 {
                     var editor = new VRMEditorImporterContext(context, prefabPath);
                     foreach (var textureInfo in context.TextureDescriptorGenerator.Get().GetEnumerable())
@@ -68,7 +69,7 @@ namespace VRM
             };
 
             // extract texture images
-            using (var context = new VRMImporterContext(data))
+            using (var context = new VRMImporterContext(vrm))
             {
                 var editor = new VRMEditorImporterContext(context, prefabPath);
                 editor.ConvertAndExtractImages(onCompleted);

--- a/Assets/VRM/Runtime/IO/VRMData.cs
+++ b/Assets/VRM/Runtime/IO/VRMData.cs
@@ -1,0 +1,21 @@
+﻿using UniGLTF;
+
+namespace VRM
+{
+    public class VRMData
+    {
+        public GltfData Data { get; }
+        public glTF_VRM_extensions VrmExtensions { get; }
+
+        public VRMData(GltfData data)
+        {
+            Data = data;
+
+            if (!glTF_VRM_extensions.TryDeserialize(data.GLTF.extensions, out VRM.glTF_VRM_extensions vrm))
+            {
+                throw new NotVrm0Exception();
+            }
+            VrmExtensions = vrm;
+        }
+    }
+}

--- a/Assets/VRM/Runtime/IO/VRMData.cs
+++ b/Assets/VRM/Runtime/IO/VRMData.cs
@@ -5,7 +5,7 @@ namespace VRM
     public class VRMData
     {
         public GltfData Data { get; }
-        public glTF_VRM_extensions VrmExtensions { get; }
+        public glTF_VRM_extensions VrmExtension { get; }
 
         public VRMData(GltfData data)
         {
@@ -15,7 +15,7 @@ namespace VRM
             {
                 throw new NotVrm0Exception();
             }
-            VrmExtensions = vrm;
+            VrmExtension = vrm;
         }
     }
 }

--- a/Assets/VRM/Runtime/IO/VRMData.cs.meta
+++ b/Assets/VRM/Runtime/IO/VRMData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0e742fcd2ddaec4e95346e8be56bacb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM/Runtime/IO/VRMException.cs
+++ b/Assets/VRM/Runtime/IO/VRMException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace VRM
+{
+    public class NotVrm0Exception : Exception
+    {
+        public NotVrm0Exception()
+        { }
+    }
+}

--- a/Assets/VRM/Runtime/IO/VRMException.cs.meta
+++ b/Assets/VRM/Runtime/IO/VRMException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca411333fc4a541409b0b826f232cf90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -17,7 +17,7 @@ namespace VRM
         {
             get
             {
-                return _data.VrmExtensions;
+                return _data.VrmExtension;
             }
         }
 
@@ -26,7 +26,7 @@ namespace VRM
             IReadOnlyDictionary<SubAssetKey, Object> externalObjectMap = null,
             ITextureDeserializer textureDeserializer = null,
             IMaterialDescriptorGenerator materialGenerator = null)
-            : base(data.Data, externalObjectMap, textureDeserializer, materialGenerator ?? new VRMMaterialDescriptorGenerator(data.VrmExtensions))
+            : base(data.Data, externalObjectMap, textureDeserializer, materialGenerator ?? new VRMMaterialDescriptorGenerator(data.VrmExtension))
         {
             _data = data;
             TextureDescriptorGenerator = new VrmTextureDescriptorGenerator(Data, VRM);

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -21,23 +21,24 @@ namespace VRM
         public VRM.glTF_VRM_extensions VRM { get; private set; }
 
         public VRMImporterContext(
-            GltfData data,
+            GltfData data, VRM.glTF_VRM_extensions vrm = null,
             IReadOnlyDictionary<SubAssetKey, Object> externalObjectMap = null,
             ITextureDeserializer textureDeserializer = null,
             IMaterialDescriptorGenerator materialGenerator = null)
             : base(data, externalObjectMap, textureDeserializer)
         {
             // parse VRM part
-            if (glTF_VRM_extensions.TryDeserialize(GLTF.extensions, out glTF_VRM_extensions vrm))
+            if (vrm == null)
             {
-                VRM = vrm;
-                TextureDescriptorGenerator = new VrmTextureDescriptorGenerator(Data, VRM);
-                MaterialDescriptorGenerator = materialGenerator ?? new VRMMaterialDescriptorGenerator(VRM);
+                glTF_VRM_extensions.TryDeserialize(GLTF.extensions, out vrm);
             }
-            else
+            if (vrm == null)
             {
                 throw new NotVrm0Exception();
             }
+            VRM = vrm;
+            TextureDescriptorGenerator = new VrmTextureDescriptorGenerator(Data, VRM);
+            MaterialDescriptorGenerator = materialGenerator ?? new VRMMaterialDescriptorGenerator(VRM);
         }
 
         #region OnLoad

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -12,31 +12,23 @@ namespace VRM
 {
     public class VRMImporterContext : ImporterContext
     {
-        public class NotVrm0Exception : Exception
+        VRMData _data;
+        public VRM.glTF_VRM_extensions VRM
         {
-            public NotVrm0Exception()
-            { }
+            get
+            {
+                return _data.VrmExtensions;
+            }
         }
 
-        public VRM.glTF_VRM_extensions VRM { get; private set; }
-
         public VRMImporterContext(
-            GltfData data, VRM.glTF_VRM_extensions vrm = null,
+            VRMData data,
             IReadOnlyDictionary<SubAssetKey, Object> externalObjectMap = null,
             ITextureDeserializer textureDeserializer = null,
             IMaterialDescriptorGenerator materialGenerator = null)
-            : base(data, externalObjectMap, textureDeserializer)
+            : base(data.Data, externalObjectMap, textureDeserializer)
         {
-            // parse VRM part
-            if (vrm == null)
-            {
-                glTF_VRM_extensions.TryDeserialize(GLTF.extensions, out vrm);
-            }
-            if (vrm == null)
-            {
-                throw new NotVrm0Exception();
-            }
-            VRM = vrm;
+            _data = data;
             TextureDescriptorGenerator = new VrmTextureDescriptorGenerator(Data, VRM);
             MaterialDescriptorGenerator = materialGenerator ?? new VRMMaterialDescriptorGenerator(VRM);
         }

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -26,11 +26,10 @@ namespace VRM
             IReadOnlyDictionary<SubAssetKey, Object> externalObjectMap = null,
             ITextureDeserializer textureDeserializer = null,
             IMaterialDescriptorGenerator materialGenerator = null)
-            : base(data.Data, externalObjectMap, textureDeserializer)
+            : base(data.Data, externalObjectMap, textureDeserializer, materialGenerator ?? new VRMMaterialDescriptorGenerator(data.VrmExtensions))
         {
             _data = data;
             TextureDescriptorGenerator = new VrmTextureDescriptorGenerator(Data, VRM);
-            MaterialDescriptorGenerator = materialGenerator ?? new VRMMaterialDescriptorGenerator(VRM);
         }
 
         #region OnLoad

--- a/Assets/VRM/Samples/FirstPersonSample/VRMRuntimeLoader.cs
+++ b/Assets/VRM/Samples/FirstPersonSample/VRMRuntimeLoader.cs
@@ -84,10 +84,10 @@ namespace VRM.FirstPersonSample
             }
 
             // GLB形式でJSONを取得しParseします
+            // VRM extension を parse します
             var data = new GlbFileParser(path).Parse();
-            // var data = new GlbBinaryParser(anyBinary).Parse();
-
-            using (var context = new VRMImporterContext(data))
+            var vrm = new VRMData(data);
+            using (var context = new VRMImporterContext(vrm))
             {
                 // metaを取得(todo: thumbnailテクスチャのロード)
                 var meta = await context.ReadMetaAsync();
@@ -127,9 +127,9 @@ namespace VRM.FirstPersonSample
 
             // GLB形式でJSONを取得しParseします
             var data = new GlbFileParser(path).Parse();
-            // var data = new GlbBinaryParser(anyBinary).Parse();
-
-            var context = new VRMImporterContext(data);
+            // VRM extension を parse します
+            var vrm = new VRMData(data);
+            var context = new VRMImporterContext(vrm);
             var loaded = default(RuntimeGltfInstance);
             if (m_loadAsync)
             {

--- a/Assets/VRM/Samples/RuntimeExporterSample/VRMRuntimeExporter.cs
+++ b/Assets/VRM/Samples/RuntimeExporterSample/VRMRuntimeExporter.cs
@@ -51,9 +51,9 @@ namespace VRM.RuntimeExporterSample
 
             // GLB形式でJSONを取得しParseします
             var data = new GlbFileParser(path).Parse();
-            // var data = new GlbBinaryParser(anyBinary).Parse();
-
-            using (var context = new VRMImporterContext(data))
+            // VRM extension を parse します
+            var vrm = new VRMData(data);
+            using (var context = new VRMImporterContext(vrm))
             {
 
                 // metaを取得(todo: thumbnailテクスチャのロード)

--- a/Assets/VRM/Samples/SimpleViewer/SimpleViewer.unity
+++ b/Assets/VRM/Samples/SimpleViewer/SimpleViewer.unity
@@ -121,6 +121,84 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &13043733
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 13043734}
+  - component: {fileID: 13043736}
+  - component: {fileID: 13043735}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &13043734
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 13043733}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 630871733}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 9, y: -0.5}
+  m_SizeDelta: {x: -28, y: -3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &13043735
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 13043733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Use URP Material
+--- !u!222 &13043736
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 13043733}
+  m_CullTransparentMesh: 0
 --- !u!1 &124675793
 GameObject:
   m_ObjectHideFlags: 0
@@ -790,6 +868,7 @@ RectTransform:
   - {fileID: 935566651}
   - {fileID: 634488421}
   - {fileID: 1923377807}
+  - {fileID: 630871733}
   m_Father: {fileID: 124675794}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -859,6 +938,80 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 339774396}
+  m_CullTransparentMesh: 0
+--- !u!1 &409410325
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 409410326}
+  - component: {fileID: 409410328}
+  - component: {fileID: 409410327}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &409410326
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409410325}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1736108988}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &409410327
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409410325}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &409410328
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409410325}
   m_CullTransparentMesh: 0
 --- !u!1 &450042403
 GameObject:
@@ -1242,6 +1395,91 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 597950321}
   m_CullTransparentMesh: 0
+--- !u!1 &630871732
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 630871733}
+  - component: {fileID: 630871734}
+  m_Layer: 5
+  m_Name: UseUrpMaterial
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &630871733
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 630871732}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1736108988}
+  - {fileID: 13043734}
+  m_Father: {fileID: 339774397}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 162, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &630871734
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 630871732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1736108989}
+  toggleTransition: 1
+  graphic: {fileID: 409410327}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_IsOn: 0
 --- !u!1 &634488420
 GameObject:
   m_ObjectHideFlags: 0
@@ -4395,6 +4633,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1636340563}
   m_CullTransparentMesh: 0
+--- !u!1 &1736108987
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1736108988}
+  - component: {fileID: 1736108990}
+  - component: {fileID: 1736108989}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1736108988
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1736108987}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 409410326}
+  m_Father: {fileID: 630871733}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 10, y: -10}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1736108989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1736108987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1736108990
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1736108987}
+  m_CullTransparentMesh: 0
 --- !u!1 &1761414315
 GameObject:
   m_ObjectHideFlags: 0
@@ -4667,6 +4980,7 @@ MonoBehaviour:
   m_open: {fileID: 2009818433}
   m_enableLipSync: {fileID: 935566650}
   m_enableAutoBlink: {fileID: 634488422}
+  m_useUrpMaterial: {fileID: 630871734}
   m_src: {fileID: 0}
   m_target: {fileID: 802105000}
   Root: {fileID: 124675793}

--- a/Assets/VRM/Samples/SimpleViewer/ViewerUI.cs
+++ b/Assets/VRM/Samples/SimpleViewer/ViewerUI.cs
@@ -327,22 +327,27 @@ namespace VRM.SimpleViewer
 
         static IMaterialDescriptorGenerator GetGltfMaterialGenerator(bool useUrp)
         {
-            if(useUrp){
+            if (useUrp)
+            {
                 return new GltfUrpMaterialDescriptorGenerator();
             }
-            else{
+            else
+            {
                 return new GltfMaterialDescriptorGenerator();
             }
         }
 
         static IMaterialDescriptorGenerator GetVrmMaterialGenerator(bool useUrp, VRM.glTF_VRM_extensions vrm)
         {
-            if(useUrp){
+            if (useUrp)
+            {
                 return new VRM.VRMUrpMaterialDescriptorGenerator(vrm);
-             }else{
-                 return  new VRM.VRMMaterialDescriptorGenerator(vrm);            
-             }
-        }                
+            }
+            else
+            {
+                return new VRM.VRMMaterialDescriptorGenerator(vrm);
+            }
+        }
 
         async void LoadModelAsync(string path)
         {
@@ -358,12 +363,8 @@ namespace VRM.SimpleViewer
                 case ".vrm":
                     {
                         var data = new GlbFileParser(path).Parse();
-                        if(!glTF_VRM_extensions.TryDeserialize(data.GLTF.extensions, out VRM.glTF_VRM_extensions vrm))
-                        {
-                            throw new System.ArgumentException();
-                        }
-
-                        using (var context = new VRMImporterContext(data, vrm, materialGenerator: GetVrmMaterialGenerator(m_useUrpMaterial.isOn, vrm)))
+                        var vrm = new VRMData(data);
+                        using (var context = new VRMImporterContext(vrm, materialGenerator: GetVrmMaterialGenerator(m_useUrpMaterial.isOn, vrm.VrmExtensions)))
                         {
                             await m_texts.UpdateMetaAsync(context);
                             var loaded = await context.LoadAsync();

--- a/Assets/VRM/Samples/SimpleViewer/ViewerUI.cs
+++ b/Assets/VRM/Samples/SimpleViewer/ViewerUI.cs
@@ -364,7 +364,7 @@ namespace VRM.SimpleViewer
                     {
                         var data = new GlbFileParser(path).Parse();
                         var vrm = new VRMData(data);
-                        using (var context = new VRMImporterContext(vrm, materialGenerator: GetVrmMaterialGenerator(m_useUrpMaterial.isOn, vrm.VrmExtensions)))
+                        using (var context = new VRMImporterContext(vrm, materialGenerator: GetVrmMaterialGenerator(m_useUrpMaterial.isOn, vrm.VrmExtension)))
                         {
                             await m_texts.UpdateMetaAsync(context);
                             var loaded = await context.LoadAsync();

--- a/Assets/VRM/Tests/MToonTest.cs
+++ b/Assets/VRM/Tests/MToonTest.cs
@@ -47,11 +47,12 @@ namespace VRM
             }
 
             var data = new GlbFileParser(path).Parse();
-            
-            var importer = new VRMImporterContext(data, null);
+            var vrm = new VRMData(data);
 
-            Assert.AreEqual(73, data.GLTF.materials.Count);
-            Assert.True(VRMMToonMaterialImporter.TryCreateParam(data, importer.VRM, 0, out MaterialDescriptor matDesc));
+            var importer = new VRMImporterContext(vrm, null);
+
+            Assert.AreEqual(73, vrm.Data.GLTF.materials.Count);
+            Assert.True(VRMMToonMaterialImporter.TryCreateParam(vrm.Data, importer.VRM, 0, out MaterialDescriptor matDesc));
         }
 
         static string AliciaPath
@@ -68,7 +69,7 @@ namespace VRM
         {
             var path = AliciaPath;
             var data = new GlbFileParser(path).Parse();
-            var vrmImporter = new VRMImporterContext(data, null);
+            var vrmImporter = new VRMImporterContext(new VRMData(data), null);
             var materialParam = new VRMMaterialDescriptorGenerator(vrmImporter.VRM).Get(data, 0);
             Assert.AreEqual("VRM/MToon", materialParam.ShaderName);
             Assert.AreEqual("Alicia_body", materialParam.TextureSlots["_MainTex"].UnityObjectName);

--- a/Assets/VRM/Tests/SampleTests/VRMImportExportTests.cs
+++ b/Assets/VRM/Tests/SampleTests/VRMImportExportTests.cs
@@ -45,7 +45,7 @@ namespace VRM.Samples
             var path = AliciaPath;
             var data = new GlbFileParser(path).Parse();
 
-            using (var context = new VRMImporterContext(data))
+            using (var context = new VRMImporterContext(new VRMData(data)))
             using (var loaded = context.Load())
             {
                 loaded.ShowMeshes();
@@ -193,7 +193,7 @@ namespace VRM.Samples
             var path = AliciaPath;
             var data = new GlbFileParser(path).Parse();
 
-            using (var context = new VRMImporterContext(data))
+            using (var context = new VRMImporterContext(new VRMData(data)))
             using (var loaded = context.Load())
             {
                 loaded.ShowMeshes();
@@ -214,7 +214,7 @@ namespace VRM.Samples
             var path = AliciaPath;
             var data = new GlbFileParser(path).Parse();
 
-            using (var context = new VRMImporterContext(data))
+            using (var context = new VRMImporterContext(new VRMData(data)))
             {
                 var oldJson = context.GLTF.ToJson().ParseAsJson().ToString("  ");
 

--- a/Assets/VRM/Tests/VRMLoadTests.cs
+++ b/Assets/VRM/Tests/VRMLoadTests.cs
@@ -72,7 +72,7 @@ namespace VRM
 
             try
             {
-                using (var importer = new VRMImporterContext(data))
+                using (var importer = new VRMImporterContext(new VRMData(data)))
                 {
                     return importer.Load().gameObject;
                 }

--- a/Assets/VRM/Tests/VRMLookAtTests.cs
+++ b/Assets/VRM/Tests/VRMLookAtTests.cs
@@ -22,7 +22,7 @@ namespace VRM
         {
             var data = new GlbFileParser(AliciaPath).Parse();
             byte[] bytes = default;
-            using (var loader = new VRMImporterContext(data))
+            using (var loader = new VRMImporterContext(new VRMData(data)))
             using (var loaded = loader.Load())
             {
                 loaded.ShowMeshes();
@@ -38,7 +38,7 @@ namespace VRM
             }
 
             var data2 = new GlbLowLevelParser(AliciaPath, bytes).Parse();
-            using (var loader2 = new VRMImporterContext(data2))
+            using (var loader2 = new VRMImporterContext(new VRMData(data2)))
             {
                 Assert.AreEqual(LookAtType.BlendShape, loader2.VRM.firstPerson.lookAtType);
             }
@@ -50,7 +50,7 @@ namespace VRM
             var data = new GlbFileParser(AliciaPath).Parse();
             byte[] bytes = default;
             CurveMapper horizontalInner = default;
-            using (var loader = new VRMImporterContext(data))
+            using (var loader = new VRMImporterContext(new VRMData(data)))
             using (var loaded = loader.Load())
             {
                 loaded.ShowMeshes();
@@ -66,7 +66,7 @@ namespace VRM
             }
 
             var data2 = new GlbLowLevelParser(AliciaPath, bytes).Parse();
-            using (var loader = new VRMImporterContext(data2))
+            using (var loader = new VRMImporterContext(new VRMData(data2)))
             using (var loaded = loader.Load())
             {
                 loaded.ShowMeshes();
@@ -83,7 +83,7 @@ namespace VRM
             var data = new GlbFileParser(AliciaPath).Parse();
             byte[] bytes = default;
             CurveMapper horizontalInner = default;
-            using (var loader = new VRMImporterContext(data))
+            using (var loader = new VRMImporterContext(new VRMData(data)))
             using (var loaded = loader.Load())
             {
                 loaded.ShowMeshes();
@@ -99,7 +99,7 @@ namespace VRM
             }
 
             var data2 = new GlbLowLevelParser(AliciaPath, bytes).Parse();
-            using (var loader = new VRMImporterContext(data2))
+            using (var loader = new VRMImporterContext(new VRMData(data2)))
             using (var loaded = loader.Load())
             {
                 loaded.ShowMeshes();

--- a/Assets/VRM/Tests/VrmDividedMeshTests.cs
+++ b/Assets/VRM/Tests/VrmDividedMeshTests.cs
@@ -21,8 +21,8 @@ namespace VRM
 
         static GameObject Load(byte[] bytes, string path)
         {
-            var data = new GlbLowLevelParser(path, bytes).Parse();
-
+            var gltf = new GlbLowLevelParser(path, bytes).Parse();
+            var data = new VRMData(gltf);
             using (var loader = new VRMImporterContext(data))
             {
                 var loaded = loader.Load();

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterEditorGUI.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterEditorGUI.cs
@@ -23,7 +23,7 @@ namespace UniVRM10
         RemapEditorMaterial m_materialEditor;
         RemapEditorVrm m_vrmEditor;
 
-        Vrm10Parser.Result m_result;
+        Vrm10Data m_result;
 
         IEnumerable<SubAssetKey> EnumerateExpressinKeys(UniGLTF.Extensions.VRMC_vrm.Expressions expressions)
         {
@@ -65,7 +65,7 @@ namespace UniVRM10
 
             var importer = target as VrmScriptedImporter;
             m_importer = importer;
-            if (!Vrm10Parser.TryParseOrMigrate(m_importer.assetPath, importer.MigrateToVrm1, out m_result))
+            if (!Vrm10Data.TryParseOrMigrate(m_importer.assetPath, importer.MigrateToVrm1, out m_result))
             {
                 // error
                 return;
@@ -78,7 +78,7 @@ namespace UniVRM10
             var materialKeys = m_result.Data.GLTF.materials.Select((x, i) => generator.Get(m_result.Data, i).SubAssetKey);
             var textureKeys = new Vrm10TextureDescriptorGenerator(m_result.Data).Get().GetEnumerable().Select(x => x.SubAssetKey);
             m_materialEditor = new RemapEditorMaterial(materialKeys.Concat(textureKeys), GetEditorMap, SetEditorMap);
-            m_vrmEditor = new RemapEditorVrm(new[] { VRM10Object.SubAssetKey }.Concat(EnumerateExpressinKeys(m_result.Vrm.Expressions)), GetEditorMap, SetEditorMap);
+            m_vrmEditor = new RemapEditorVrm(new[] { VRM10Object.SubAssetKey }.Concat(EnumerateExpressinKeys(m_result.VrmExtension.Expressions)), GetEditorMap, SetEditorMap);
         }
 
         enum Tabs
@@ -125,7 +125,7 @@ namespace UniVRM10
                     break;
 
                 case Tabs.Materials:
-                    if (m_result.Data != null && m_result.Vrm != null)
+                    if (m_result.Data != null && m_result.VrmExtension != null)
                     {
                         m_materialEditor.OnGUI(m_importer, m_result.Data, new Vrm10TextureDescriptorGenerator(m_result.Data),
                             assetPath => $"{Path.GetFileNameWithoutExtension(assetPath)}.vrm1.Textures",
@@ -135,9 +135,9 @@ namespace UniVRM10
                     break;
 
                 case Tabs.Vrm:
-                    if (m_result.Data != null && m_result.Vrm != null)
+                    if (m_result.Data != null && m_result.VrmExtension != null)
                     {
-                        m_vrmEditor.OnGUI(m_importer, m_result.Data, m_result.Vrm);
+                        m_vrmEditor.OnGUI(m_importer, m_result.Data, m_result.VrmExtension);
                         ApplyRevertGUI();
                     }
                     break;

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
@@ -35,7 +35,7 @@ namespace UniVRM10
             Debug.Log("OnImportAsset to " + scriptedImporter.assetPath);
 #endif
 
-            if (!Vrm10Parser.TryParseOrMigrate(scriptedImporter.assetPath, migrateToVrm1, out Vrm10Parser.Result result))
+            if (!Vrm10Data.TryParseOrMigrate(scriptedImporter.assetPath, migrateToVrm1, out Vrm10Data result))
             {
                 // fail to parse vrm1
                 return;
@@ -50,7 +50,7 @@ namespace UniVRM10
 
             var materialGenerator = GetMaterialDescriptorGenerator(renderPipeline);
 
-            using (var loader = new Vrm10Importer(result.Data, result.Vrm, extractedObjects, materialGenerator: materialGenerator))
+            using (var loader = new Vrm10Importer(result, extractedObjects, materialGenerator: materialGenerator))
             {
                 // settings TextureImporters
                 foreach (var textureInfo in loader.TextureDescriptorGenerator.Get().GetEnumerable())

--- a/Assets/VRM10/Runtime/IO/Vrm10Data.cs.meta
+++ b/Assets/VRM10/Runtime/IO/Vrm10Data.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e4bece9378632bd4682bf5551630fafe
+guid: a3f895ff50d723e42b14bc126f90387e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -16,29 +16,24 @@ namespace UniVRM10
     {
         readonly VrmLib.Model m_model;
 
-        UniGLTF.Extensions.VRMC_vrm.VRMC_vrm m_vrm;
+        readonly Vrm10Data m_vrm;
 
         IReadOnlyDictionary<SubAssetKey, UnityEngine.Object> m_externalMap;
 
         public Vrm10Importer(
-            UniGLTF.GltfData data, UniGLTF.Extensions.VRMC_vrm.VRMC_vrm vrm,
+            Vrm10Data vrm,
             IReadOnlyDictionary<SubAssetKey, UnityEngine.Object> externalObjectMap = null,
             ITextureDeserializer textureDeserializer = null,
             IMaterialDescriptorGenerator materialGenerator = null)
-            : base(data, externalObjectMap, textureDeserializer)
+            : base(vrm.Data, externalObjectMap, textureDeserializer)
         {
-            if (data == null)
-            {
-                throw new ArgumentNullException("data");
-            }
-
             if (vrm == null)
             {
                 throw new ArgumentNullException("vrm");
             }
             m_vrm = vrm;
 
-            TextureDescriptorGenerator = new Vrm10TextureDescriptorGenerator(data);
+            TextureDescriptorGenerator = new Vrm10TextureDescriptorGenerator(Data);
             MaterialDescriptorGenerator = materialGenerator ?? new Vrm10MaterialDescriptorGenerator();
 
             m_externalMap = externalObjectMap;
@@ -48,66 +43,66 @@ namespace UniVRM10
             }
 
             // bin に対して右手左手変換を破壊的に実行することに注意 !(bin が変換済みになる)
-            m_model = ModelReader.Read(data);
+            m_model = ModelReader.Read(Data);
 
             // assign humanoid bones
-            if (m_vrm.Humanoid != null)
+            if (m_vrm.VrmExtension.Humanoid is UniGLTF.Extensions.VRMC_vrm.Humanoid humanoid)
             {
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Hips, VrmLib.HumanoidBones.hips);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftUpperLeg, VrmLib.HumanoidBones.leftUpperLeg);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightUpperLeg, VrmLib.HumanoidBones.rightUpperLeg);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLowerLeg, VrmLib.HumanoidBones.leftLowerLeg);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLowerLeg, VrmLib.HumanoidBones.rightLowerLeg);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftFoot, VrmLib.HumanoidBones.leftFoot);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightFoot, VrmLib.HumanoidBones.rightFoot);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Spine, VrmLib.HumanoidBones.spine);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Chest, VrmLib.HumanoidBones.chest);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Neck, VrmLib.HumanoidBones.neck);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Head, VrmLib.HumanoidBones.head);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftShoulder, VrmLib.HumanoidBones.leftShoulder);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightShoulder, VrmLib.HumanoidBones.rightShoulder);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftUpperArm, VrmLib.HumanoidBones.leftUpperArm);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightUpperArm, VrmLib.HumanoidBones.rightUpperArm);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLowerArm, VrmLib.HumanoidBones.leftLowerArm);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLowerArm, VrmLib.HumanoidBones.rightLowerArm);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftHand, VrmLib.HumanoidBones.leftHand);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightHand, VrmLib.HumanoidBones.rightHand);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftToes, VrmLib.HumanoidBones.leftToes);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightToes, VrmLib.HumanoidBones.rightToes);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftEye, VrmLib.HumanoidBones.leftEye);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightEye, VrmLib.HumanoidBones.rightEye);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.Jaw, VrmLib.HumanoidBones.jaw);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftThumbProximal, VrmLib.HumanoidBones.leftThumbProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftThumbIntermediate, VrmLib.HumanoidBones.leftThumbIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftThumbDistal, VrmLib.HumanoidBones.leftThumbDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftIndexProximal, VrmLib.HumanoidBones.leftIndexProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftIndexIntermediate, VrmLib.HumanoidBones.leftIndexIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftIndexDistal, VrmLib.HumanoidBones.leftIndexDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftMiddleProximal, VrmLib.HumanoidBones.leftMiddleProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftMiddleIntermediate, VrmLib.HumanoidBones.leftMiddleIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftMiddleDistal, VrmLib.HumanoidBones.leftMiddleDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftRingProximal, VrmLib.HumanoidBones.leftRingProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftRingIntermediate, VrmLib.HumanoidBones.leftRingIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftRingDistal, VrmLib.HumanoidBones.leftRingDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLittleProximal, VrmLib.HumanoidBones.leftLittleProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLittleIntermediate, VrmLib.HumanoidBones.leftLittleIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.LeftLittleDistal, VrmLib.HumanoidBones.leftLittleDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightThumbProximal, VrmLib.HumanoidBones.rightThumbProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightThumbIntermediate, VrmLib.HumanoidBones.rightThumbIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightThumbDistal, VrmLib.HumanoidBones.rightThumbDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightIndexProximal, VrmLib.HumanoidBones.rightIndexProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightIndexIntermediate, VrmLib.HumanoidBones.rightIndexIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightIndexDistal, VrmLib.HumanoidBones.rightIndexDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightMiddleProximal, VrmLib.HumanoidBones.rightMiddleProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightMiddleIntermediate, VrmLib.HumanoidBones.rightMiddleIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightMiddleDistal, VrmLib.HumanoidBones.rightMiddleDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightRingProximal, VrmLib.HumanoidBones.rightRingProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightRingIntermediate, VrmLib.HumanoidBones.rightRingIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightRingDistal, VrmLib.HumanoidBones.rightRingDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLittleProximal, VrmLib.HumanoidBones.rightLittleProximal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLittleIntermediate, VrmLib.HumanoidBones.rightLittleIntermediate);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.RightLittleDistal, VrmLib.HumanoidBones.rightLittleDistal);
-                AssignHumanoid(m_model.Nodes, m_vrm.Humanoid.HumanBones.UpperChest, VrmLib.HumanoidBones.upperChest);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.Hips, VrmLib.HumanoidBones.hips);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftUpperLeg, VrmLib.HumanoidBones.leftUpperLeg);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightUpperLeg, VrmLib.HumanoidBones.rightUpperLeg);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftLowerLeg, VrmLib.HumanoidBones.leftLowerLeg);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightLowerLeg, VrmLib.HumanoidBones.rightLowerLeg);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftFoot, VrmLib.HumanoidBones.leftFoot);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightFoot, VrmLib.HumanoidBones.rightFoot);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.Spine, VrmLib.HumanoidBones.spine);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.Chest, VrmLib.HumanoidBones.chest);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.Neck, VrmLib.HumanoidBones.neck);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.Head, VrmLib.HumanoidBones.head);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftShoulder, VrmLib.HumanoidBones.leftShoulder);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightShoulder, VrmLib.HumanoidBones.rightShoulder);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftUpperArm, VrmLib.HumanoidBones.leftUpperArm);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightUpperArm, VrmLib.HumanoidBones.rightUpperArm);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftLowerArm, VrmLib.HumanoidBones.leftLowerArm);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightLowerArm, VrmLib.HumanoidBones.rightLowerArm);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftHand, VrmLib.HumanoidBones.leftHand);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightHand, VrmLib.HumanoidBones.rightHand);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftToes, VrmLib.HumanoidBones.leftToes);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightToes, VrmLib.HumanoidBones.rightToes);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftEye, VrmLib.HumanoidBones.leftEye);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightEye, VrmLib.HumanoidBones.rightEye);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.Jaw, VrmLib.HumanoidBones.jaw);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftThumbProximal, VrmLib.HumanoidBones.leftThumbProximal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftThumbIntermediate, VrmLib.HumanoidBones.leftThumbIntermediate);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftThumbDistal, VrmLib.HumanoidBones.leftThumbDistal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftIndexProximal, VrmLib.HumanoidBones.leftIndexProximal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftIndexIntermediate, VrmLib.HumanoidBones.leftIndexIntermediate);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftIndexDistal, VrmLib.HumanoidBones.leftIndexDistal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftMiddleProximal, VrmLib.HumanoidBones.leftMiddleProximal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftMiddleIntermediate, VrmLib.HumanoidBones.leftMiddleIntermediate);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftMiddleDistal, VrmLib.HumanoidBones.leftMiddleDistal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftRingProximal, VrmLib.HumanoidBones.leftRingProximal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftRingIntermediate, VrmLib.HumanoidBones.leftRingIntermediate);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftRingDistal, VrmLib.HumanoidBones.leftRingDistal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftLittleProximal, VrmLib.HumanoidBones.leftLittleProximal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftLittleIntermediate, VrmLib.HumanoidBones.leftLittleIntermediate);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftLittleDistal, VrmLib.HumanoidBones.leftLittleDistal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightThumbProximal, VrmLib.HumanoidBones.rightThumbProximal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightThumbIntermediate, VrmLib.HumanoidBones.rightThumbIntermediate);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightThumbDistal, VrmLib.HumanoidBones.rightThumbDistal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightIndexProximal, VrmLib.HumanoidBones.rightIndexProximal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightIndexIntermediate, VrmLib.HumanoidBones.rightIndexIntermediate);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightIndexDistal, VrmLib.HumanoidBones.rightIndexDistal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightMiddleProximal, VrmLib.HumanoidBones.rightMiddleProximal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightMiddleIntermediate, VrmLib.HumanoidBones.rightMiddleIntermediate);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightMiddleDistal, VrmLib.HumanoidBones.rightMiddleDistal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightRingProximal, VrmLib.HumanoidBones.rightRingProximal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightRingIntermediate, VrmLib.HumanoidBones.rightRingIntermediate);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightRingDistal, VrmLib.HumanoidBones.rightRingDistal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightLittleProximal, VrmLib.HumanoidBones.rightLittleProximal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightLittleIntermediate, VrmLib.HumanoidBones.rightLittleIntermediate);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightLittleDistal, VrmLib.HumanoidBones.rightLittleDistal);
+                AssignHumanoid(m_model.Nodes, humanoid.HumanBones.UpperChest, VrmLib.HumanoidBones.upperChest);
             }
         }
 
@@ -234,7 +229,7 @@ namespace UniVRM10
             var controller = Root.AddComponent<VRM10Controller>();
 
             // vrm
-            controller.Vrm = await LoadVrmAsync(awaitCaller, m_vrm);
+            controller.Vrm = await LoadVrmAsync(awaitCaller, m_vrm.VrmExtension);
 
             // springBone
             if (UniGLTF.Extensions.VRMC_springBone.GltfDeserializer.TryGet(Data.GLTF.extensions, out UniGLTF.Extensions.VRMC_springBone.VRMC_springBone springBone))

--- a/Assets/VRM10/Runtime/Scenes/Sample.cs
+++ b/Assets/VRM10/Runtime/Scenes/Sample.cs
@@ -15,12 +15,12 @@ namespace UniVRM10.Sample
 
         static GameObject Import(byte[] bytes, FileInfo path)
         {
-            if (!Vrm10Parser.TryParseOrMigrate(path.FullName, bytes, doMigrate: true, out Vrm10Parser.Result result))
+            if (!Vrm10Data.TryParseOrMigrate(path.FullName, bytes, doMigrate: true, out Vrm10Data result))
             {
                 return null;
             }
 
-            using (var loader = new Vrm10Importer(result.Data, result.Vrm))
+            using (var loader = new Vrm10Importer(result))
             {
                 var loaded = loader.Load();
                 loaded.ShowMeshes();

--- a/Assets/VRM10/Samples/VRM10Viewer/VRM10Viewer.unity
+++ b/Assets/VRM10/Samples/VRM10Viewer/VRM10Viewer.unity
@@ -573,6 +573,80 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &251940583
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 251940584}
+  - component: {fileID: 251940586}
+  - component: {fileID: 251940585}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &251940584
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 251940583}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 452923209}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &251940585
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 251940583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &251940586
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 251940583}
+  m_CullTransparentMesh: 0
 --- !u!1 &284921870
 GameObject:
   m_ObjectHideFlags: 0
@@ -865,6 +939,7 @@ RectTransform:
   - {fileID: 935566651}
   - {fileID: 634488421}
   - {fileID: 1767738854}
+  - {fileID: 1438613464}
   m_Father: {fileID: 124675794}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1009,6 +1084,81 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &452923208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 452923209}
+  - component: {fileID: 452923211}
+  - component: {fileID: 452923210}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &452923209
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 452923208}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 251940584}
+  m_Father: {fileID: 1438613464}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 10, y: -10}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &452923210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 452923208}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &452923211
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 452923208}
+  m_CullTransparentMesh: 0
 --- !u!1 &488934504
 GameObject:
   m_ObjectHideFlags: 0
@@ -4099,6 +4249,91 @@ MonoBehaviour:
   blendDistance: 0
   weight: 1
   priority: 0
+--- !u!1 &1438613463
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1438613464}
+  - component: {fileID: 1438613465}
+  m_Layer: 5
+  m_Name: UseUrpMaterial
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1438613464
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1438613463}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 452923209}
+  - {fileID: 2090837017}
+  m_Father: {fileID: 339774397}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 162, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1438613465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1438613463}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 452923210}
+  toggleTransition: 1
+  graphic: {fileID: 251940585}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_IsOn: 0
 --- !u!1 &1476033060
 GameObject:
   m_ObjectHideFlags: 0
@@ -4948,6 +5183,7 @@ MonoBehaviour:
   m_enableLipSync: {fileID: 935566650}
   m_enableAutoBlink: {fileID: 634488422}
   m_enableAutoExpression: {fileID: 1767738855}
+  m_useUrpMaterial: {fileID: 1438613465}
   m_src: {fileID: 0}
   m_target: {fileID: 802105000}
   Root: {fileID: 0}
@@ -5559,6 +5795,84 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2010083453}
+  m_CullTransparentMesh: 0
+--- !u!1 &2090837016
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2090837017}
+  - component: {fileID: 2090837019}
+  - component: {fileID: 2090837018}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2090837017
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2090837016}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1438613464}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 9, y: -0.5}
+  m_SizeDelta: {x: -28, y: -3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2090837018
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2090837016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Use URP Material
+--- !u!222 &2090837019
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2090837016}
   m_CullTransparentMesh: 0
 --- !u!1 &2105159131
 GameObject:

--- a/Assets/VRM10/Samples/VRM10Viewer/VRM10ViewerUI.cs
+++ b/Assets/VRM10/Samples/VRM10Viewer/VRM10ViewerUI.cs
@@ -26,6 +26,9 @@ namespace UniVRM10.VRM10Viewer
 
         [SerializeField]
         Toggle m_enableAutoExpression = default;
+
+        [SerializeField]
+        Toggle m_useUrpMaterial = default;
         #endregion
 
         [SerializeField]
@@ -323,6 +326,18 @@ namespace UniVRM10.VRM10Viewer
             }
         }
 
+        static IMaterialDescriptorGenerator GetMaterialDescriptorGenerator(bool useUrp)
+        {
+            if (useUrp)
+            {
+                return new Vrm10UrpMaterialDescriptorGenerator();
+            }
+            else
+            {
+                return new Vrm10MaterialDescriptorGenerator();
+            }
+        }
+
         void LoadModel(string path)
         {
             if (!File.Exists(path))
@@ -341,7 +356,7 @@ namespace UniVRM10.VRM10Viewer
                             Debug.LogError(result.Message);
                             return;
                         }
-                        using (var loader = new Vrm10Importer(result))
+                        using (var loader = new Vrm10Importer(result, materialGenerator: GetMaterialDescriptorGenerator(m_useUrpMaterial.isOn)))
                         {
                             var loaded = loader.Load();
                             loaded.ShowMeshes();
@@ -378,6 +393,7 @@ namespace UniVRM10.VRM10Viewer
                         }
                         break;
                     }
+
                 case ".zip":
                     {
                         var data = new ZipArchivedGltfFileParser(path).Parse();

--- a/Assets/VRM10/Samples/VRM10Viewer/VRM10ViewerUI.cs
+++ b/Assets/VRM10/Samples/VRM10Viewer/VRM10ViewerUI.cs
@@ -326,7 +326,7 @@ namespace UniVRM10.VRM10Viewer
             }
         }
 
-        static IMaterialDescriptorGenerator GetMaterialDescriptorGenerator(bool useUrp)
+        static IMaterialDescriptorGenerator GetVrmMaterialDescriptorGenerator(bool useUrp)
         {
             if (useUrp)
             {
@@ -335,6 +335,18 @@ namespace UniVRM10.VRM10Viewer
             else
             {
                 return new Vrm10MaterialDescriptorGenerator();
+            }
+        }
+
+        static IMaterialDescriptorGenerator GetMaterialDescriptorGenerator(bool useUrp)
+        {
+            if (useUrp)
+            {
+                return new GltfUrpMaterialDescriptorGenerator();
+            }
+            else
+            {
+                return new GltfMaterialDescriptorGenerator();
             }
         }
 
@@ -356,7 +368,7 @@ namespace UniVRM10.VRM10Viewer
                             Debug.LogError(result.Message);
                             return;
                         }
-                        using (var loader = new Vrm10Importer(result, materialGenerator: GetMaterialDescriptorGenerator(m_useUrpMaterial.isOn)))
+                        using (var loader = new Vrm10Importer(result, materialGenerator: GetVrmMaterialDescriptorGenerator(m_useUrpMaterial.isOn)))
                         {
                             var loaded = loader.Load();
                             loaded.ShowMeshes();
@@ -370,7 +382,7 @@ namespace UniVRM10.VRM10Viewer
                     {
                         var data = new GlbFileParser(path).Parse();
 
-                        using (var loader = new UniGLTF.ImporterContext(data))
+                        using (var loader = new UniGLTF.ImporterContext(data, materialGenerator: GetMaterialDescriptorGenerator(m_useUrpMaterial.isOn)))
                         {
                             var loaded = loader.Load();
                             loaded.ShowMeshes();
@@ -384,7 +396,7 @@ namespace UniVRM10.VRM10Viewer
                     {
                         var data = new GltfFileWithResourceFilesParser(path).Parse();
 
-                        using (var loader = new UniGLTF.ImporterContext(data))
+                        using (var loader = new UniGLTF.ImporterContext(data, materialGenerator: GetMaterialDescriptorGenerator(m_useUrpMaterial.isOn)))
                         {
                             var loaded = loader.Load();
                             loaded.ShowMeshes();
@@ -398,7 +410,7 @@ namespace UniVRM10.VRM10Viewer
                     {
                         var data = new ZipArchivedGltfFileParser(path).Parse();
 
-                        using (var loader = new UniGLTF.ImporterContext(data))
+                        using (var loader = new UniGLTF.ImporterContext(data, materialGenerator: GetMaterialDescriptorGenerator(m_useUrpMaterial.isOn)))
                         {
                             var loaded = loader.Load();
                             loaded.ShowMeshes();

--- a/Assets/VRM10/Samples/VRM10Viewer/VRM10ViewerUI.cs
+++ b/Assets/VRM10/Samples/VRM10Viewer/VRM10ViewerUI.cs
@@ -336,12 +336,12 @@ namespace UniVRM10.VRM10Viewer
             {
                 case ".vrm":
                     {
-                        if (!Vrm10Parser.TryParseOrMigrate(path, doMigrate: true, out Vrm10Parser.Result result))
+                        if (!Vrm10Data.TryParseOrMigrate(path, doMigrate: true, out Vrm10Data result))
                         {
                             Debug.LogError(result.Message);
                             return;
                         }
-                        using (var loader = new Vrm10Importer(result.Data, result.Vrm))
+                        using (var loader = new Vrm10Importer(result))
                         {
                             var loaded = loader.Load();
                             loaded.ShowMeshes();

--- a/Assets/VRM10/Tests.PlayMode/MaterialTests.cs
+++ b/Assets/VRM10/Tests.PlayMode/MaterialTests.cs
@@ -31,18 +31,18 @@ namespace UniVRM10.Test
         private (GameObject, IReadOnlyList<VRMShaders.MaterialFactory.MaterialLoadInfo>) ToUnity(byte[] bytes)
         {
             // Vrm => Model
-            if (!Vrm10Parser.TryParseOrMigrate("tpm.vrm", bytes, true, out Vrm10Parser.Result result))
+            if (!Vrm10Data.TryParseOrMigrate("tpm.vrm", bytes, true, out Vrm10Data result))
             {
                 throw new Exception();
             }
 
-            return ToUnity(result.Data, result.Vrm);
+            return ToUnity(result);
         }
 
-        private (GameObject, IReadOnlyList<VRMShaders.MaterialFactory.MaterialLoadInfo>) ToUnity(GltfData data, VRMC_vrm vrm)
+        private (GameObject, IReadOnlyList<VRMShaders.MaterialFactory.MaterialLoadInfo>) ToUnity(Vrm10Data data)
         {
             // Model => Unity
-            using (var loader = new Vrm10Importer(data, vrm))
+            using (var loader = new Vrm10Importer(data))
             {
                 var loaded = loader.Load();
                 return (loaded.gameObject, loader.MaterialFactory.Materials);

--- a/Assets/VRM10/Tests/ApiSampleTests.cs
+++ b/Assets/VRM10/Tests/ApiSampleTests.cs
@@ -19,9 +19,9 @@ namespace UniVRM10.Test
             return model;
         }
 
-        GameObject BuildGameObject(GltfData data, VRMC_vrm vrm, bool showMesh)
+        GameObject BuildGameObject(Vrm10Data data, bool showMesh)
         {
-            using (var loader = new Vrm10Importer(data, vrm))
+            using (var loader = new Vrm10Importer(data))
             {
                 var loaded = loader.Load();
                 if (showMesh)
@@ -39,9 +39,9 @@ namespace UniVRM10.Test
             var path = "Tests/Models/Alicia_vrm-0.51/AliciaSolid_vrm-0.51.vrm";
             Debug.Log($"load: {path}");
 
-            Assert.IsTrue(Vrm10Parser.TryParseOrMigrate(path, true, out Vrm10Parser.Result result));
+            Assert.IsTrue(Vrm10Data.TryParseOrMigrate(path, true, out Vrm10Data result));
 
-            var go = BuildGameObject(result.Data, result.Vrm, true);
+            var go = BuildGameObject(result, true);
             Debug.Log(go);
 
             // export


### PR DESCRIPTION
gltf から vrm 拡張を取り出す責務を `VrmData class` とした。
`VRMImporterContext` はこれを引数に受ける。

ドキュメントを書いていてサンプルコードを書いてみたら、
VRMImporterContext の materialGenerator をカスタマイズするのに VRM.glTF_VRM_extensions vrm が必用なのだが、
VRMImporterContext の中で VRM.glTF_VRM_extensions vrm を取り出していて使いづらかった。

* このインタフェースを使う SimpleViewer などのサンプル
* このインタフェースを使う Test
