### PR TITLE
`VRM/UnlitTransparentZWrite` の Import を修正

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfUnlitMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfUnlitMaterialImporter.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+﻿using UniGLTF.UniUnlit;
 using VRMShaders;
 using ColorSpace = VRMShaders.ColorSpace;
 
@@ -6,8 +6,6 @@ namespace UniGLTF
 {
     public static class GltfUnlitMaterialImporter
     {
-        public const string ShaderName = "UniGLTF/UniUnlit";
-
         public static bool TryCreateParam(GltfData data, int i, out MaterialDescriptor matDesc)
         {
             if (i < 0 || i >= data.GLTF.materials.Count)
@@ -23,7 +21,7 @@ namespace UniGLTF
                 return false;
             }
 
-            matDesc = new MaterialDescriptor(GltfMaterialDescriptorGenerator.GetMaterialName(i, src), ShaderName);
+            matDesc = new MaterialDescriptor(GltfMaterialDescriptorGenerator.GetMaterialName(i, src), UniUnlitUtil.ShaderName);
 
             // texture
             if (src.pbrMetallicRoughness.baseColorTexture != null)
@@ -46,41 +44,41 @@ namespace UniGLTF
             {
                 if (src.alphaMode == "OPAQUE")
                 {
-                    UniUnlit.Utils.SetRenderMode(material, UniUnlit.UniUnlitRenderMode.Opaque);
+                    UniUnlitUtil.SetRenderMode(material, UniUnlit.UniUnlitRenderMode.Opaque);
                 }
                 else if (src.alphaMode == "BLEND")
                 {
-                    UniUnlit.Utils.SetRenderMode(material, UniUnlit.UniUnlitRenderMode.Transparent);
+                    UniUnlitUtil.SetRenderMode(material, UniUnlit.UniUnlitRenderMode.Transparent);
                 }
                 else if (src.alphaMode == "MASK")
                 {
-                    UniUnlit.Utils.SetRenderMode(material, UniUnlit.UniUnlitRenderMode.Cutout);
+                    UniUnlitUtil.SetRenderMode(material, UniUnlit.UniUnlitRenderMode.Cutout);
                     material.SetFloat("_Cutoff", src.alphaCutoff);
                 }
                 else
                 {
                     // default OPAQUE
-                    UniUnlit.Utils.SetRenderMode(material, UniUnlit.UniUnlitRenderMode.Opaque);
+                    UniUnlitUtil.SetRenderMode(material, UniUnlit.UniUnlitRenderMode.Opaque);
                 }
 
                 // culling
                 if (src.doubleSided)
                 {
-                    UniUnlit.Utils.SetCullMode(material, UniUnlit.UniUnlitCullMode.Off);
+                    UniUnlitUtil.SetCullMode(material, UniUnlit.UniUnlitCullMode.Off);
                 }
                 else
                 {
-                    UniUnlit.Utils.SetCullMode(material, UniUnlit.UniUnlitCullMode.Back);
+                    UniUnlitUtil.SetCullMode(material, UniUnlit.UniUnlitCullMode.Back);
                 }
 
                 // VColor
                 var hasVertexColor = data.GLTF.MaterialHasVertexColor(i);
                 if (hasVertexColor)
                 {
-                    UniUnlit.Utils.SetVColBlendMode(material, UniUnlit.UniUnlitVertexColorBlendOp.Multiply);
+                    UniUnlitUtil.SetVColBlendMode(material, UniUnlit.UniUnlitVertexColorBlendOp.Multiply);
                 }
 
-                UniUnlit.Utils.ValidateProperties(material, true);
+                UniUnlitUtil.ValidateProperties(material, true);
             });
 
             return true;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/MaterialExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/MaterialExporter.cs
@@ -220,7 +220,7 @@ namespace UniGLTF
                 case "Unlit/Texture":
                 case "Unlit/Transparent":
                 case "Unlit/Transparent Cutout":
-                case "UniGLTF/UniUnlit":
+                case UniUnlit.UniUnlitUtil.ShaderName:
                     return true;
 
                 default:
@@ -244,7 +244,7 @@ namespace UniGLTF
                 case "Unlit/Transparent Cutout":
                     return Export_UnlitCutout(m);
 
-                case "UniGLTF/UniUnlit":
+                case UniUnlit.UniUnlitUtil.ShaderName:
                     return Export_UniUnlit(m);
 
                 default:
@@ -285,7 +285,7 @@ namespace UniGLTF
         {
             var material = glTF_KHR_materials_unlit.CreateDefault();
 
-            var renderMode = UniUnlit.Utils.GetRenderMode(m);
+            var renderMode = UniUnlit.UniUnlitUtil.GetRenderMode(m);
             if (renderMode == UniUnlitRenderMode.Opaque)
             {
                 material.alphaMode = glTFBlendMode.OPAQUE.ToString();
@@ -304,7 +304,7 @@ namespace UniGLTF
                 material.alphaMode = glTFBlendMode.OPAQUE.ToString();
             }
 
-            var cullMode = UniUnlit.Utils.GetCullMode(m);
+            var cullMode = UniUnlit.UniUnlitUtil.GetCullMode(m);
             if (cullMode == UniUnlitCullMode.Off)
             {
                 material.doubleSided = true;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/VertexColorState.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/VertexColorState.cs
@@ -26,11 +26,11 @@ namespace UniGLTF
             {
                 return false;
             }
-            if (m.shader.name != UniGLTF.UniUnlit.Utils.ShaderName)
+            if (m.shader.name != UniGLTF.UniUnlit.UniUnlitUtil.ShaderName)
             {
                 return false;
             }
-            if (UniGLTF.UniUnlit.Utils.GetVColBlendMode(m) != UniGLTF.UniUnlit.UniUnlitVertexColorBlendOp.Multiply)
+            if (UniGLTF.UniUnlit.UniUnlitUtil.GetVColBlendMode(m) != UniGLTF.UniUnlit.UniUnlitVertexColorBlendOp.Multiply)
             {
                 return false;
             }

--- a/Assets/VRM/Runtime/IO/VRMMaterialDescriptorGenerator.cs
+++ b/Assets/VRM/Runtime/IO/VRMMaterialDescriptorGenerator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using UniGLTF;
+﻿using UniGLTF;
 using UnityEngine;
 using VRMShaders;
 
@@ -16,24 +14,35 @@ namespace VRM
 
         public MaterialDescriptor Get(GltfData data, int i)
         {
-            // mtoon
-            if (!VRMMToonMaterialImporter.TryCreateParam(data, m_vrm, i, out MaterialDescriptor matDesc))
+            MaterialDescriptor matDesc;
+
+            // legacy "VRM/UnlitTransparentZWrite"
+            if (VRMZWriteMaterialImporter.TryCreateParam(data, m_vrm, i, out matDesc))
             {
-                // unlit
-                if (!GltfUnlitMaterialImporter.TryCreateParam(data, i, out matDesc))
-                {
-                    // pbr
-                    if (!GltfPbrMaterialImporter.TryCreateParam(data, i, out matDesc))
-                    {
-                        // fallback
-#if VRM_DEVELOP
-                        Debug.LogWarning($"material: {i} out of range. fallback");
-#endif
-                        return new MaterialDescriptor(GltfMaterialDescriptorGenerator.GetMaterialName(i, null), GltfPbrMaterialImporter.ShaderName);
-                    }
-                }
+                return matDesc;
             }
-            return matDesc;
+
+            // mtoon
+            if (VRMMToonMaterialImporter.TryCreateParam(data, m_vrm, i, out matDesc))
+            {
+                return matDesc;
+            }
+
+            // unlit
+            if (GltfUnlitMaterialImporter.TryCreateParam(data, i, out matDesc))
+            {
+                return matDesc;
+            }
+
+            // pbr
+            if (GltfPbrMaterialImporter.TryCreateParam(data, i, out matDesc))
+            {
+                return matDesc;
+            }
+
+            // fallback
+            Debug.LogWarning($"fallback");
+            return new MaterialDescriptor(GltfMaterialDescriptorGenerator.GetMaterialName(i, null), GltfPbrMaterialImporter.ShaderName);
         }
     }
 }

--- a/Assets/VRM/Runtime/IO/VRMZWriteMaterialImporter.cs
+++ b/Assets/VRM/Runtime/IO/VRMZWriteMaterialImporter.cs
@@ -1,0 +1,87 @@
+using UniGLTF;
+using UnityEngine;
+using VRMShaders;
+
+namespace VRM
+{
+    public static class VRMZWriteMaterialImporter
+    {
+        public const string ShaderName = "VRM/UnlitTransparentZWrite";
+
+        public static bool TryCreateParam(GltfData data, glTF_VRM_extensions vrm, int materialIdx, out MaterialDescriptor matDesc)
+        {
+            if (vrm?.materialProperties == null || vrm.materialProperties.Count == 0)
+            {
+                matDesc = default;
+                return false;
+            }
+            if (materialIdx < 0 || materialIdx >= vrm.materialProperties.Count)
+            {
+                matDesc = default;
+                return false;
+            }
+
+            var vrmMaterial = vrm.materialProperties[materialIdx];
+            if (vrmMaterial.shader != ShaderName)
+            {
+                // fallback to gltf
+                matDesc = default;
+                return false;
+            }
+
+            // use material.name, because material name may renamed in GltfParser.
+            var name = data.GLTF.materials[materialIdx].name;
+
+            // 
+            // import as MToon
+            //
+            matDesc = new MaterialDescriptor(name, MToon.Utils.ShaderName);
+
+            matDesc.RenderQueue = vrmMaterial.renderQueue;
+
+            if (vrmMaterial.textureProperties.ContainsKey(MToon.Utils.PropMainTex))
+            {
+                if (VRMMToonTextureImporter.TryGetTextureFromMaterialProperty(data, vrmMaterial, MToon.Utils.PropMainTex, out var texture))
+                {
+                    matDesc.TextureSlots.Add(MToon.Utils.PropMainTex, texture.Item2);
+                    matDesc.TextureSlots.Add(MToon.Utils.PropShadeTexture, texture.Item2);
+                }
+            }
+
+            matDesc.Colors[MToon.Utils.PropColor] = Color.white;
+            matDesc.Colors[MToon.Utils.PropShadeColor] = Color.white;
+
+            foreach (var kv in vrmMaterial.keywordMap)
+            {
+                if (kv.Value)
+                {
+                    matDesc.Actions.Add(material => material.EnableKeyword(kv.Key));
+                }
+                else
+                {
+                    matDesc.Actions.Add(material => material.DisableKeyword(kv.Key));
+                }
+            }
+
+            foreach (var kv in vrmMaterial.tagMap)
+            {
+                matDesc.Actions.Add(material => material.SetOverrideTag(kv.Key, kv.Value));
+            }
+
+            if (vrmMaterial.shader == MToon.Utils.ShaderName)
+            {
+                // TODO: Material拡張にMToonの項目が追加されたら旧バージョンのshaderPropから変換をかける
+                // インポート時にUniVRMに含まれるMToonのバージョンに上書きする
+                matDesc.FloatValues[MToon.Utils.PropVersion] = MToon.Utils.VersionNumber;
+            }
+
+            matDesc.Actions.Add(m =>
+            {
+                m.SetFloat(MToon.Utils.PropBlendMode, (float)MToon.RenderMode.TransparentWithZWrite);
+                MToon.Utils.ValidateProperties(m, true);
+            });
+
+            return true;
+        }
+    }
+}

--- a/Assets/VRM/Runtime/IO/VRMZWriteMaterialImporter.cs.meta
+++ b/Assets/VRM/Runtime/IO/VRMZWriteMaterialImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51208fe94c21c4b4abb16fd89a3aa7f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRMShaders/GLTF/IO/Runtime/MaterialFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/MaterialFactory.cs
@@ -24,7 +24,7 @@ namespace VRMShaders
             {"VRM/UnlitCutout", "Unlit/Transparent Cutout"},
             // 互換性は無いがとりあえず、
             {"VRM/UnlitTransparentZWrite", "VRM/MToon"},
-            {"UniGLTF/StandardVColor", UniGLTF.UniUnlit.Utils.ShaderName},
+            {"UniGLTF/StandardVColor", UniGLTF.UniUnlit.UniUnlitUtil.ShaderName},
         };
 
         public struct MaterialLoadInfo

