### PR TITLE
fix (VRM1.0, MToon): exported emissive factor should be in linear colorspace

### DIFF
--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
@@ -84,7 +84,8 @@ namespace UniVRM10
             mtoon.GiEqualizationFactor = context.GiEqualizationFactor;
 
             // Emission
-            dst.emissiveFactor = context.EmissiveFactorLinear.ToFloat3(ColorSpace.sRGB, ColorSpace.Linear);
+            // Emissive factor is stored in Linear space
+            dst.emissiveFactor = context.EmissiveFactorLinear.ToFloat3(ColorSpace.Linear, ColorSpace.Linear);
             var emissiveTextureIndex = textureExporter.RegisterExportingAsSRgb(context.EmissiveTexture, needsAlpha: false);
             if (emissiveTextureIndex != -1)
             {

--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialImporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialImporter.cs
@@ -72,7 +72,8 @@ namespace UniVRM10
             // GI
 
             // Emission
-            var emissionColor = material?.emissiveFactor?.ToColor3(gltfColorSpace, ColorSpace.sRGB);
+            // Emissive factor should be stored in Linear space
+            var emissionColor = material?.emissiveFactor?.ToColor3(gltfColorSpace, ColorSpace.Linear);
             if (emissionColor.HasValue)
             {
                 yield return (MToon10Prop.EmissiveFactor.ToUnityShaderLabName(), emissionColor.Value);

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon10Context.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon10Context.cs
@@ -102,7 +102,8 @@ namespace VRMShaders.VRM10.MToon10.Runtime
         // Emission
         public Color EmissiveFactorLinear
         {
-            get => _material.GetColor(MToon10Prop.EmissiveFactor).linear;
+            // Emissive factor is stored in Linear space
+            get => _material.GetColor(MToon10Prop.EmissiveFactor);
         }
 
         public Texture EmissiveTexture


### PR DESCRIPTION
MToonのexport時の `emissiveFactor` がLinearでなくsRGBでシリアライズされていたため、これを修正します。
