### PR TITLE
ReconstructSpringBoneを呼んだ時、デフォルトの回転角の指定が正しく行えない問題を修正

### DIFF
--- a/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneInstanceBuffers.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneInstanceBuffers.cs
@@ -107,7 +107,7 @@ namespace UniVRM10.FastSpringBones.System
                         parentTransformIndex = parent != null ? transformIndexDictionary[parent] : -1,
                         currentTail = currentTail,
                         prevTail = currentTail,
-                        localRotation = joint.Transform.localRotation,
+                        localRotation = Quaternion.identity,
                         boneAxis = localChildPosition.normalized,
                         length = localChildPosition.magnitude
                     });


### PR DESCRIPTION
ReconstructSpringBoneを呼んだ時、デフォルトの回転角の指定が正しく行えない問題を修正しました