### PR TITLE
[1.0] preview の MaterialUVBindings 動作を修正

### DIFF
--- a/Assets/VRM10/Runtime/Components/Expression/MaterialValueBindingMerger.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/MaterialValueBindingMerger.cs
@@ -10,7 +10,6 @@ namespace UniVRM10
     ///
     internal sealed class MaterialValueBindingMerger
     {
-        public const string UV_PROPERTY = "_MainTex_ST";
         public const string COLOR_PROPERTY = "_Color";
         public const string EMISSION_COLOR_PROPERTY = "_EmissionColor";
         public const string RIM_COLOR_PROPERTY = "_RimColor";

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
@@ -234,19 +234,12 @@ namespace UniVRM10
             if (m_materialMap != null)
             {
                 // clear
-                //Debug.LogFormat("clear material");
                 foreach (var kv in m_materialMap)
                 {
-                    foreach (var _kv in kv.Value.PropMap)
-                    {
-                        // var prop = VrmLib.MaterialBindTypeExtensions.GetProperty(_kv.Key);
-                        kv.Value.Material.SetColor(_kv.Value.Name, _kv.Value.DefaultValues);
-                    }
-
-                    // clear UV
-                    kv.Value.Material.SetVector("_MainTex_ST", new Vector4(1, 1, 0, 0));
+                    kv.Value.Clear();
                 }
 
+                // color
                 if (bake.MaterialColorBindings != null)
                 {
                     foreach (var x in bake.MaterialColorBindings)
@@ -274,6 +267,7 @@ namespace UniVRM10
                     }
                 }
 
+                // uv
                 if (bake.MaterialUVBindings != null)
                 {
                     foreach (var x in bake.MaterialUVBindings)
@@ -281,17 +275,7 @@ namespace UniVRM10
                         PreviewMaterialItem item;
                         if (m_materialMap.TryGetValue(x.MaterialName, out item))
                         {
-                            // var valueName = x.ValueName;
-                            // if (valueName.EndsWith("_ST_S")
-                            // || valueName.EndsWith("_ST_T"))
-                            // {
-                            //     valueName = valueName.Substring(0, valueName.Length - 2);
-                            // }
-
-                            var value = item.Material.GetVector("_MainTex_ST");
-                            //Debug.LogFormat("{0} => {1}", valueName, x.TargetValue);
-                            value += ((x.ScalingOffset - new Vector4(1, 1, 0, 0)) * weight);
-                            item.Material.SetColor("_MainTex_ST", value);
+                            item.AddScaleOffset(x.ScalingOffset, weight);
                         }
                     }
                 }

--- a/Assets/VRM10/Runtime/Components/Expression/PreviewMaterialItem.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/PreviewMaterialItem.cs
@@ -104,5 +104,33 @@ namespace UniVRM10
 
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// [Preview] 積算する前の初期値にクリアする
+        /// </summary>
+        public void Clear()
+        {
+            // clear Color
+            foreach (var _kv in PropMap)
+            {
+                Material.SetColor(_kv.Value.Name, _kv.Value.DefaultValues);
+            }
+
+            // clear UV
+            Material.SetVector(UV_PROPERTY, DefaultUVScaleOffset);
+        }
+
+        /// <summary>
+        /// [Preview] scaleOffset を weight で重みを付けて加える
+        /// </summary>
+        /// <param name="scaleOffset"></param>
+        /// <param name="weight"></param>
+        public void AddScaleOffset(Vector4 scaleOffset, float weight)
+        {
+            var value = Material.GetVector(UV_PROPERTY);
+            //Debug.LogFormat("{0} => {1}", valueName, x.TargetValue);
+            value += (scaleOffset - DefaultUVScaleOffset) * weight;
+            Material.SetColor(UV_PROPERTY, value);
+        }
     }
 }


### PR DESCRIPTION
https://github.com/vrm-c/vrm-specification/issues/279

Editor の Preview も追随。

<img width=200 src=https://user-images.githubusercontent.com/68057/133560658-d05a8b88-f245-4364-9d8f-e6364a2d70de.gif>

修正前は、[0, 0, 1, 1] と設定との間でアニメーションしていた。
