### PR TITLE
未知の material をエクスポートするとエラーになるのを回避

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/MaterialValidator.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/MaterialValidator.cs
@@ -43,12 +43,26 @@ namespace UniGLTF
             // main color
             yield return (MaterialExporter.COLOR_TEXTURE_PROP, m.GetTexture(MaterialExporter.COLOR_TEXTURE_PROP));
 
-            if (GetGltfMaterialTypeFromUnityShaderName(m.shader.name) == "Standard")
+            if (GetGltfMaterialTypeFromUnityShaderName(m.shader.name) == "unlit")
             {
-                // PBR
+                yield break;
+            }
+
+            // PBR
+            if (m.HasProperty(MaterialExporter.METALLIC_TEX_PROP))
+            {
                 yield return (MaterialExporter.METALLIC_TEX_PROP, m.GetTexture(MaterialExporter.METALLIC_TEX_PROP));
+            }
+            if (m.HasProperty(MaterialExporter.NORMAL_TEX_PROP))
+            {
                 yield return (MaterialExporter.NORMAL_TEX_PROP, m.GetTexture(MaterialExporter.NORMAL_TEX_PROP));
+            }
+            if (m.HasProperty(MaterialExporter.EMISSION_TEX_PROP))
+            {
                 yield return (MaterialExporter.EMISSION_TEX_PROP, m.GetTexture(MaterialExporter.EMISSION_TEX_PROP));
+            }
+            if (m.HasProperty(MaterialExporter.OCCLUSION_TEX_PROP))
+            {
                 yield return (MaterialExporter.OCCLUSION_TEX_PROP, m.GetTexture(MaterialExporter.OCCLUSION_TEX_PROP));
             }
         }

--- a/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/MaterialValidator.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/MaterialValidator.cs
@@ -43,16 +43,14 @@ namespace UniGLTF
             // main color
             yield return (MaterialExporter.COLOR_TEXTURE_PROP, m.GetTexture(MaterialExporter.COLOR_TEXTURE_PROP));
 
-            if (GetGltfMaterialTypeFromUnityShaderName(m.shader.name) == "unlit")
+            if (GetGltfMaterialTypeFromUnityShaderName(m.shader.name) == "Standard")
             {
-                yield break;
+                // PBR
+                yield return (MaterialExporter.METALLIC_TEX_PROP, m.GetTexture(MaterialExporter.METALLIC_TEX_PROP));
+                yield return (MaterialExporter.NORMAL_TEX_PROP, m.GetTexture(MaterialExporter.NORMAL_TEX_PROP));
+                yield return (MaterialExporter.EMISSION_TEX_PROP, m.GetTexture(MaterialExporter.EMISSION_TEX_PROP));
+                yield return (MaterialExporter.OCCLUSION_TEX_PROP, m.GetTexture(MaterialExporter.OCCLUSION_TEX_PROP));
             }
-
-            // PBR
-            yield return (MaterialExporter.METALLIC_TEX_PROP, m.GetTexture(MaterialExporter.METALLIC_TEX_PROP));
-            yield return (MaterialExporter.NORMAL_TEX_PROP, m.GetTexture(MaterialExporter.NORMAL_TEX_PROP));
-            yield return (MaterialExporter.EMISSION_TEX_PROP, m.GetTexture(MaterialExporter.EMISSION_TEX_PROP));
-            yield return (MaterialExporter.OCCLUSION_TEX_PROP, m.GetTexture(MaterialExporter.OCCLUSION_TEX_PROP));
         }
     }
 }


### PR DESCRIPTION
Standard でも Unlit でもない Material を含むモデルを GLTF エクスポートしようとすると・・・

![error](https://user-images.githubusercontent.com/68057/143390214-b72e7e7f-8557-495c-a8cd-a47aa5850111.jpg)
