### PR TITLE
Quaternion.AngleAxisの単位が間違えていたことによるバグを修正

### DIFF
--- a/Assets/VRM/Runtime/FastSpringBone/Blittables/BlittablePoint.cs
+++ b/Assets/VRM/Runtime/FastSpringBone/Blittables/BlittablePoint.cs
@@ -132,7 +132,7 @@ namespace VRM.FastSpringBones.Blittables
 
         private static Quaternion FromToRotation(Vector3 from, Vector3 to)
             => Quaternion.AngleAxis(
-                angle: Mathf.Acos(Mathf.Clamp(Vector3.Dot(from.normalized, to.normalized), -1f, 1f)),
+                angle: Mathf.Acos(Mathf.Clamp(Vector3.Dot(from.normalized, to.normalized), -1f, 1f)) * Mathf.Rad2Deg,
                 axis: Vector3.Cross(from, to).normalized
             );
 


### PR DESCRIPTION
Quaternion.AngleAxisの単位が間違えていたことによるバグを修正