--- a/Assets/VRMShaders/GLTF/UniUnlit/Editor/UniUnlitEditor.cs
+++ b/Assets/VRMShaders/GLTF/UniUnlit/Editor/UniUnlitEditor.cs
@@ -22,12 +22,12 @@ namespace UniGLTF.UniUnlit
         
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] properties)
         {
-            _mainTex = FindProperty(Utils.PropNameMainTex, properties);
-            _color = FindProperty(Utils.PropNameColor, properties);
-            _cutoff = FindProperty(Utils.PropNameCutoff, properties);
-            _blendMode = FindProperty(Utils.PropNameBlendMode, properties);
-            _cullMode = FindProperty(Utils.PropNameCullMode, properties);
-            _vColBlendMode = FindProperty(Utils.PropNameVColBlendMode, properties);
+            _mainTex = FindProperty(UniUnlitUtil.PropNameMainTex, properties);
+            _color = FindProperty(UniUnlitUtil.PropNameColor, properties);
+            _cutoff = FindProperty(UniUnlitUtil.PropNameCutoff, properties);
+            _blendMode = FindProperty(UniUnlitUtil.PropNameBlendMode, properties);
+            _cullMode = FindProperty(UniUnlitUtil.PropNameCullMode, properties);
+            _vColBlendMode = FindProperty(UniUnlitUtil.PropNameVColBlendMode, properties);
 //            _srcBlend = FindProperty(PropNameSrcBlend, properties);
 //            _dstBlend = FindProperty(PropNameDstBlend, properties);
 //            _zWrite = FindProperty(PropNameZWrite, properties);
@@ -46,18 +46,18 @@ namespace UniGLTF.UniUnlit
         public override void AssignNewShaderToMaterial(Material material, Shader oldShader, Shader newShader)
         {
             var blendMode = UniUnlitRenderMode.Opaque;
-            if (material.HasProperty(Utils.PropNameStandardShadersRenderMode)) // from Standard shader
+            if (material.HasProperty(UniUnlitUtil.PropNameStandardShadersRenderMode)) // from Standard shader
             {
-                blendMode = (UniUnlitRenderMode) Math.Min(2f, material.GetFloat(Utils.PropNameStandardShadersRenderMode));
+                blendMode = (UniUnlitRenderMode) Math.Min(2f, material.GetFloat(UniUnlitUtil.PropNameStandardShadersRenderMode));
             }
 
             // assigns UniUnlit's properties...
             base.AssignNewShaderToMaterial(material, oldShader, newShader);
 
             // take over old value
-            material.SetFloat(Utils.PropNameBlendMode, (float) blendMode);
+            material.SetFloat(UniUnlitUtil.PropNameBlendMode, (float) blendMode);
 
-            Utils.ValidateProperties(material, isRenderModeChangedByUser: true);
+            UniUnlitUtil.ValidateProperties(material, isRenderModeChangedByUser: true);
         }
 
         private void DrawRenderingBox(MaterialEditor materialEditor, Material[] materials)
@@ -152,7 +152,7 @@ namespace UniGLTF.UniUnlit
         {
             foreach (var material in materials)
             {
-                Utils.ValidateProperties(material, isRenderModeChangedByUser);
+                UniUnlitUtil.ValidateProperties(material, isRenderModeChangedByUser);
             }
         }
     }

