### PR TITLE
[1.0] thumbnail の名前が無い時に SubAssetKey を作るのに失敗するのを修正

### DIFF
--- a/Assets/VRM10/Runtime/IO/Texture/Vrm10TextureDescriptorGenerator.cs
+++ b/Assets/VRM10/Runtime/IO/Texture/Vrm10TextureDescriptorGenerator.cs
@@ -82,6 +82,10 @@ namespace UniVRM10
             var imageIndex = vrm.Meta.ThumbnailImage.Value;
             var gltfImage = data.GLTF.images[imageIndex];
             var name = TextureImportName.GetUnityObjectName(TextureImportTypes.sRGB, gltfImage.name, gltfImage.uri);
+            if (string.IsNullOrEmpty(name))
+            {
+                name = "thumbnail";
+            }
 
             GetTextureBytesAsync getThumbnailImageBytesAsync = () =>
             {

--- a/Assets/VRM10/Runtime/IO/Texture/Vrm10TextureDescriptorGenerator.cs
+++ b/Assets/VRM10/Runtime/IO/Texture/Vrm10TextureDescriptorGenerator.cs
@@ -84,7 +84,7 @@ namespace UniVRM10
             var name = TextureImportName.GetUnityObjectName(TextureImportTypes.sRGB, gltfImage.name, gltfImage.uri);
             if (string.IsNullOrEmpty(name))
             {
-                name = "thumbnail";
+                name = MigrationVrmMeta.THUMBNAIL_NAME;
             }
 
             GetTextureBytesAsync getThumbnailImageBytesAsync = () =>

--- a/Assets/VRM10/Runtime/Migration/MigrationVrm.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrm.cs
@@ -38,7 +38,7 @@ namespace UniVRM10
                 var vrm1 = new UniGLTF.Extensions.VRMC_vrm.VRMC_vrm();
 
                 // meta (required)
-                vrm1.Meta = MigrationVrmMeta.Migrate(vrm0["meta"]);
+                vrm1.Meta = MigrationVrmMeta.Migrate(gltf, vrm0["meta"]);
                 // humanoid (required)
                 vrm1.Humanoid = MigrationVrmHumanoid.Migrate(vrm0["humanoid"]);
 

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
@@ -27,6 +27,8 @@ namespace UniVRM10
     // },
     public static class MigrationVrmMeta
     {
+        public const string THUMBNAIL_NAME = "__VRM10_thumbnail__";
+
         public static UniGLTF.Extensions.VRMC_vrm.Meta Migrate(UniGLTF.glTF gltf, JsonNode vrm0)
         {
             var meta = new UniGLTF.Extensions.VRMC_vrm.Meta
@@ -69,7 +71,7 @@ namespace UniVRM10
                                 if (string.IsNullOrEmpty(gltfImage.name))
                                 {
                                     // fall back default name
-                                    gltfImage.name = "__VRM10_thumbnail__";
+                                    gltfImage.name = THUMBNAIL_NAME;
                                 }
                             }
                             break;

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
@@ -27,8 +27,6 @@ namespace UniVRM10
     // },
     public static class MigrationVrmMeta
     {
-        public const string THUMBNAIL_NAME = "__VRM10_thumbnail__";
-
         public static UniGLTF.Extensions.VRMC_vrm.Meta Migrate(UniGLTF.glTF gltf, JsonNode vrm0)
         {
             var meta = new UniGLTF.Extensions.VRMC_vrm.Meta
@@ -60,19 +58,14 @@ namespace UniVRM10
                         {
                             // vrm0x use texture. vrm10 use image
                             var textureIndex = kv.Value.GetInt32();
-                            var gltfTexture = gltf.textures[textureIndex];
-                            meta.ThumbnailImage = gltfTexture.source;
-
-                            var gltfImage = gltf.images[gltfTexture.source];
-                            if (string.IsNullOrEmpty(gltfImage.name))
+                            if (textureIndex == -1)
                             {
-                                // use texture name
-                                gltfImage.name = gltfTexture.name;
-                                if (string.IsNullOrEmpty(gltfImage.name))
-                                {
-                                    // fall back default name
-                                    gltfImage.name = THUMBNAIL_NAME;
-                                }
+                                meta.ThumbnailImage = -1;
+                            }
+                            else
+                            {
+                                var gltfTexture = gltf.textures[textureIndex];
+                                meta.ThumbnailImage = gltfTexture.source;
                             }
                             break;
                         }

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
@@ -27,7 +27,7 @@ namespace UniVRM10
     // },
     public static class MigrationVrmMeta
     {
-        public static UniGLTF.Extensions.VRMC_vrm.Meta Migrate(JsonNode vrm0)
+        public static UniGLTF.Extensions.VRMC_vrm.Meta Migrate(UniGLTF.glTF gltf, JsonNode vrm0)
         {
             var meta = new UniGLTF.Extensions.VRMC_vrm.Meta
             {
@@ -54,7 +54,26 @@ namespace UniVRM10
                     case "author": meta.Authors = new List<string>() { kv.Value.GetString() }; break;
                     case "contactInformation": meta.ContactInformation = kv.Value.GetString(); break;
                     case "reference": meta.References = new List<string>() { kv.Value.GetString() }; break;
-                    case "texture": meta.ThumbnailImage = kv.Value.GetInt32(); break;
+                    case "texture":
+                        {
+                            // vrm0x use texture. vrm10 use image
+                            var textureIndex = kv.Value.GetInt32();
+                            var gltfTexture = gltf.textures[textureIndex];
+                            meta.ThumbnailImage = gltfTexture.source;
+
+                            var gltfImage = gltf.images[gltfTexture.source];
+                            if (string.IsNullOrEmpty(gltfImage.name))
+                            {
+                                // use texture name
+                                gltfImage.name = gltfTexture.name;
+                                if (string.IsNullOrEmpty(gltfImage.name))
+                                {
+                                    // fall back default name
+                                    gltfImage.name = "__VRM10_thumbnail__";
+                                }
+                            }
+                            break;
+                        }
 
                     case "allowedUserName":
                         {

--- a/Assets/VRM10/Tests/ExpressionTests.cs
+++ b/Assets/VRM10/Tests/ExpressionTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
@@ -7,34 +6,10 @@ namespace UniVRM10.Test
 {
     public class ExpressionTests
     {
-        static string AliciaPath
-        {
-            get
-            {
-                return Path.GetFullPath(Application.dataPath + "/../Tests/Models/Alicia_vrm-0.51/AliciaSolid_vrm-0.51.vrm")
-                    .Replace("\\", "/");
-            }
-        }
-
-        static VRM10Controller Load()
-        {
-            Vrm10Data.TryParseOrMigrate(AliciaPath, true, out Vrm10Data vrm);
-            using (var loader = new Vrm10Importer(vrm))
-            {
-                var task = loader.LoadAsync(new VRMShaders.ImmediateCaller());
-                task.Wait();
-
-                var instance = task.Result;
-
-                return instance.GetComponent<VRM10Controller>();
-            }
-
-        }
-
         [Test]
         public void DuplicatedMaterialColorBindings()
         {
-            var controller = Load();
+            var controller = TestAsset.LoadAlicia();
 
             var src = controller.Vrm.Expression.Aa.MaterialColorBindings.ToList();
 
@@ -63,7 +38,7 @@ namespace UniVRM10.Test
         [Test]
         public void DuplicatedMaterialUVBindings()
         {
-            var controller = Load();
+            var controller = TestAsset.LoadAlicia();
 
             var renderers = controller.GetComponentsInChildren<Renderer>();
             var name = renderers[0].sharedMaterials[0].name;

--- a/Assets/VRM10/Tests/LoadTests.cs
+++ b/Assets/VRM10/Tests/LoadTests.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+
+namespace UniVRM10.Test
+{
+    public class LoadTests
+    {
+        [Test]
+        public void EmptyThumbnailName()
+        {
+            Assert.True(Vrm10Data.TryParseOrMigrate(TestAsset.AliciaPath, true, out Vrm10Data vrm));
+
+            var index = vrm.VrmExtension.Meta.ThumbnailImage.Value;
+
+            // empty thumbnail name
+            vrm.Data.GLTF.images[index].name = null;
+
+            using (var loader = new Vrm10Importer(vrm))
+            {
+                loader.LoadAsync(new VRMShaders.ImmediateCaller()).Wait();
+            }
+        }
+    }
+}

--- a/Assets/VRM10/Tests/LoadTests.cs.meta
+++ b/Assets/VRM10/Tests/LoadTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9a9a3ce2deae9c4791d816aa189df3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM10/Tests/TestAsset.cs
+++ b/Assets/VRM10/Tests/TestAsset.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using UnityEngine;
+
+namespace UniVRM10
+{
+    public static class TestAsset
+    {
+        public static string AliciaPath
+        {
+            get
+            {
+                return Path.GetFullPath(Application.dataPath + "/../Tests/Models/Alicia_vrm-0.51/AliciaSolid_vrm-0.51.vrm")
+                    .Replace("\\", "/");
+            }
+        }
+
+        public static VRM10Controller LoadAlicia()
+        {
+            Vrm10Data.TryParseOrMigrate(AliciaPath, true, out Vrm10Data vrm);
+            using (var loader = new Vrm10Importer(vrm))
+            {
+                var task = loader.LoadAsync(new VRMShaders.ImmediateCaller());
+                task.Wait();
+
+                var instance = task.Result;
+
+                return instance.GetComponent<VRM10Controller>();
+            }
+        }
+    }
+}

--- a/Assets/VRM10/Tests/TestAsset.cs.meta
+++ b/Assets/VRM10/Tests/TestAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b18f57dcd7d3c19469aa4842b2ee6ae1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* 無かったらデフォルト名にフォールバック
* vrm0x では texture を使っていたのが、vrm10 では image を使うようになったので無名になるのかも。対処した
* univrm のエクスポートでは基本的に image と texture の index は一致する

#1188 