### PR TITLE
At importing, Unity asset name is fixed with ignore-case comparison.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbLowLevelParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbLowLevelParser.cs
@@ -174,7 +174,8 @@ namespace UniGLTF
         /// </summary>
         private static void FixTextureNameUnique(glTF GLTF)
         {
-            var used = new HashSet<string>();
+            // NOTE: Windows FileSystem は大文字小文字の違いは同名ファイルとして扱ってしまうため, IgnoreCase で評価する.
+            var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             for (var textureIdx = 0; textureIdx < GLTF.textures.Count; ++textureIdx)
             {
                 var gltfTexture = GLTF.textures[textureIdx];
@@ -200,7 +201,8 @@ namespace UniGLTF
 
         private static void FixMaterialNameUnique(glTF GLTF)
         {
-            var used = new HashSet<string>();
+            // NOTE: Windows FileSystem は大文字小文字の違いは同名ファイルとして扱ってしまうため, IgnoreCase で評価する.
+            var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             for (var materialIdx = 0; materialIdx < GLTF.materials.Count; ++materialIdx)
             {
                 var material = GLTF.materials[materialIdx];
@@ -231,7 +233,8 @@ namespace UniGLTF
 
         private static void FixAnimationNameUnique(glTF GLTF)
         {
-            var used = new HashSet<string>();
+            // NOTE: Windows FileSystem は大文字小文字の違いは同名ファイルとして扱ってしまうため, IgnoreCase で評価する.
+            var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             for (int i = 0; i < GLTF.animations.Count; ++i)
             {
                 var animation = GLTF.animations[i];

--- a/Assets/UniGLTF/Tests/UniGLTF/GlbParserTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/GlbParserTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace UniGLTF
+{
+    public sealed class GlbParserTests
+    {
+        [Test]
+        public void TextureNameUniqueness()
+        {
+            var gltfData = new glTF();
+            gltfData.asset.version = "2.0";
+            gltfData.buffers.Add(new glTFBuffer(new ArrayByteBuffer(Array.Empty<byte>())));
+            gltfData.textures.Add(new glTFTexture
+            {
+                name = "FooBar",
+                source = 0,
+            });
+            gltfData.textures.Add(new glTFTexture
+            {
+                name = "foobar",
+                source = 1,
+            });
+            gltfData.images.Add(new glTFImage
+            {
+                name = "HogeFuga",
+            });
+            gltfData.images.Add(new glTFImage
+            {
+                name = "hogefuga",
+            });
+
+            var parser = new GlbLowLevelParser("Test", gltfData.ToGlbBytes());
+            var data = parser.Parse();
+
+            Assert.AreEqual("FooBar", data.GLTF.textures[0].name);
+            // NOTE: 大文字小文字が違うだけの名前は、同一としてみなされ、Suffix が付く。
+            Assert.AreEqual("foobar__UNIGLTF__DUPLICATED__2", data.GLTF.textures[1].name);
+        }
+    }
+}

--- a/Assets/UniGLTF/Tests/UniGLTF/GlbParserTests.cs.meta
+++ b/Assets/UniGLTF/Tests/UniGLTF/GlbParserTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 21904270c266400aa6fe5edf3915a31e
+timeCreated: 1634282839


### PR DESCRIPTION
Editor Import において、大文字小文字が違うだけのアセットネームは、Windows などのファイルシステムにおいて同一として扱われ、ファイルが統合されてしまい、エラーとなっていた。

Example
- `Wood.png`
- `wood.png`

したがって GlbParser でのアセット名修正において、IgnoreCase で評価するようにした。
また、簡易なテストも追加した。