--- a/Assets/VRMShaders/GLTF/UniUnlit/Runtime/UniUnlitUtil.cs
+++ b/Assets/VRMShaders/GLTF/UniUnlit/Runtime/UniUnlitUtil.cs
@@ -24,7 +24,7 @@ namespace UniGLTF.UniUnlit
         Multiply = 1,
     }
 
-    public static class Utils
+    public static class UniUnlitUtil
     {
         public const string ShaderName = "UniGLTF/UniUnlit";
         public const string PropNameMainTex = "_MainTex";

--- a/Assets/VRMShaders/GLTF/UniUnlit/Runtime/UniUnlitUtil.cs.meta
+++ b/Assets/VRMShaders/GLTF/UniUnlit/Runtime/UniUnlitUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 318c9e903f457f94589b2c5513d7d914
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRMShaders/GLTF/UniUnlit/Runtime/Utils.cs.meta
+++ b/Assets/VRMShaders/GLTF/UniUnlit/Runtime/Utils.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: e96cbbd810384352a6799dd731533178
-timeCreated: 1537534399


### PR DESCRIPTION
#1139

MToon へのフォールバック時に同じような見た目になるようにプロパティを書き換え。

主要な変更

* VRMMaterialDescriptorGenerator
* VRMZWriteMaterialImporter

ついで

* `UniUnilt.Utils` を `UniUnlit.UniUnlitUtil` に rename 。 ( using 時に `Utils` だと分かりづらいため )
* const UniUnlit.UniUnlitUtil.ShaderName を使うように修正
