### PR TITLE
New Mesh APIを利用することで、GPUへのMeshアップロードコストを削減

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -177,9 +177,9 @@ namespace UniGLTF
                     var index = i;
                     using (MeasureTime("ReadMesh"))
                     {
-                        var x = await awaitCaller.Run(() => meshImporter.ReadMesh(Data, index, inverter));
-                        var y = await BuildMeshAsync(awaitCaller, MeasureTime, x, index);
-                        Meshes.Add(y);
+                        var meshContext = await awaitCaller.Run(() => meshImporter.ReadMesh(Data, index, inverter));
+                        var meshWithMaterials = await BuildMeshAsync(awaitCaller, MeasureTime, meshContext, index);
+                        Meshes.Add(meshWithMaterials);
                     }
                 }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshImporter.cs
@@ -31,6 +31,7 @@ namespace UniGLTF
 
         internal MeshContext ReadMesh(GltfData data, int meshIndex, IAxisInverter inverter)
         {
+            Profiler.BeginSample("ReadMesh");
             var gltfMesh = data.GLTF.meshes[meshIndex];
 
             var meshContext = new MeshContext(gltfMesh.name, meshIndex);
@@ -46,7 +47,8 @@ namespace UniGLTF
             meshContext.RenameBlendShape(gltfMesh);
 
             meshContext.DropUnusedVertices();
-
+            
+            Profiler.EndSample();
             return meshContext;
         }
 
@@ -61,12 +63,7 @@ namespace UniGLTF
             };
 
             meshContext.UploadMeshVertices(mesh);
