### PR TITLE
[Exporter] shader版の StandardMap の Exporter 変換を追加

### DIFF
--- a/Assets/VRMShaders/GLTF/IO/Resources/UniGLTF/StandardMapExporter.shader
+++ b/Assets/VRMShaders/GLTF/IO/Resources/UniGLTF/StandardMapExporter.shader
@@ -1,0 +1,68 @@
+﻿Shader "Hidden/UniGLTF/StandardMapExporter"
+{
+     Properties
+     {
+          _MainTex ("Texture", 2D) = "white" {}
+          _UnitySmoothness ("Unity Smoothness Factor", Float) = 1.0
+          _UnityMetallicSmoothTexture ("Unity Metallic Smoothness Texture", 2D) = "black" {}
+          _UnityOcclusionTexture ("Unity Occlusion Texture", 2D) = "black" {}
+     }
+     SubShader
+     {
+          // No culling or depth
+          Cull Off ZWrite Off ZTest Always
+
+          Pass
+          {
+               CGPROGRAM
+               #pragma vertex vert
+               #pragma fragment frag
+
+               #include "UnityCG.cginc"
+
+               struct appdata
+               {
+                    float4 vertex : POSITION;
+                    float2 uv : TEXCOORD0;
+               };
+
+               struct v2f
+               {
+                    float2 uv : TEXCOORD0;
+                    float4 vertex : SV_POSITION;
+               };
+
+               v2f vert (appdata v)
+               {
+                    v2f o;
+                    o.vertex = UnityObjectToClipPos(v.vertex);
+                    o.uv = v.uv;
+                    return o;
+               }
+
+               sampler2D _MainTex;
+               half _UnitySmoothness;
+               sampler2D _UnityMetallicSmoothTexture;
+               sampler2D _UnityOcclusionTexture;
+
+               fixed4 frag (v2f i) : SV_Target
+               {
+                    half4 occlusionTex = tex2D(_UnityOcclusionTexture, i.uv);
+                    half occlusion = occlusionTex.g; // G: Unity Occlusion
+
+                    half4 metallicRoughnessTex = tex2D(_UnityMetallicSmoothTexture, i.uv);
+                    half smoothness = metallicRoughnessTex.a * _UnitySmoothness; // A: Unity Roughness
+                    half metallic = metallicRoughnessTex.r; // R: Unity Metallic
+
+                    fixed4 result;
+                    result.r = occlusion;  // R: glTF Occlusion 
+                    result.g = 1.0 - smoothness;  // G: glTF Roughness
+                    result.b = metallic; // B: glTF Metallic
+                    result.a = 1.0; // A: glTF not used
+
+                    return result;
+               }
+               ENDCG
+          }
+     }
+}

--- a/Assets/VRMShaders/GLTF/IO/Resources/UniGLTF/StandardMapExporter.shader.meta
+++ b/Assets/VRMShaders/GLTF/IO/Resources/UniGLTF/StandardMapExporter.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 862aa29f5c3daf44fbe9db6344f02a52
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#1178 

* 変数名が Exporter になっていたのを Importer に修正
* 然る後に Exporter 一式追加

![daitai](https://user-images.githubusercontent.com/68057/132664388-fc4826a3-f001-4ff7-bd6c-6b8703bcdd3a.jpg)

左エクスポート前、右エクスポート後再インポート。見分けは付かないのでたぶん OK