### PR TITLE
Colorsのnull考慮漏れを修正

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
@@ -142,7 +142,7 @@ namespace UniGLTF
                     var joints = jointsGetter?.Invoke(i) ?? (0, 0, 0, 0);
                     var weights = weightsGetter != null ? NormalizeBoneWeight(weightsGetter(i)) : (0, 0, 0, 0);
 
-                    var color = colors[i];
+                    var color = colors != null ? colors[i] : Color.black;
                     _vertices.Add(
                         new MeshVertex(
                             position,


### PR DESCRIPTION
https://github.com/vrm-c/UniVRM/issues/1393

MeshContext、colorsがnullだった場合の考慮漏れを修正しました