### PR TITLE
fix (VRM1.0, MToon): change export spec version to 1.0-beta

### DIFF
--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
@@ -10,7 +10,7 @@ namespace UniVRM10
 {
     public static class Vrm10MToonMaterialExporter
     {
-        const string MTOON_SPEC_VERSION = "1.0-draft";
+        const string MTOON_SPEC_VERSION = "1.0-beta";
 
         public static bool TryExportMaterialAsMToon(Material src, ITextureExporter textureExporter, out glTFMaterial dst)
         {


### PR DESCRIPTION
MToonのExportバージョンを `1.0-draft` から `1.0-beta` に変更しました。
three-vrmの1.0-betaでは現状、specVersionを `1.0-beta` にしないとMToonを読み込むことが出来ません。