### PR TITLE
Ignore meshFilter if it hided or hasn't vertex

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportInfo.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportInfo.cs
@@ -201,7 +201,7 @@ namespace UniGLTF
             else if (renderer is MeshRenderer mr)
             {
                 var filter = mr.GetComponent<MeshFilter>();
-                if (filter != null)
+                if (filter.hideFlags == HideFlags.None && Mesh.vertexCount > 0 && filter != null)
                 {
                     Mesh = filter.sharedMesh;
                 }


### PR DESCRIPTION
- MeshFilterが非表示の場合に、その情報をexportしないように変更しました
  - TextMeshProなどがツリーに紛れていたとき、それを含めないようにすることが目的
- Meshが頂点を持たないとき、その情報をexportしないように変更しました
  - meshはexportされないが、それに紐付いた拡張情報や、マテリアルなどはexportされてしまうバグがあった