### PR TITLE
meshを正規化するときに、法線を正規化する

### DIFF
--- a/Assets/UniGLTF/Runtime/MeshUtility/BoneNormalizer.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/BoneNormalizer.cs
@@ -370,7 +370,7 @@ namespace UniGLTF.MeshUtility
                     }
                     else
                     {
-                        normals[j] = m.MultiplyVector(normals[j]) - meshNormals[j];
+                        normals[j] = m.MultiplyVector(normals[j].normalized) - meshNormals[j];
                     }
                 }
 

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
@@ -70,7 +70,7 @@ namespace UniGLTF.MeshUtility
             src.vertices = src.vertices.Select(x => m.MultiplyPoint(x)).ToArray();
             if (src.normals != null && src.normals.Length > 0)
             {
-                src.normals = src.normals.Select(x => m.MultiplyVector(x)).ToArray();
+                src.normals = src.normals.Select(x => m.MultiplyVector(x.normalized)).ToArray();
             }
             if (src.tangents != null && src.tangents.Length > 0)
             {


### PR DESCRIPTION
さもないと blendshape が壊れる

#1354

`vrm-0.88` `original fbx` `fixed`
<img  width=600 src=https://user-images.githubusercontent.com/68057/140698629-14a0f946-95a8-4201-a483-fbc51210aa46.jpg>

blender由来の z-up mesh が起因で 行列に回転が入っていることでトリガーするかもしれない。