-
-            mesh.subMeshCount = meshContext.SubMeshes.Count;
-            for (var i = 0; i < meshContext.SubMeshes.Count; ++i)
-            {
-                mesh.SetTriangles(meshContext.SubMeshes[i], i);
-            }
+            meshContext.UploadMeshIndices(mesh);
 
             if (!meshContext.HasNormal)
             {
@@ -124,7 +121,7 @@ namespace UniGLTF
             Func<int, Material> ctx,
             MeshContext meshContext)
         {
-            Profiler.BeginSample("MeshImporter._BuildMesh");
+            Profiler.BeginSample("MeshImporter.BuildMesh");
             var (mesh, recalculateTangents) = BuildMesh(meshContext);
             Profiler.EndSample();
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
@@ -11,25 +11,25 @@ namespace UniGLTF
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     internal readonly struct MeshVertex
     {
-        public readonly Vector3 Position;
-        public readonly Vector3 Normal;
-        public readonly Color Color;
-        public readonly Vector2 Uv;
-        public readonly Vector2 Uv2;
-        public readonly float BoneWeight0;
-        public readonly float BoneWeight1;
-        public readonly float BoneWeight2;
-        public readonly float BoneWeight3;
-        public readonly ushort BoneIndex0;
-        public readonly ushort BoneIndex1;
-        public readonly ushort BoneIndex2;
-        public readonly ushort BoneIndex3;
+        private readonly Vector3 _position;
+        private readonly Vector3 _normal;
+        private readonly Color _color;
+        private readonly Vector2 _texcoord0;
+        private readonly Vector2 _texcoord1;
+        private readonly float _boneWeight0;
+        private readonly float _boneWeight1;
+        private readonly float _boneWeight2;
+        private readonly float _boneWeight3;
+        private readonly ushort _boneIndex0;
+        private readonly ushort _boneIndex1;
+        private readonly ushort _boneIndex2;
+        private readonly ushort _boneIndex3;
 
         public MeshVertex(
             Vector3 position,
             Vector3 normal,
-            Vector2 uv,
-            Vector2 uv2,
+            Vector2 texcoord0,
+            Vector2 texcoord1,
             Color color,
             ushort boneIndex0,
             ushort boneIndex1,
@@ -40,19 +40,19 @@ namespace UniGLTF
             float boneWeight2,
             float boneWeight3)
         {
-            Position = position;
-            Normal = normal;
-            Uv = uv;
-            Uv2 = uv2;
-            Color = color;
-            BoneIndex0 = boneIndex0;
-            BoneIndex1 = boneIndex1;
-            BoneIndex2 = boneIndex2;
-            BoneIndex3 = boneIndex3;
-            BoneWeight0 = boneWeight0;
-            BoneWeight1 = boneWeight1;
-            BoneWeight2 = boneWeight2;
-            BoneWeight3 = boneWeight3;
+            _position = position;
+            _normal = normal;
+            _texcoord0 = texcoord0;
+            _texcoord1 = texcoord1;
+            _color = color;
+            _boneIndex0 = boneIndex0;
+            _boneIndex1 = boneIndex1;
+            _boneIndex2 = boneIndex2;
+            _boneIndex3 = boneIndex3;
+            _boneWeight0 = boneWeight0;
+            _boneWeight1 = boneWeight1;
+            _boneWeight2 = boneWeight2;
+            _boneWeight3 = boneWeight3;
         }
 
         public static VertexAttributeDescriptor[] GetVertexAttributeDescriptor() => new[] {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
@@ -14,8 +14,8 @@ namespace UniGLTF
         private readonly Vector3 _position;
         private readonly Vector3 _normal;
         private readonly Color _color;
-        private readonly Vector2 _texcoord0;
-        private readonly Vector2 _texcoord1;
+        private readonly Vector2 _texCoord0;
+        private readonly Vector2 _texCoord1;
         private readonly float _boneWeight0;
         private readonly float _boneWeight1;
         private readonly float _boneWeight2;
@@ -28,8 +28,8 @@ namespace UniGLTF
         public MeshVertex(
             Vector3 position,
             Vector3 normal,
-            Vector2 texcoord0,
-            Vector2 texcoord1,
+            Vector2 texCoord0,
+            Vector2 texCoord1,
             Color color,
             ushort boneIndex0,
             ushort boneIndex1,
@@ -42,8 +42,8 @@ namespace UniGLTF
         {
             _position = position;
             _normal = normal;
-            _texcoord0 = texcoord0;
-            _texcoord1 = texcoord1;
+            _texCoord0 = texCoord0;
+            _texCoord1 = texCoord1;
             _color = color;
             _boneIndex0 = boneIndex0;
             _boneIndex1 = boneIndex1;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
@@ -9,7 +9,7 @@ namespace UniGLTF
     /// そのままGPUにアップロードされる
     /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    public readonly struct MeshVertex
+    internal readonly struct MeshVertex
     {
         public readonly Vector3 Position;
         public readonly Vector3 Normal;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
@@ -1,0 +1,64 @@
+using System.Runtime.InteropServices;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace UniGLTF
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public readonly struct MeshVertex
+    {
+        public readonly Vector3 Position;
+        public readonly Vector3 Normal;
+        public readonly Color Color;
+        public readonly Vector2 Uv;
+        public readonly Vector2 Uv2;
+        public readonly float BoneWeight0;
+        public readonly float BoneWeight1;
+        public readonly float BoneWeight2;
+        public readonly float BoneWeight3;
+        public readonly ushort BoneIndex0;
+        public readonly ushort BoneIndex1;
+        public readonly ushort BoneIndex2;
+        public readonly ushort BoneIndex3;
+
+        public MeshVertex(
+            Vector3 position,
+            Vector3 normal,
+            Vector2 uv,
+            Vector2 uv2,
+            Color color,
+            ushort boneIndex0,
+            ushort boneIndex1,
+            ushort boneIndex2,
+            ushort boneIndex3,
+            float boneWeight0,
+            float boneWeight1,
+            float boneWeight2,
+            float boneWeight3)
+        {
+            Position = position;
+            Normal = normal;
+            Uv = uv;
+            Uv2 = uv2;
+            Color = color;
+            BoneIndex0 = boneIndex0;
+            BoneIndex1 = boneIndex1;
+            BoneIndex2 = boneIndex2;
+            BoneIndex3 = boneIndex3;
+            BoneWeight0 = boneWeight0;
+            BoneWeight1 = boneWeight1;
+            BoneWeight2 = boneWeight2;
+            BoneWeight3 = boneWeight3;
+        }
+
+        public static VertexAttributeDescriptor[] GetVertexAttributeDescriptor() => new[] {
+            new VertexAttributeDescriptor(VertexAttribute.Position),
+                new VertexAttributeDescriptor(VertexAttribute.Normal),
+                new VertexAttributeDescriptor(VertexAttribute.Color, dimension: 4),
+                new VertexAttributeDescriptor(VertexAttribute.TexCoord0, dimension: 2),
+                new VertexAttributeDescriptor(VertexAttribute.TexCoord1, dimension: 2),
+                new VertexAttributeDescriptor(VertexAttribute.BlendWeight, dimension: 4),
+                new VertexAttributeDescriptor(VertexAttribute.BlendIndices, VertexAttributeFormat.UInt16, 4),
+            };
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
@@ -8,7 +8,7 @@ namespace UniGLTF
     /// インターリーブされたメッシュの頂点情報を表す構造体
     /// そのままGPUにアップロードされる
     /// </summary>
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    [StructLayout(LayoutKind.Sequential)]
     internal readonly struct MeshVertex
     {
         private readonly Vector3 _position;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
@@ -4,6 +4,10 @@ using UnityEngine.Rendering;
 
 namespace UniGLTF
 {
+    /// <summary>
+    /// インターリーブされたメッシュの頂点情報を表す構造体
+    /// そのままGPUにアップロードされる
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public readonly struct MeshVertex
     {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0d540d8e32d54e7089a72156edb7ad80
+timeCreated: 1636526648

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/PrimitiveExtensions.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/PrimitiveExtensions.cs
@@ -1,0 +1,119 @@
+using System;
+using UnityEngine;
+
+namespace UniGLTF
+{
+    internal static class PrimitiveExtensions
+    {
+        public static bool HasNormal(this glTFPrimitives primitives) => primitives.attributes.NORMAL != -1;
+        public static bool HasTexCoord0(this glTFPrimitives primitives) => primitives.attributes.TEXCOORD_0 != -1;
+        public static bool HasTexCoord1(this glTFPrimitives primitives) => primitives.attributes.TEXCOORD_1 != -1;
+        public static bool HasSkin(this glTFPrimitives primitives) => primitives.attributes.JOINTS_0 != -1 && primitives.attributes.WEIGHTS_0 != -1;
+        public static bool HasColor(this glTFPrimitives primitives) => primitives.attributes.COLOR_0 != -1;
+
+        public static Vector3[] GetPositions(this glTFPrimitives primitives, GltfData data)
+        {
+            return data.GetArrayFromAccessor<Vector3>(primitives.attributes.POSITION);
+        }
+
+        public static Vector3[] GetNormals(this glTFPrimitives primitives, GltfData data, int positionsLength)
+        {
+            if (!HasNormal(primitives)) return null;
+            var result = data.GetArrayFromAccessor<Vector3>(primitives.attributes.NORMAL);
+            if (result.Length != positionsLength)
+            {
+                throw new Exception("different length");
+            }
+
+            return result;
+        }
+
+        public static Vector2[] GetTexCoords0(this glTFPrimitives primitives, GltfData data, int positionsLength)
+        {
+            if (!HasTexCoord0(primitives)) return null;
+            var result = data.GetArrayFromAccessor<Vector2>(primitives.attributes.TEXCOORD_0);
+            if (result.Length != positionsLength)
+            {
+                throw new Exception("different length");
+            }
+
+            return result;
+        }
+        
+        public static Vector2[] GetTexCoords1(this glTFPrimitives primitives, GltfData data, int positionsLength)
+        {
+            if (!HasTexCoord1(primitives)) return null;
+            var result = data.GetArrayFromAccessor<Vector2>(primitives.attributes.TEXCOORD_1);
+            if (result.Length != positionsLength)
+            {
+                throw new Exception("different length");
+            }
+            
+            return result;
+        }
+
+        public static Color[] GetColors(this glTFPrimitives primitives, GltfData data, int positionsLength)
+        {
+            if (!HasColor(primitives)) return null;
+            
+            switch (data.GLTF.accessors[primitives.attributes.COLOR_0].TypeCount)
+            {
+                case 3:
+                {
+                    var vec3Color = data.GetArrayFromAccessor<Vector3>(primitives.attributes.COLOR_0);
+                    if (vec3Color.Length != positionsLength)
+                    {
+                        throw new Exception("different length");
+                    }
+                    var colors = new Color[vec3Color.Length];
+
+                    for (var index = 0; index < vec3Color.Length; index++)
+                    {
+                        var color = vec3Color[index];
+                        colors[index] = new Color(color.x, color.y, color.z);
+                    }
+
+                    return colors;
+                }
+                case 4:
+                    var result = data.GetArrayFromAccessor<Color>(primitives.attributes.COLOR_0);
+                    if (result.Length != positionsLength)
+                    {
+                        throw new Exception("different length");
+                    }
+
+                    return result;
+                default:
+                    throw new NotImplementedException(
+                        $"unknown color type {data.GLTF.accessors[primitives.attributes.COLOR_0].type}");
+            }
+        }
+
+        public static JointsAccessor.Getter GetJoints(this glTFPrimitives primitives,  GltfData data, int positionsLength)
+        {
+            // skin
+            if (!HasSkin(primitives)) return null;
+            var (getter, length) = JointsAccessor.GetAccessor(data, primitives.attributes.JOINTS_0);
+            if (length != positionsLength)
+            {
+                throw new Exception("different length");
+            }
+
+            return getter;
+
+        }
+
+        public static WeightsAccessor.Getter GetWeights(this glTFPrimitives primitives, GltfData data, int positionsLength)
+        {
+            // skin
+            if (!HasSkin(primitives)) return null;
+            var (getter, length) = WeightsAccessor.GetAccessor(data, primitives.attributes.WEIGHTS_0);
+            if (length != positionsLength)
+            {
+                throw new Exception("different length");
+            }
+
+            return getter;
+        }
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/PrimitiveExtensions.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/PrimitiveExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 867e7d22991044cd921d5479269142f2
+timeCreated: 1636536120


### PR DESCRIPTION
# 変更内容
- Unity2019から追加されたNew Mesh APIを利用するように変更しました
  - Meshのアップロードコストが大幅に削減できます（詳細は次の負荷計測の項に）
- Tangent周りのコードの維持が難しかったため削除
  - 必要性があれば復元しますが、アプローチは相談したい

# 負荷計測
- エディタ上でのAlicia Solidの読み込み時間で計測
- BuildMeshのコストが2.79ms -> 0.79ms
    - GC Allocも1300KB -> 2.6KB

## Before
![image](https://user-images.githubusercontent.com/3889597/141242359-6d1447ae-6494-4fb1-bc18-e9b6d13cf22b.png)

## After
![image](https://user-images.githubusercontent.com/3889597/141242246-6dbb9e8e-c90f-48c6-83d1-b19863fc5777.png)
