### PR TITLE
lambda `Func<Task<AnimationClip>>` cause warning. Use Task.FromResult

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -133,9 +133,10 @@ namespace UniGLTF
             {
                 foreach (var (key, gltfAnimation) in Enumerable.Zip(AnimationImporterUtil.EnumerateSubAssetKeys(GLTF), GLTF.animations, (x, y) => (x, y)))
                 {
-                    await AnimationClipFactory.LoadAnimationClipAsync(key, async () =>
+                    await AnimationClipFactory.LoadAnimationClipAsync(key, () =>
                     {
-                        return AnimationImporterUtil.ConvertAnimationClip(GLTF, gltfAnimation, InvertAxis.Create());
+                        var clip = AnimationImporterUtil.ConvertAnimationClip(GLTF, gltfAnimation, InvertAxis.Create());
+                        return Task.FromResult(clip);
                     });
                 }
 


### PR DESCRIPTION
#1121
