### PR TITLE
VRM1.0についてもNew Mesh APIを使う

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshVertex.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -8,7 +9,7 @@ namespace UniGLTF
     /// インターリーブされたメッシュの頂点情報を表す構造体
     /// そのままGPUにアップロードされる
     /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
+    [Serializable, StructLayout(LayoutKind.Sequential)]
     internal readonly struct MeshVertex
     {
         private readonly Vector3 _position;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/SkinJoint.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/SkinJoint.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace UniGLTF
 {
+    [Serializable]
     public struct SkinJoints : IEquatable<SkinJoints>
     {
         public ushort Joint0;

--- a/Assets/VRM10/Runtime/IO/Model/CopyIndicesJob.cs
+++ b/Assets/VRM10/Runtime/IO/Model/CopyIndicesJob.cs
@@ -1,0 +1,120 @@
+using Unity.Collections;
+using Unity.Jobs;
+
+#if ENABLE_VRM10_BURST
+using Unity.Burst;
+#endif
+
+namespace UniVRM10
+{
+    /// <summary>
+    /// インデックス配列を、オフセットを加えながら複製するJob郡
+    /// MEMO: ushortを考慮することをやめればかなりシンプルに書ける
+    /// </summary>
+    internal struct CopyIndicesJobs
+    {
+        /// <summary>
+        /// unsigned int -> unsigned int
+        /// </summary>
+#if ENABLE_VRM10_BURST
+        [BurstCompile]
+#endif
+        public struct UInt2UInt : IJobParallelFor
+        {
+            private readonly uint _vertexOffset;
+
+            [ReadOnly] private readonly NativeSlice<uint> _source;
+            [WriteOnly] private NativeSlice<uint> _destination;
+
+            public UInt2UInt(uint vertexOffset, NativeSlice<uint> source, NativeSlice<uint> destination)
+            {
+                _vertexOffset = vertexOffset;
+                _source = source;
+                _destination = destination;
+            }
+
+            public void Execute(int index)
+            {
+                _destination[index] = _source[index] + _vertexOffset;
+            }
+        }
+
+        /// <summary>
+        /// unsigned short -> unsigned int
+        /// </summary>
+#if ENABLE_VRM10_BURST
+        [BurstCompile]
+#endif
+        public struct Ushort2Uint : IJobParallelFor
+        {
+            private readonly uint _vertexOffset;
+
+            [ReadOnly] private readonly NativeSlice<ushort> _source;
+            [WriteOnly] private NativeSlice<uint> _destination;
+
+            public Ushort2Uint(uint vertexOffset, NativeSlice<ushort> source, NativeSlice<uint> destination)
+            {
+                _vertexOffset = vertexOffset;
+                _source = source;
+                _destination = destination;
+            }
+
+            public void Execute(int index)
+            {
+                _destination[index] = _source[index] + _vertexOffset;
+            }
+        }
+
+        /// <summary>
+        /// unsigned short -> unsigned short
+        /// </summary>
+#if ENABLE_VRM10_BURST
+        [BurstCompile]
+#endif
+        public struct Ushort2Ushort : IJobParallelFor
+        {
+            private readonly ushort _vertexOffset;
+
+            [ReadOnly] private readonly NativeSlice<ushort> _source;
+            [WriteOnly] private NativeSlice<ushort> _destination;
+
+            public Ushort2Ushort(ushort vertexOffset, NativeSlice<ushort> source, NativeSlice<ushort> destination)
+            {
+                _vertexOffset = vertexOffset;
+                _source = source;
+                _destination = destination;
+            }
+
+            public void Execute(int index)
+            {
+                _destination[index] = (ushort)(_source[index] + _vertexOffset);
+            }
+        }
+
+        /// <summary>
+        /// unsigned int -> unsigned short
+        /// </summary>
+#if ENABLE_VRM10_BURST
+        [BurstCompile]
+#endif
+        public struct Uint2Ushort : IJobParallelFor
+        {
+            private readonly ushort _vertexOffset;
+
+            [ReadOnly] private readonly NativeSlice<uint> _source;
+            [WriteOnly] private NativeSlice<ushort> _destination;
+
+            public Uint2Ushort(ushort vertexOffset, NativeSlice<uint> source, NativeSlice<ushort> destination)
+            {
+                _vertexOffset = vertexOffset;
+                _source = source;
+                _destination = destination;
+            }
+
+            public void Execute(int index)
+            {
+                _destination[index] = (ushort)(_source[index] + _vertexOffset);
+            }
+        }
+    }
+}

--- a/Assets/VRM10/Runtime/IO/Model/CopyIndicesJob.cs.meta
+++ b/Assets/VRM10/Runtime/IO/Model/CopyIndicesJob.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3c6a7113ee13415e9b8c1063a683f3f8
+timeCreated: 1637033014

--- a/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
+++ b/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
@@ -11,7 +11,7 @@ using Unity.Burst;
 namespace UniVRM10
 {
     /// <summary>
-    /// 渡されたバッファを一つのバッファにインターリーブする
+    /// 渡されたバッファを一つのバッファにインターリーブするJob
     /// </summary>
 #if ENABLE_VRM10_BURST
     [BurstCompile]

--- a/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
+++ b/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
@@ -14,14 +14,14 @@ namespace UniVRM10
     /// 渡されたバッファを一つのバッファにインターリーブする
     /// </summary>
 #if ENABLE_VRM10_BURST
-//    [BurstCompile]
+    [BurstCompile]
 #endif
     internal struct InterleaveMeshVerticesJob : IJobParallelFor
     {
         [WriteOnly, NativeDisableParallelForRestriction]
         private NativeArray<MeshVertex> _vertices;
 
-        [ReadOnly, NativeDisableParallelForRestriction]
+        [ReadOnly]
         private readonly NativeArray<Vector3> _positions;
 
         // default値を許容する

--- a/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
+++ b/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
@@ -18,39 +18,36 @@ namespace UniVRM10
 #endif
     internal struct InterleaveMeshVerticesJob : IJobParallelFor
     {
-        [WriteOnly, NativeDisableParallelForRestriction]
-        private NativeArray<MeshVertex> _vertices;
+        [WriteOnly]
+        private NativeSlice<MeshVertex> _vertices;
 
         [ReadOnly]
-        private readonly NativeArray<Vector3> _positions;
+        private readonly NativeSlice<Vector3> _positions;
 
         // default値を許容する
         [ReadOnly, NativeDisableContainerSafetyRestriction]
-        private readonly NativeArray<Vector3> _normals;
+        private readonly NativeSlice<Vector3> _normals;
 
         [ReadOnly, NativeDisableContainerSafetyRestriction]
-        private readonly NativeArray<Vector2> _texCoords;
+        private readonly NativeSlice<Vector2> _texCoords;
 
         [ReadOnly, NativeDisableContainerSafetyRestriction]
-        private readonly NativeArray<Color> _colors;
+        private readonly NativeSlice<Color> _colors;
 
         [ReadOnly, NativeDisableContainerSafetyRestriction]
-        private readonly NativeArray<Vector4> _weights;
+        private readonly NativeSlice<Vector4> _weights;
 
         [ReadOnly, NativeDisableContainerSafetyRestriction]
-        private readonly NativeArray<SkinJoints> _joints;
-
-        private readonly int _verticesOffset;
+        private readonly NativeSlice<SkinJoints> _joints;
 
         public InterleaveMeshVerticesJob(
-            NativeArray<MeshVertex> vertices,
+            NativeSlice<MeshVertex> vertices,
             NativeArray<Vector3> positions,
             NativeArray<Vector3> normals = default,
             NativeArray<Vector2> texCoords = default,
             NativeArray<Color> colors = default,
             NativeArray<Vector4> weights = default,
-            NativeArray<SkinJoints> joints = default,
-            int verticesOffset = 0)
+            NativeArray<SkinJoints> joints = default)
         {
             _vertices = vertices;
             _positions = positions;
@@ -59,24 +56,23 @@ namespace UniVRM10
             _colors = colors;
             _weights = weights;
             _joints = joints;
-            _verticesOffset = verticesOffset;
         }
 
         public void Execute(int index)
         {
-            _vertices[index + _verticesOffset] = new MeshVertex(
+            _vertices[index] = new MeshVertex(
                 _positions[index],
-                _normals.IsCreated ? _normals[index] : Vector3.zero,
-                _texCoords.IsCreated ? _texCoords[index] : Vector2.zero,
-                _colors.IsCreated ? _colors[index] : Color.white,
-                _joints.IsCreated ? _joints[index].Joint0 : (ushort)0,
-                _joints.IsCreated ? _joints[index].Joint1 : (ushort)0,
-                _joints.IsCreated ? _joints[index].Joint2 : (ushort)0,
-                _joints.IsCreated ? _joints[index].Joint3 : (ushort)0,
-                _weights.IsCreated ? _weights[index].x : 0,
-                _weights.IsCreated ? _weights[index].y : 0,
-                _weights.IsCreated ? _weights[index].z : 0,
-                _weights.IsCreated ? _weights[index].w : 0
+                _normals.Length > 0 ? _normals[index] : Vector3.zero,
+                _texCoords.Length > 0 ? _texCoords[index] : Vector2.zero,
+                _colors.Length > 0 ? _colors[index] : Color.white,
+                _joints.Length > 0 ? _joints[index].Joint0 : (ushort)0,
+                _joints.Length > 0 ? _joints[index].Joint1 : (ushort)0,
+                _joints.Length > 0 ? _joints[index].Joint2 : (ushort)0,
+                _joints.Length > 0 ? _joints[index].Joint3 : (ushort)0,
+                _weights.Length > 0 ? _weights[index].x : 0,
+                _weights.Length > 0 ? _weights[index].y : 0,
+                _weights.Length > 0 ? _weights[index].z : 0,
+                _weights.Length > 0 ? _weights[index].w : 0
             );
         }
     }

--- a/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
+++ b/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
@@ -1,0 +1,65 @@
+using UniGLTF;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
+using UnityEngine;
+
+#if ENABLE_VRM10_BURST
+using Unity.Burst;
+#endif
+
+namespace UniVRM10
+{
+    #if ENABLE_VRM10_BURST
+    [BurstCompile]
+    #endif
+    internal struct InterleaveMeshVerticesJob : IJobParallelFor
+    {
+        [WriteOnly] private NativeArray<MeshVertex> _vertices;
+        
+        [ReadOnly] private readonly NativeArray<Vector3> _positions;
+        
+        // default値を許容する
+        [ReadOnly, NativeDisableContainerSafetyRestriction] private readonly NativeArray<Vector3> _normals;
+        [ReadOnly, NativeDisableContainerSafetyRestriction] private readonly NativeArray<Vector2> _texCoords;
+        [ReadOnly, NativeDisableContainerSafetyRestriction] private readonly NativeArray<Color> _colors;
+        [ReadOnly, NativeDisableContainerSafetyRestriction] private readonly NativeArray<Vector4> _weights;
+        [ReadOnly, NativeDisableContainerSafetyRestriction] private readonly NativeArray<SkinJoints> _joints;
+
+        public InterleaveMeshVerticesJob(
+            NativeArray<MeshVertex> vertices,
+            NativeArray<Vector3> positions,
+            NativeArray<Vector3> normals = default,
+            NativeArray<Vector2> texCoords = default,
+            NativeArray<Color> colors = default,
+            NativeArray<Vector4> weights = default,
+            NativeArray<SkinJoints> joints = default)
+        {
+            _vertices = vertices;
+            _positions = positions;
+            _normals = normals;
+            _texCoords = texCoords;
+            _colors = colors;
+            _weights = weights;
+            _joints = joints;
+        }
+
+        public void Execute(int index)
+        {
+            _vertices[index] = new MeshVertex(
+                _positions[index],
+                _normals.IsCreated ? _normals[index] : Vector3.zero,
+                _texCoords.IsCreated ? _texCoords[index] : Vector2.zero,
+                _colors.IsCreated ? _colors[index] : Color.white,
+                _joints.IsCreated ? _joints[index].Joint0 : (ushort)0,
+                _joints.IsCreated ? _joints[index].Joint1 : (ushort)0,
+                _joints.IsCreated ? _joints[index].Joint2 : (ushort)0,
+                _joints.IsCreated ? _joints[index].Joint3 : (ushort)0,
+                _weights.IsCreated ? _weights[index].x : 0,
+                _weights.IsCreated ? _weights[index].y : 0,
+                _weights.IsCreated ? _weights[index].z : 0,
+                _weights.IsCreated ? _weights[index].w : 0
+            );
+        }
+    }
+}

--- a/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
+++ b/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
@@ -10,21 +10,37 @@ using Unity.Burst;
 
 namespace UniVRM10
 {
-    #if ENABLE_VRM10_BURST
-    [BurstCompile]
-    #endif
+    /// <summary>
+    /// 渡されたバッファを一つのバッファにインターリーブする
+    /// </summary>
+#if ENABLE_VRM10_BURST
+//    [BurstCompile]
+#endif
     internal struct InterleaveMeshVerticesJob : IJobParallelFor
     {
-        [WriteOnly] private NativeArray<MeshVertex> _vertices;
-        
-        [ReadOnly] private readonly NativeArray<Vector3> _positions;
-        
+        [WriteOnly, NativeDisableParallelForRestriction]
+        private NativeArray<MeshVertex> _vertices;
+
+        [ReadOnly, NativeDisableParallelForRestriction]
+        private readonly NativeArray<Vector3> _positions;
+
         // default値を許容する
-        [ReadOnly, NativeDisableContainerSafetyRestriction] private readonly NativeArray<Vector3> _normals;
-        [ReadOnly, NativeDisableContainerSafetyRestriction] private readonly NativeArray<Vector2> _texCoords;
-        [ReadOnly, NativeDisableContainerSafetyRestriction] private readonly NativeArray<Color> _colors;
-        [ReadOnly, NativeDisableContainerSafetyRestriction] private readonly NativeArray<Vector4> _weights;
-        [ReadOnly, NativeDisableContainerSafetyRestriction] private readonly NativeArray<SkinJoints> _joints;
+        [ReadOnly, NativeDisableContainerSafetyRestriction]
+        private readonly NativeArray<Vector3> _normals;
+
+        [ReadOnly, NativeDisableContainerSafetyRestriction]
+        private readonly NativeArray<Vector2> _texCoords;
+
+        [ReadOnly, NativeDisableContainerSafetyRestriction]
+        private readonly NativeArray<Color> _colors;
+
+        [ReadOnly, NativeDisableContainerSafetyRestriction]
+        private readonly NativeArray<Vector4> _weights;
+
+        [ReadOnly, NativeDisableContainerSafetyRestriction]
+        private readonly NativeArray<SkinJoints> _joints;
+
+        private readonly int _verticesOffset;
 
         public InterleaveMeshVerticesJob(
             NativeArray<MeshVertex> vertices,
@@ -33,7 +49,8 @@ namespace UniVRM10
             NativeArray<Vector2> texCoords = default,
             NativeArray<Color> colors = default,
             NativeArray<Vector4> weights = default,
-            NativeArray<SkinJoints> joints = default)
+            NativeArray<SkinJoints> joints = default,
+            int verticesOffset = 0)
         {
             _vertices = vertices;
             _positions = positions;
@@ -42,11 +59,12 @@ namespace UniVRM10
             _colors = colors;
             _weights = weights;
             _joints = joints;
+            _verticesOffset = verticesOffset;
         }
 
         public void Execute(int index)
         {
-            _vertices[index] = new MeshVertex(
+            _vertices[index + _verticesOffset] = new MeshVertex(
                 _positions[index],
                 _normals.IsCreated ? _normals[index] : Vector3.zero,
                 _texCoords.IsCreated ? _texCoords[index] : Vector2.zero,

--- a/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
+++ b/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs
@@ -42,12 +42,12 @@ namespace UniVRM10
 
         public InterleaveMeshVerticesJob(
             NativeSlice<MeshVertex> vertices,
-            NativeArray<Vector3> positions,
-            NativeArray<Vector3> normals = default,
-            NativeArray<Vector2> texCoords = default,
-            NativeArray<Color> colors = default,
-            NativeArray<Vector4> weights = default,
-            NativeArray<SkinJoints> joints = default)
+            NativeSlice<Vector3> positions,
+            NativeSlice<Vector3> normals = default,
+            NativeSlice<Vector2> texCoords = default,
+            NativeSlice<Color> colors = default,
+            NativeSlice<Vector4> weights = default,
+            NativeSlice<SkinJoints> joints = default)
         {
             _vertices = vertices;
             _positions = positions;

--- a/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs.meta
+++ b/Assets/VRM10/Runtime/IO/Model/InterleaveMeshVerticesJob.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 01d2fcab0a3941fa9cf2e4f1a641105b
+timeCreated: 1636688648

--- a/Assets/VRM10/Runtime/IO/Model/MeshImporter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshImporter.cs
@@ -23,7 +23,6 @@ namespace UniVRM10
             Profiler.BeginSample("MeshImporter.LoadSharedMesh");
             var mesh = new Mesh();
 
-            // これらのNativeArrayはJobによって開放される
             var positions = src.VertexBuffer.Positions.AsNativeArray<Vector3>(Allocator.TempJob);
             var normals = src.VertexBuffer.Normals?.AsNativeArray<Vector3>(Allocator.TempJob) ?? default;
             var texCoords = src.VertexBuffer.TexCoords?.AsNativeArray<Vector2>(Allocator.TempJob) ?? default;
@@ -37,6 +36,7 @@ namespace UniVRM10
             var jobHandle =
                 new InterleaveMeshVerticesJob(vertices, positions, normals, texCoords, colors, weights, joints)
                     .Schedule(vertices.Length, 1);
+            JobHandle.ScheduleBatchedJobs();
             
             // BindPoseを更新
             if (weights.IsCreated && joints.IsCreated)
@@ -73,13 +73,13 @@ namespace UniVRM10
             switch (src.IndexBuffer.ComponentType)
             {
                 case AccessorValueType.UNSIGNED_SHORT:
-                    var shortIndices = src.IndexBuffer.AsNativeArray<short>(Allocator.Temp);
+                    var shortIndices = src.IndexBuffer.AsNativeArray<ushort>(Allocator.Temp);
                     mesh.SetIndexBufferParams(shortIndices.Length, IndexFormat.UInt16);
                     mesh.SetIndexBufferData(shortIndices, 0, 0, shortIndices.Length);
                     shortIndices.Dispose();
                     break;
                 case AccessorValueType.UNSIGNED_INT:
-                    var intIndices = src.IndexBuffer.AsNativeArray<int>(Allocator.Temp);
+                    var intIndices = src.IndexBuffer.AsNativeArray<uint>(Allocator.Temp);
                     mesh.SetIndexBufferParams(intIndices.Length, IndexFormat.UInt32);
                     mesh.SetIndexBufferData(intIndices, 0, 0, intIndices.Length);
                     intIndices.Dispose();

--- a/Assets/VRM10/Runtime/IO/Model/MeshImporter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshImporter.cs
@@ -18,17 +18,18 @@ namespace UniVRM10
         /// <param name="mesh"></param>
         /// <param name="src"></param>
         /// <param name="skin"></param>
-        public static Mesh LoadSharedMesh(VrmLib.Mesh src, VrmLib.Skin skin = null)
+        public static Mesh LoadSharedMesh(VrmLib.Mesh src, Skin skin = null)
         {
             Profiler.BeginSample("MeshImporter.LoadSharedMesh");
             var mesh = new Mesh();
 
-            var positions = src.VertexBuffer.Positions.GetAsNativeArray<Vector3>(Allocator.TempJob);
-            var normals = src.VertexBuffer.Normals?.GetAsNativeArray<Vector3>(Allocator.TempJob) ?? default;
-            var texCoords = src.VertexBuffer.TexCoords?.GetAsNativeArray<Vector2>(Allocator.TempJob) ?? default;
-            var colors = src.VertexBuffer.Colors?.GetAsNativeArray<Color>(Allocator.TempJob) ?? default;
-            var weights = src.VertexBuffer.Weights?.GetAsNativeArray<Vector4>(Allocator.TempJob) ?? default;
-            var joints = src.VertexBuffer.Joints?.GetAsNativeArray<SkinJoints>(Allocator.TempJob) ?? default;
+            // これらのNativeArrayはJobによって開放される
+            var positions = src.VertexBuffer.Positions.AsNativeArray<Vector3>(Allocator.TempJob);
+            var normals = src.VertexBuffer.Normals?.AsNativeArray<Vector3>(Allocator.TempJob) ?? default;
+            var texCoords = src.VertexBuffer.TexCoords?.AsNativeArray<Vector2>(Allocator.TempJob) ?? default;
+            var colors = src.VertexBuffer.Colors?.AsNativeArray<Color>(Allocator.TempJob) ?? default;
+            var weights = src.VertexBuffer.Weights?.AsNativeArray<Vector4>(Allocator.TempJob) ?? default;
+            var joints = src.VertexBuffer.Joints?.AsNativeArray<SkinJoints>(Allocator.TempJob) ?? default;
 
             var vertices = new NativeArray<MeshVertex>(positions.Length, Allocator.TempJob);
             
@@ -60,7 +61,7 @@ namespace UniVRM10
             if (colors.IsCreated) colors.Dispose();
             if (weights.IsCreated) weights.Dispose();
             if (joints.IsCreated) joints.Dispose();
-            
+
             // 頂点を更新
             MeshVertex.SetVertexBufferParamsToMesh(mesh, vertices.Length);
             mesh.SetVertexBufferData(vertices, 0, 0, vertices.Length);
@@ -72,13 +73,13 @@ namespace UniVRM10
             switch (src.IndexBuffer.ComponentType)
             {
                 case AccessorValueType.UNSIGNED_SHORT:
-                    var shortIndices = src.IndexBuffer.GetAsNativeArray<short>(Allocator.Temp);
+                    var shortIndices = src.IndexBuffer.AsNativeArray<short>(Allocator.Temp);
                     mesh.SetIndexBufferParams(shortIndices.Length, IndexFormat.UInt16);
                     mesh.SetIndexBufferData(shortIndices, 0, 0, shortIndices.Length);
                     shortIndices.Dispose();
                     break;
                 case AccessorValueType.UNSIGNED_INT:
-                    var intIndices = src.IndexBuffer.GetAsNativeArray<int>(Allocator.Temp);
+                    var intIndices = src.IndexBuffer.AsNativeArray<int>(Allocator.Temp);
                     mesh.SetIndexBufferParams(intIndices.Length, IndexFormat.UInt32);
                     mesh.SetIndexBufferData(intIndices, 0, 0, intIndices.Length);
                     intIndices.Dispose();

--- a/Assets/VRM10/Runtime/IO/Model/MeshImporter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshImporter.cs
@@ -38,6 +38,7 @@ namespace UniVRM10
                 new InterleaveMeshVerticesJob(vertices, positions, normals, texCoords, colors, weights, joints)
                     .Schedule(vertices.Length, 1);
             
+            // BindPoseを更新
             if (weights.IsCreated && joints.IsCreated)
             {
                 if (weights.Length != positions.Length || joints.Length != positions.Length)

--- a/Assets/VRM10/Runtime/IO/Model/MeshImporterDivided.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshImporterDivided.cs
@@ -6,92 +6,58 @@ using Unity.Collections;
 using Unity.Jobs;
 using UnityEngine;
 using UnityEngine.Profiling;
+using UnityEngine.Rendering;
+using VrmLib;
+using Mesh = UnityEngine.Mesh;
 
 namespace UniVRM10
 {
     public static class MeshImporterDivided
     {
-        public static Mesh LoadDivided(VrmLib.MeshGroup src)
+        public static Mesh LoadDivided(MeshGroup meshGroup)
         {
             Profiler.BeginSample("MeshImporterDivided.LoadDivided");
-            
-            var dst = new UnityEngine.Mesh();
-            if (src.Meshes.Sum(x => x.IndexBuffer.Count) > ushort.MaxValue)
-            {
-                dst.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
-            }
 
-            // 頂点バッファを構築
-            var vertexCount = src.Meshes.Sum(x => x.VertexBuffer.Count);
-            var vertices = new NativeArray<MeshVertex>(vertexCount, Allocator.TempJob);
+            var vertexCount = meshGroup.Meshes.Sum(mesh => mesh.VertexBuffer.Count);
+            var indexCount = meshGroup.Meshes.Sum(mesh => mesh.IndexBuffer.Count);
 
-            var jobDisposables = new List<IDisposable>();
-            
-            // JobのSchedule
-            JobHandle jobHandle = default;
+            var resultMesh = new Mesh();
+
+            // 頂点バッファ・BindPoseを構築して更新
+            UpdateVerticesAndBindPose(meshGroup, vertexCount, resultMesh);
+
+            // インデックスバッファを構築して更新
+            UpdateIndices(meshGroup, vertexCount, indexCount, resultMesh);
+
+            // SubMeshを更新
+            resultMesh.subMeshCount = meshGroup.Meshes.Count;
             var indexOffset = 0;
-            foreach (var mesh in src.Meshes)
+            for (var i = 0; i < meshGroup.Meshes.Count; ++i)
             {
-                // これらのNativeArrayはJobによって開放される
-                var positions = mesh.VertexBuffer.Positions.AsNativeArray<Vector3>(Allocator.TempJob);
-                var normals = mesh.VertexBuffer.Normals.AsNativeArray<Vector3>(Allocator.TempJob);
-                var texCoords = mesh.VertexBuffer.TexCoords.AsNativeArray<Vector2>(Allocator.TempJob);
-                var weights = src.Skin != null ? mesh.VertexBuffer.Weights.AsNativeArray<Vector4>(Allocator.TempJob) : default;
-                var joints = src.Skin != null ? mesh.VertexBuffer.Joints.AsNativeArray<SkinJoints>(Allocator.TempJob) : default;
-                if (positions.IsCreated) jobDisposables.Add(positions);
-                if (normals.IsCreated) jobDisposables.Add(normals);
-                if (texCoords.IsCreated) jobDisposables.Add(texCoords);
-                if (weights.IsCreated) jobDisposables.Add(weights);
-                if (joints.IsCreated) jobDisposables.Add(joints);
-
-                jobHandle = new InterleaveMeshVerticesJob(vertices, positions, normals, texCoords, default, weights, joints, indexOffset)
-                    .Schedule(mesh.VertexBuffer.Count, 1, jobHandle);
-                indexOffset += mesh.VertexBuffer.Count;
+                var mesh = meshGroup.Meshes[i];
+                resultMesh.SetSubMesh(i, new SubMeshDescriptor(indexOffset, mesh.IndexBuffer.Count));
+                indexOffset += mesh.IndexBuffer.Count;
             }
 
-            // Jobと並行してBindposeの更新を行う
-            if (src.Skin != null)
-            {
-                dst.bindposes = src.Skin.InverseMatrices.GetSpan<Matrix4x4>().ToArray();
-            }
-            
-            // Jobを完了
-            jobHandle.Complete();
-            
-            foreach (var disposable in jobDisposables)
-            {
-                disposable.Dispose();
-            }
+            // 各種データを再構築
+            Profiler.BeginSample("Bounds");
+            resultMesh.RecalculateBounds();
+            Profiler.EndSample();
+            Profiler.BeginSample("Tangents");
+            resultMesh.RecalculateTangents();
+            Profiler.EndSample();
 
-            MeshVertex.SetVertexBufferParamsToMesh(dst, vertices.Length);
-            dst.SetVertexBufferData(vertices, 0, 0, vertices.Length);
-            
-            vertices.Dispose();
-
-            // triangles
-            dst.subMeshCount = src.Meshes.Count;
-            var offset = 0;
-            for (var meshIndex = 0; meshIndex < src.Meshes.Count; ++meshIndex)
-            {
-                var mesh = src.Meshes[meshIndex];
-                var indices = mesh.IndexBuffer.GetAsIntArray().Select(x => offset + x).ToArray();
-                dst.SetTriangles(indices, meshIndex);
-                offset += mesh.VertexBuffer.Count;
-            }
-
-            dst.RecalculateBounds();
-            dst.RecalculateTangents();
-
-            // blendshape
-            var blendShapeCount = src.Meshes[0].MorphTargets.Count;
+            // BlendShapeを更新
+            Profiler.BeginSample("BlendShape");
+            var blendShapeCount = meshGroup.Meshes[0].MorphTargets.Count;
             var blendShapePositions = new List<Vector3>();
             var blendShapeNormals = new List<Vector3>();
             for (var i = 0; i < blendShapeCount; ++i)
             {
                 blendShapePositions.Clear();
                 blendShapeNormals.Clear();
-                var name = src.Meshes[0].MorphTargets[i].Name;
-                foreach (var mesh in src.Meshes)
+                var name = meshGroup.Meshes[0].MorphTargets[i].Name;
+                foreach (var mesh in meshGroup.Meshes)
                 {
                     var morphTarget = mesh.MorphTargets[i];
                     blendShapePositions.AddRange(morphTarget.VertexBuffer.Positions.GetSpan<Vector3>());
@@ -102,15 +68,207 @@ namespace UniVRM10
                     else
                     {
                         // fill zero
-                        blendShapeNormals.AddRange(Enumerable.Range(0, morphTarget.VertexBuffer.Count).Select(x => Vector3.zero));
+                        blendShapeNormals.AddRange(Enumerable.Range(0, morphTarget.VertexBuffer.Count)
+                            .Select(x => Vector3.zero));
                     }
                 }
-                dst.AddBlendShapeFrame(name, 100.0f, blendShapePositions.ToArray(), blendShapeNormals.ToArray(), null);
+
+                resultMesh.AddBlendShapeFrame(name, 100.0f, blendShapePositions.ToArray(), blendShapeNormals.ToArray(),
+                    null);
+            }
+            Profiler.EndSample();
+
+            Profiler.EndSample();
+
+            return resultMesh;
+        }
+
+        /// <summary>
+        /// インデックスバッファを更新する
+        /// MEMO: 出力に対するushortを考慮することをやめればかなりシンプルに書ける
+        /// </summary>
+        private static void UpdateIndices(MeshGroup meshGroup, int vertexCount, int indexCount, Mesh resultMesh)
+        {
+            Profiler.BeginSample("MeshImporterDivided.UpdateIndices");
+
+            JobHandle jobHandle = default;
+
+            var disposables = new List<IDisposable>();
+
+            // 出力をushortにするべきかどうかを判別
+            if (vertexCount < ushort.MaxValue)
+            {
+                var indices = new NativeArray<ushort>(indexCount, Allocator.TempJob);
+                disposables.Add(indices);
+                var indexOffset = 0;
+                var vertexOffset = 0;
+                foreach (var mesh in meshGroup.Meshes)
+                {
+                    switch (mesh.IndexBuffer.ComponentType)
+                    {
+                        case AccessorValueType.SHORT:
+                        {
+                            // unsigned short -> unsigned short
+                            var source = mesh.IndexBuffer.AsNativeArray<ushort>(Allocator.TempJob);
+                            disposables.Add(source);
+                            jobHandle = new CopyIndicesJobs.Ushort2Ushort(
+                                    (ushort)vertexOffset,
+                                    new NativeSlice<ushort>(source),
+                                    new NativeSlice<ushort>(indices, indexOffset, mesh.IndexBuffer.Count))
+                                .Schedule(mesh.IndexBuffer.Count, 1, jobHandle);
+                            break;
+                        }
+                        case AccessorValueType.UNSIGNED_INT:
+                        {
+                            // unsigned int -> unsigned short
+                            var source = mesh.IndexBuffer.AsNativeArray<uint>(Allocator.TempJob);
+                            disposables.Add(source);
+                            jobHandle = new CopyIndicesJobs.Uint2Ushort(
+                                    (ushort)vertexOffset,
+                                    source,
+                                    new NativeSlice<ushort>(indices, indexOffset, mesh.IndexBuffer.Count))
+                                .Schedule(mesh.IndexBuffer.Count, 1, jobHandle);
+                            break;
+                        }
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
+                    vertexOffset += mesh.VertexBuffer.Count;
+                    indexOffset += mesh.IndexBuffer.Count;
+                }
+
+                jobHandle.Complete();
+
+                resultMesh.SetIndexBufferParams(indexCount, IndexFormat.UInt16);
+                resultMesh.SetIndexBufferData(indices, 0, 0, indexCount);
+            }
+            else
+            {
+                var indices = new NativeArray<uint>(indexCount, Allocator.TempJob);
+                disposables.Add(indices);
+                var indexOffset = 0;
+                var vertexOffset = 0;
+                foreach (var mesh in meshGroup.Meshes)
+                {
+                    switch (mesh.IndexBuffer.ComponentType)
+                    {
+                        case AccessorValueType.SHORT:
+                        {
+                            // unsigned short -> unsigned int
+                            var source = mesh.IndexBuffer.AsNativeArray<ushort>(Allocator.TempJob);
+                            disposables.Add(source);
+                            jobHandle = new CopyIndicesJobs.Ushort2Uint(
+                                    (uint)vertexOffset,
+                                    source,
+                                    new NativeSlice<uint>(indices, indexOffset, mesh.IndexBuffer.Count))
+                                .Schedule(mesh.IndexBuffer.Count, 1, jobHandle);
+                            break;
+                        }
+                        case AccessorValueType.UNSIGNED_INT:
+                        {
+                            // unsigned int -> unsigned int
+                            var source = mesh.IndexBuffer.AsNativeArray<uint>(Allocator.TempJob);
+                            disposables.Add(source);
+                            jobHandle = new CopyIndicesJobs.UInt2UInt(
+                                    (uint)vertexOffset,
+                                    source,
+                                    new NativeSlice<uint>(indices, indexOffset, mesh.IndexBuffer.Count))
+                                .Schedule(mesh.IndexBuffer.Count, 1, jobHandle);
+                            break;
+                        }
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
+                    vertexOffset += mesh.VertexBuffer.Count;
+                    indexOffset += mesh.IndexBuffer.Count;
+                }
+
+                jobHandle.Complete();
+
+                resultMesh.SetIndexBufferParams(indexCount, IndexFormat.UInt32);
+                resultMesh.SetIndexBufferData(indices, 0, 0, indexCount);
+            }
+
+            foreach (var disposable in disposables)
+            {
+                disposable.Dispose();
             }
 
             Profiler.EndSample();
-            
-            return dst;
+        }
+
+        /// <summary>
+        /// メッシュの頂点情報の更新を行う際、MainThreadが空くため、その間にBindPoseの更新も行う
+        /// </summary>
+        private static void UpdateVerticesAndBindPose(
+            MeshGroup meshGroup,
+            int vertexCount,
+            Mesh resultMesh)
+        {
+            Profiler.BeginSample("MeshImporterDivided.UpdateVerticesAndBindPose");
+
+            var disposables = new List<IDisposable>();
+
+            // JobのSchedule
+            var vertices = new NativeArray<MeshVertex>(vertexCount, Allocator.TempJob);
+            disposables.Add(vertices);
+
+            var indexOffset = 0;
+            JobHandle interleaveVertexJob = default;
+
+            foreach (var mesh in meshGroup.Meshes)
+            {
+                var positions = mesh.VertexBuffer.Positions.AsNativeArray<Vector3>(Allocator.TempJob);
+                var normals = mesh.VertexBuffer.Normals.AsNativeArray<Vector3>(Allocator.TempJob);
+                var texCoords = mesh.VertexBuffer.TexCoords.AsNativeArray<Vector2>(Allocator.TempJob);
+                var weights = meshGroup.Skin != null
+                    ? mesh.VertexBuffer.Weights.AsNativeArray<Vector4>(Allocator.TempJob)
+                    : default;
+                var joints = meshGroup.Skin != null
+                    ? mesh.VertexBuffer.Joints.AsNativeArray<SkinJoints>(Allocator.TempJob)
+                    : default;
+                if (positions.IsCreated) disposables.Add(positions);
+                if (normals.IsCreated) disposables.Add(normals);
+                if (texCoords.IsCreated) disposables.Add(texCoords);
+                if (weights.IsCreated) disposables.Add(weights);
+                if (joints.IsCreated) disposables.Add(joints);
+
+                interleaveVertexJob = new InterleaveMeshVerticesJob(
+                        new NativeSlice<MeshVertex>(vertices, indexOffset, mesh.VertexBuffer.Count),
+                        positions,
+                        normals,
+                        texCoords,
+                        default,
+                        weights,
+                        joints)
+                    .Schedule(mesh.VertexBuffer.Count, 1, interleaveVertexJob);
+                indexOffset += mesh.VertexBuffer.Count;
+            }
+
+            JobHandle.ScheduleBatchedJobs();
+
+            // 並行してBindposeの更新を行う
+            if (meshGroup.Skin != null)
+            {
+                resultMesh.bindposes = meshGroup.Skin.InverseMatrices.GetSpan<Matrix4x4>().ToArray();
+            }
+
+            // Jobを完了
+            interleaveVertexJob.Complete();
+
+            // VertexBufferを設定
+            MeshVertex.SetVertexBufferParamsToMesh(resultMesh, vertices.Length);
+            resultMesh.SetVertexBufferData(vertices, 0, 0, vertices.Length);
+
+            // 各種バッファを破棄
+            foreach (var disposable in disposables)
+            {
+                disposable.Dispose();
+            }
+
+            Profiler.EndSample();
         }
     }
 }

--- a/Assets/VRM10/Runtime/IO/Model/MeshVertex.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshVertex.cs
@@ -1,0 +1,70 @@
+using System.Runtime.InteropServices;
+using UnityEditor.UI;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace UniVRM10
+{
+    /// <summary>
+    /// インターリーブされたメッシュの頂点情報を表す構造体
+    /// そのままGPUにアップロードされる
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal readonly struct MeshVertex
+    {
+        private readonly Vector3 _position;
+        private readonly Vector3 _normal;
+        private readonly Color _color;
+        private readonly Vector2 _texCoord;
+        private readonly float _boneWeight0;
+        private readonly float _boneWeight1;
+        private readonly float _boneWeight2;
+        private readonly float _boneWeight3;
+        private readonly ushort _boneIndex0;
+        private readonly ushort _boneIndex1;
+        private readonly ushort _boneIndex2;
+        private readonly ushort _boneIndex3;
+
+        public MeshVertex(
+            Vector3 position,
+            Vector3 normal,
+            Vector2 texCoord,
+            Color color,
+            ushort boneIndex0,
+            ushort boneIndex1,
+            ushort boneIndex2,
+            ushort boneIndex3,
+            float boneWeight0,
+            float boneWeight1,
+            float boneWeight2,
+            float boneWeight3)
+        {
+            _position = position;
+            _normal = normal;
+            _texCoord = texCoord;
+            _color = color;
+            _boneIndex0 = boneIndex0;
+            _boneIndex1 = boneIndex1;
+            _boneIndex2 = boneIndex2;
+            _boneIndex3 = boneIndex3;
+            _boneWeight0 = boneWeight0;
+            _boneWeight1 = boneWeight1;
+            _boneWeight2 = boneWeight2;
+            _boneWeight3 = boneWeight3;
+        }
+
+        private static readonly VertexAttributeDescriptor[] vertexAttributeDescriptor = {
+            new VertexAttributeDescriptor(VertexAttribute.Position),
+            new VertexAttributeDescriptor(VertexAttribute.Normal),
+            new VertexAttributeDescriptor(VertexAttribute.Color, dimension: 4),
+            new VertexAttributeDescriptor(VertexAttribute.TexCoord0, dimension: 2),
+            new VertexAttributeDescriptor(VertexAttribute.BlendWeight, dimension: 4),
+            new VertexAttributeDescriptor(VertexAttribute.BlendIndices, VertexAttributeFormat.UInt16, 4),
+        };
+
+        public static void SetVertexBufferParamsToMesh(Mesh mesh, int length)
+        {
+            mesh.SetVertexBufferParams(length, vertexAttributeDescriptor);
+        }
+    }
+}

--- a/Assets/VRM10/Runtime/IO/Model/MeshVertex.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshVertex.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 using UnityEditor.UI;
 using UnityEngine;
@@ -9,7 +10,7 @@ namespace UniVRM10
     /// インターリーブされたメッシュの頂点情報を表す構造体
     /// そのままGPUにアップロードされる
     /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
+    [Serializable, StructLayout(LayoutKind.Sequential)]
     internal readonly struct MeshVertex
     {
         private readonly Vector3 _position;

--- a/Assets/VRM10/Runtime/IO/Model/MeshVertex.cs.meta
+++ b/Assets/VRM10/Runtime/IO/Model/MeshVertex.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 78c70746c10e46bc97de0a7afedb23c7
+timeCreated: 1636625951

--- a/Assets/VRM10/Runtime/VRM10.asmdef
+++ b/Assets/VRM10/Runtime/VRM10.asmdef
@@ -8,7 +8,8 @@
         "GUID:bce005214fa49654d93927908c15b1f2",
         "GUID:0aaf403bd13871a44b7127aef2695ff8",
         "GUID:b7aa47b240b57de44a4b2021c143c9bf",
-        "GUID:f2ca1407928ebdc4bbe7765cc278be44"
+        "GUID:f2ca1407928ebdc4bbe7765cc278be44",
+        "GUID:2665a8d13d1b3f18800f46e256720795"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -17,6 +18,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.burst",
+            "expression": "0.0.1",
+            "define": "ENABLE_VRM10_BURST"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Assets/VRM10/vrmlib/Runtime/BufferAccessor.cs
+++ b/Assets/VRM10/vrmlib/Runtime/BufferAccessor.cs
@@ -109,7 +109,7 @@ namespace VrmLib
         /// バッファをNativeArrayに変換して返す
         /// 開放の責務は使い手側にある点に注意
         /// </summary>
-        public unsafe NativeArray<T> GetAsNativeArray<T>(Allocator allocator, bool checkStride = true) where T : struct
+        public unsafe NativeArray<T> AsNativeArray<T>(Allocator allocator, bool checkStride = true) where T : struct
         {
             if (checkStride && Marshal.SizeOf(typeof(T)) != Stride)
             {

--- a/Assets/VRM10/vrmlib/Runtime/BufferAccessor.cs
+++ b/Assets/VRM10/vrmlib/Runtime/BufferAccessor.cs
@@ -119,6 +119,17 @@ namespace VrmLib
             }
         }
 
+        /// <summary>
+        /// バッファをNativeSliceへと書き込む
+        /// </summary>
+        public unsafe void CopyToNativeSlice<T>(NativeSlice<T> destArray) where T : unmanaged
+        {
+            fixed (byte* byteArray = Bytes.Array)
+            {
+                UnsafeUtility.MemCpy((T*)destArray.GetUnsafePtr(), byteArray + Bytes.Offset, Bytes.Count);
+            }
+        }
+
         public void Assign<T>(T[] values) where T : struct
         {
             if (Marshal.SizeOf(typeof(T)) != Stride)

--- a/Assets/VRM10/vrmlib/Runtime/BufferAccessor.cs
+++ b/Assets/VRM10/vrmlib/Runtime/BufferAccessor.cs
@@ -109,7 +109,7 @@ namespace VrmLib
         /// バッファをNativeArrayに変換して返す
         /// 開放の責務は使い手側にある点に注意
         /// </summary>
-        public unsafe NativeArray<T> GetNativeArray<T>(Allocator allocator, bool checkStride = true) where T : struct
+        public unsafe NativeArray<T> GetAsNativeArray<T>(Allocator allocator, bool checkStride = true) where T : struct
         {
             if (checkStride && Marshal.SizeOf(typeof(T)) != Stride)
             {

--- a/Assets/VRM10/vrmlib/Runtime/BufferAccessor.cs
+++ b/Assets/VRM10/vrmlib/Runtime/BufferAccessor.cs
@@ -109,13 +109,8 @@ namespace VrmLib
         /// バッファをNativeArrayに変換して返す
         /// 開放の責務は使い手側にある点に注意
         /// </summary>
-        public unsafe NativeArray<T> AsNativeArray<T>(Allocator allocator, bool checkStride = true) where T : struct
+        public unsafe NativeArray<T> AsNativeArray<T>(Allocator allocator) where T : struct
         {
-            if (checkStride && Marshal.SizeOf(typeof(T)) != Stride)
-            {
-                throw new Exception("different sizeof(T) with stride");
-            }
-
             fixed (byte* byteArray = Bytes.Array)
             {
                 var nativeArray = new NativeArray<T>(Bytes.Count / Marshal.SizeOf<T>(), allocator);

--- a/Assets/VRM10/vrmlib/Runtime/VrmLib.asmdef
+++ b/Assets/VRM10/vrmlib/Runtime/VrmLib.asmdef
@@ -5,7 +5,7 @@
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,


### PR DESCRIPTION
# 概要
VRM1.0についても https://github.com/vrm-c/UniVRM/pull/1373 と同様の対応を行うことで、情報をGPUのアップロードする際のコストを削減します

# 負荷検証
## MeshImporter.LoadSharedMesh

### Before
![image](https://user-images.githubusercontent.com/3889597/141415408-93cb70c6-25e2-43e5-8e66-7fb2b3f1ec67.png)
![image](https://user-images.githubusercontent.com/3889597/141968062-f4b4c954-fa72-4e7f-9ffc-0243a8c1f128.png)


### After
![image](https://user-images.githubusercontent.com/3889597/141415454-3705df54-0c58-4dbe-a96a-460c5bcec81c.png)
![image](https://user-images.githubusercontent.com/3889597/141968115-4c676460-b9b7-4b8a-afc0-517d52c20711.png)

## MeshImporterDivided.LoadDivided

### Before
![image](https://user-images.githubusercontent.com/3889597/141968173-c966644f-b2e4-4506-a380-56e6f01f1dc7.png)
![image](https://user-images.githubusercontent.com/3889597/141968229-e4526960-fc17-486c-9699-06c2ecf2b5eb.png)

### After
![image](https://user-images.githubusercontent.com/3889597/141968263-fa8bb21d-d44a-4ec0-96ac-0749c88ace70.png)
![image](https://user-images.githubusercontent.com/3889597/141968308-dcef2e28-5b76-4c16-a1c8-38c6f1437699.png)

