### PR TITLE
[1.0] ScriptableObject VRM10Expression の MorphTargetBinding.Weight の値域を 0-1 に修正

### DIFF
--- a/Assets/VRM10/Editor/Components/Expression/ExpressionEditorHelper.cs
+++ b/Assets/VRM10/Editor/Components/Expression/ExpressionEditorHelper.cs
@@ -57,7 +57,7 @@ namespace UniVRM10
         public static bool FloatSlider(Rect rect, SerializedProperty prop, float maxValue)
         {
             var oldValue = prop.floatValue;
-            var newValue = EditorGUI.Slider(rect, prop.floatValue, 0, 100f);
+            var newValue = EditorGUI.Slider(rect, prop.floatValue, 0, maxValue);
             if (newValue != oldValue)
             {
                 prop.floatValue = newValue;

--- a/Assets/VRM10/Editor/Components/Expression/ReorderableMorphTargetBindingList.cs
+++ b/Assets/VRM10/Editor/Components/Expression/ReorderableMorphTargetBindingList.cs
@@ -57,7 +57,7 @@ namespace UniVRM10
 
                 y += height;
                 rect = new Rect(position.x, y, position.width, height);
-                if (ExpressionEditorHelper.FloatSlider(rect, property.FindPropertyRelative(nameof(MorphTargetBinding.Weight)), 100))
+                if (ExpressionEditorHelper.FloatSlider(rect, property.FindPropertyRelative(nameof(MorphTargetBinding.Weight)), 1.0f))
                 {
                     changed = true;
                 }

--- a/Assets/VRM10/Editor/Components/Expression/ReorderableMorphTargetBindingList.cs
+++ b/Assets/VRM10/Editor/Components/Expression/ReorderableMorphTargetBindingList.cs
@@ -57,7 +57,7 @@ namespace UniVRM10
 
                 y += height;
                 rect = new Rect(position.x, y, position.width, height);
-                if (ExpressionEditorHelper.FloatSlider(rect, property.FindPropertyRelative(nameof(MorphTargetBinding.Weight)), 1.0f))
+                if (ExpressionEditorHelper.FloatSlider(rect, property.FindPropertyRelative(nameof(MorphTargetBinding.Weight)), MorphTargetBinding.MAX_WEIGHT))
                 {
                     changed = true;
                 }

--- a/Assets/VRM10/Editor/Components/Expression/SerializedExpressionEditor.cs
+++ b/Assets/VRM10/Editor/Components/Expression/SerializedExpressionEditor.cs
@@ -192,11 +192,11 @@ namespace UniVRM10
                         //EditorGUI.indentLevel += 1;
                         for (int i = 0; i < mesh.blendShapeCount; ++i)
                         {
-                            var src = renderer.GetBlendShapeWeight(i);
-                            var dst = EditorGUILayout.Slider(mesh.GetBlendShapeName(i), src, 0, 100.0f);
+                            var src = renderer.GetBlendShapeWeight(i) * 0.01f;
+                            var dst = EditorGUILayout.Slider(mesh.GetBlendShapeName(i), src, 0, 1.0f);
                             if (dst != src)
                             {
-                                renderer.SetBlendShapeWeight(i, dst);
+                                renderer.SetBlendShapeWeight(i, dst * 100.0f);
                                 changed = true;
                             }
                         }
@@ -236,7 +236,7 @@ namespace UniVRM10
                             maxWeightName = name;
                             maxWeight = weight;
                         }
-                        list.Add(new MorphTargetBinding(relativePath, i, weight));
+                        list.Add(new MorphTargetBinding(relativePath, i, weight * 0.01f));
                     }
                 }
                 return list;

--- a/Assets/VRM10/Editor/Components/Expression/SerializedExpressionEditor.cs
+++ b/Assets/VRM10/Editor/Components/Expression/SerializedExpressionEditor.cs
@@ -192,11 +192,11 @@ namespace UniVRM10
                         //EditorGUI.indentLevel += 1;
                         for (int i = 0; i < mesh.blendShapeCount; ++i)
                         {
-                            var src = renderer.GetBlendShapeWeight(i) * 0.01f;
-                            var dst = EditorGUILayout.Slider(mesh.GetBlendShapeName(i), src, 0, 1.0f);
+                            var src = renderer.GetBlendShapeWeight(i) * MorphTargetBinding.UNITY_TO_VRM;
+                            var dst = EditorGUILayout.Slider(mesh.GetBlendShapeName(i), src, 0, MorphTargetBinding.MAX_WEIGHT);
                             if (dst != src)
                             {
-                                renderer.SetBlendShapeWeight(i, dst * 100.0f);
+                                renderer.SetBlendShapeWeight(i, dst * MorphTargetBinding.VRM_TO_UNITY);
                                 changed = true;
                             }
                         }
