### PR TITLE
[1.0] Fix MToon10 texture offset/scale bug.

### DIFF
--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_vertex.hlsl
@@ -17,7 +17,7 @@ Varyings MToonVertex(const Attributes v) // v is UnityCG macro specified name.
     UNITY_TRANSFER_INSTANCE_ID(v, output);
     UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
-    output.uv = TRANSFORM_TEX(v.texcoord0, _MainTex);
+    output.uv = v.texcoord0;
 
     if (MToon_IsOutlinePass())
     {


### PR DESCRIPTION
OffsetScale 変換が、頂点シェーダとフラグメントシェーダの両方で行われてしまっていた。