@@ -210,7 +210,7 @@ namespace UniVRM10
 
         MorphTargetBinding[] GetBindings(out string _maxWeightName)
         {
-            var maxWeight = 0.0f;
+            var maxUnityWeight = 0.0f;
             var maxWeightName = "";
             // weightのついたblendShapeを集める
             var values = m_items
@@ -225,18 +225,18 @@ namespace UniVRM10
                 {
                     for (int i = 0; i < mesh.blendShapeCount; ++i)
                     {
-                        var weight = x.SkinnedMeshRenderer.GetBlendShapeWeight(i);
-                        if (weight == 0)
+                        var unityWeight = x.SkinnedMeshRenderer.GetBlendShapeWeight(i);
+                        if (unityWeight == 0)
                         {
                             continue;
                         }
                         var name = mesh.GetBlendShapeName(i);
-                        if (weight > maxWeight)
+                        if (unityWeight > maxUnityWeight)
                         {
                             maxWeightName = name;
-                            maxWeight = weight;
+                            maxUnityWeight = unityWeight;
                         }
-                        list.Add(new MorphTargetBinding(relativePath, i, weight * 0.01f));
+                        list.Add(new MorphTargetBinding(relativePath, i, unityWeight * MorphTargetBinding.UNITY_TO_VRM));
                     }
                 }
                 return list;

--- a/Assets/VRM10/Editor/EditorTool/VRM10ExpressionEditorTool.cs
+++ b/Assets/VRM10/Editor/EditorTool/VRM10ExpressionEditorTool.cs
@@ -47,7 +47,11 @@ namespace UniVRM10
 
         public override void OnToolGUI(EditorWindow window)
         {
-            var root = Selection.activeTransform?.GetComponent<Vrm10Instance>();
+            if (Selection.activeTransform == null)
+            {
+                return;
+            }
+            var root = Selection.activeTransform.GetComponent<Vrm10Instance>();
             if (root == null)
             {
                 return;

--- a/Assets/VRM10/Editor/EditorTool/VRM10ExpressionEditorTool.cs
+++ b/Assets/VRM10/Editor/EditorTool/VRM10ExpressionEditorTool.cs
@@ -47,7 +47,7 @@ namespace UniVRM10
 
         public override void OnToolGUI(EditorWindow window)
         {
-            var root = Selection.activeTransform.GetComponent<Vrm10Instance>();
+            var root = Selection.activeTransform?.GetComponent<Vrm10Instance>();
             if (root == null)
             {
                 return;

--- a/Assets/VRM10/Runtime/Components/Expression/MorphTargetBinding.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/MorphTargetBinding.cs
@@ -7,6 +7,18 @@ namespace UniVRM10
     public struct MorphTargetBinding : IEquatable<MorphTargetBinding>
     {
         /// <summary>
+        /// Unity の BlendShape の値域は 0-100
+        /// </summary>
+        public const float VRM_TO_UNITY = 100.0f;
+
+        /// <summary>
+        /// VRM-1.0 の MorphTargetBinding.Weight の値域は 0-1.0
+        /// </summary>
+        public const float UNITY_TO_VRM = 0.01f;
+
+        public const float MAX_WEIGHT = 1.0f;
+
+        /// <summary>
         /// SkinnedMeshRenderer.BlendShape[Index].Weight を 指し示す。
         /// 
         /// [トレードオフ]

--- a/Assets/VRM10/Runtime/Components/Expression/MorphTargetBinding.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/MorphTargetBinding.cs
@@ -45,9 +45,9 @@ namespace UniVRM10
         {
             RelativePath = path;
             Index = index;
-            if (weight > 1.0f)
+            if (weight > MAX_WEIGHT)
             {
-                Debug.LogWarning($"weight exceed 1.0");
+                Debug.LogWarning($"MorphTargetBinding: {weight} > {MAX_WEIGHT}");
             }
             Weight = weight;
         }

--- a/Assets/VRM10/Runtime/Components/Expression/MorphTargetBinding.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/MorphTargetBinding.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 namespace UniVRM10
 {
@@ -27,11 +28,15 @@ namespace UniVRM10
         /// </summary>
         /// <param name="path"></param>
         /// <param name="index"></param>
-        /// <param name="weight">0 to 100</param>
+        /// <param name="weight">0 to 1.0</param>
         public MorphTargetBinding(string path, int index, float weight)
         {
             RelativePath = path;
             Index = index;
+            if (weight > 1.0f)
+            {
+                Debug.LogWarning($"weight exceed 1.0");
+            }
             Weight = weight;
         }
 

--- a/Assets/VRM10/Runtime/Components/Expression/MorphTargetBindingMerger.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/MorphTargetBindingMerger.cs
@@ -59,8 +59,13 @@ namespace UniVRM10
                             {
                                 m_morphTargetSetterMap.Add(binding, x =>
                                 {
+                                    if (target == null)
+                                    {
+                                        // recompile in editor ?
+                                        return;
+                                    }
                                     // VRM-1.0 weight is 0-1
-                                    target.SetBlendShapeWeight(binding.Index, x * 100.0f);
+                                    target.SetBlendShapeWeight(binding.Index, x * MorphTargetBinding.VRM_TO_UNITY);
                                 });
                             }
                             else

--- a/Assets/VRM10/Runtime/Components/Expression/MorphTargetBindingMerger.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/MorphTargetBindingMerger.cs
@@ -59,7 +59,8 @@ namespace UniVRM10
                             {
                                 m_morphTargetSetterMap.Add(binding, x =>
                                 {
-                                    target.SetBlendShapeWeight(binding.Index, x);
+                                    // VRM-1.0 weight is 0-1
+                                    target.SetBlendShapeWeight(binding.Index, x * 100.0f);
                                 });
                             }
                             else

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMeshItem.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMeshItem.cs
@@ -79,7 +79,7 @@ namespace UniVRM10
                     {
                         if (x.Index >= 0 && x.Index < SkinnedMeshRenderer.sharedMesh.blendShapeCount)
                         {
-                            SkinnedMeshRenderer.SetBlendShapeWeight(x.Index, x.Weight * weight * 100.0f);
+                            SkinnedMeshRenderer.SetBlendShapeWeight(x.Index, x.Weight * weight * MorphTargetBinding.VRM_TO_UNITY);
                         }
                         else
                         {

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMeshItem.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMeshItem.cs
@@ -79,7 +79,7 @@ namespace UniVRM10
                     {
                         if (x.Index >= 0 && x.Index < SkinnedMeshRenderer.sharedMesh.blendShapeCount)
                         {
-                            SkinnedMeshRenderer.SetBlendShapeWeight(x.Index, x.Weight * weight);
+                            SkinnedMeshRenderer.SetBlendShapeWeight(x.Index, x.Weight * weight * 100.0f);
                         }
                         else
                         {

--- a/Assets/VRM10/Runtime/IO/ExpressionExtensions.cs
+++ b/Assets/VRM10/Runtime/IO/ExpressionExtensions.cs
@@ -13,8 +13,7 @@ namespace UniVRM10
             var node = loader.Nodes[libNode].transform;
             var mesh = loader.Meshes[libNode.MeshGroup];
             var relativePath = node.RelativePathFrom(root.transform);
-            // VRM-1.0 では値域は [0-1.0f]
-            return new UniVRM10.MorphTargetBinding(relativePath, bind.Index.Value, bind.Weight.Value * 100.0f);
+            return new UniVRM10.MorphTargetBinding(relativePath, bind.Index.Value, bind.Weight.Value);
         }
 
         public static UniVRM10.MaterialColorBinding? Build10(this MaterialColorBind bind, IReadOnlyList<VRMShaders.MaterialFactory.MaterialLoadInfo> materials)

--- a/Assets/VRM10/Tests/SerializationTests.cs
+++ b/Assets/VRM10/Tests/SerializationTests.cs
@@ -210,9 +210,14 @@ namespace UniVRM10
             {
                 var data = new UniGLTF.Extensions.VRMC_vrm.Expression();
                 data.OverrideBlink = UniGLTF.Extensions.VRMC_vrm.ExpressionOverrideType.block;
+                data.MorphTargetBinds = new List<UniGLTF.Extensions.VRMC_vrm.MorphTargetBind>{
+                    new UniGLTF.Extensions.VRMC_vrm.MorphTargetBind{
+                        Weight=1.0f
+                    }
+                };
 
                 var json = Serialize(data, UniGLTF.Extensions.VRMC_vrm.GltfSerializer.__expressions_Serialize_Custom_ITEM);
-                Assert.AreEqual($"{{{q}overrideBlink{q}:{q}block{q},{q}overrideLookAt{q}:{q}none{q},{q}overrideMouth{q}:{q}none{q}}}", json);
+                Assert.AreEqual($"{{{q}morphTargetBinds{q}:[{{{q}weight{q}:1}}],{q}overrideBlink{q}:{q}block{q},{q}overrideLookAt{q}:{q}none{q},{q}overrideMouth{q}:{q}none{q}}}", json);
             }
 
             {


### PR DESCRIPTION
#1380

シリアライズの値域が 0-1 なのに対して
SciptableObject の値域が 0-100 だった。
import/export 時に値域の操作が必用だった
SciptableObject の値域を 0-1 に修正。

* GetBlendShapeWeight 時に 0.01 倍する
* SetBlendShapeWeight 時に 100 倍する
* それ以外で操作しない

ように修正。