### PR TITLE
UniGLTF において、メッシュの Bounds が計算されていなかった問題を修正

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
@@ -30,9 +30,6 @@ namespace UniGLTF
         {
             mesh.SetVertexBufferParams(_vertices.Count, MeshVertex.GetVertexAttributeDescriptor());
             mesh.SetVertexBufferData(_vertices, 0, 0, _vertices.Count);
-
-            // NOTE: mesh.vertices では自動的に行われていたが、SetVertexBuffer では行われないため、明示的に呼び出す.
-            mesh.RecalculateBounds();
         }
         /// <summary>
         /// インデックス情報をMeshに対して送る

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
@@ -30,6 +30,9 @@ namespace UniGLTF
         {
             mesh.SetVertexBufferParams(_vertices.Count, MeshVertex.GetVertexAttributeDescriptor());
             mesh.SetVertexBufferData(_vertices, 0, 0, _vertices.Count);
+
+            // NOTE: mesh.vertices では自動的に行われていたが、SetVertexBuffer では行われないため、明示的に呼び出す.
+            mesh.RecalculateBounds();
         }
         /// <summary>
         /// インデックス情報をMeshに対して送る
@@ -45,7 +48,7 @@ namespace UniGLTF
                 mesh.SetSubMesh(i, _subMeshes[i]);
             }
         }
-        
+
         private BlendShape GetOrCreateBlendShape(int i)
         {
             if (i < _blendShapes.Count && _blendShapes[i] != null)
@@ -93,7 +96,7 @@ namespace UniGLTF
         /// <summary>
         /// 各 primitive の attribute の要素が同じでない。=> uv が有るものと無いものが混在するなど
         /// glTF 的にはありうる。
-        /// 
+        ///
         /// primitive を独立した(Independent) Mesh として扱いこれを連結する。
         /// </summary>
         /// <param name="ctx"></param>
@@ -232,7 +235,7 @@ namespace UniGLTF
         }
 
         /// <summary>
-        /// 
+        ///
         /// 各primitiveが同じ attribute を共有している場合専用のローダー。
         ///
         /// </summary>

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshImporter.cs
@@ -47,7 +47,7 @@ namespace UniGLTF
             meshContext.RenameBlendShape(gltfMesh);
 
             meshContext.DropUnusedVertices();
-            
+
             Profiler.EndSample();
             return meshContext;
         }
@@ -64,6 +64,9 @@ namespace UniGLTF
 
             meshContext.UploadMeshVertices(mesh);
             meshContext.UploadMeshIndices(mesh);
+
+            // NOTE: mesh.vertices では自動的に行われていたが、SetVertexBuffer では行われないため、明示的に呼び出す.
+            mesh.RecalculateBounds();
 
             if (!meshContext.HasNormal)
             {

--- a/Assets/VRM10/Runtime/IO/Model/MeshImporter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshImporter.cs
@@ -31,13 +31,13 @@ namespace UniVRM10
             var joints = src.VertexBuffer.Joints?.AsNativeArray<SkinJoints>(Allocator.TempJob) ?? default;
 
             var vertices = new NativeArray<MeshVertex>(positions.Length, Allocator.TempJob);
-            
+
             // JobとBindPoseの更新を並行して行う
             var jobHandle =
                 new InterleaveMeshVerticesJob(vertices, positions, normals, texCoords, colors, weights, joints)
                     .Schedule(vertices.Length, 1);
             JobHandle.ScheduleBatchedJobs();
-            
+
             // BindPoseを更新
             if (weights.IsCreated && joints.IsCreated)
             {
@@ -53,7 +53,7 @@ namespace UniVRM10
 
             // Jobを完了
             jobHandle.Complete();
-            
+
             // 入力のNativeArrayを開放
             positions.Dispose();
             if (normals.IsCreated) normals.Dispose();
@@ -65,6 +65,7 @@ namespace UniVRM10
             // 頂点を更新
             MeshVertex.SetVertexBufferParamsToMesh(mesh, vertices.Length);
             mesh.SetVertexBufferData(vertices, 0, 0, vertices.Length);
+            mesh.RecalculateBounds();
 
             // 出力のNativeArrayを開放
             vertices.Dispose();
@@ -110,7 +111,7 @@ namespace UniVRM10
             // 各種パラメーターを再計算
             mesh.RecalculateBounds();
             mesh.RecalculateTangents();
-            
+
             Profiler.EndSample();
 
             return mesh;

--- a/Assets/VRM10/Runtime/IO/Model/MeshImporter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshImporter.cs
@@ -65,7 +65,6 @@ namespace UniVRM10
             // 頂点を更新
             MeshVertex.SetVertexBufferParamsToMesh(mesh, vertices.Length);
             mesh.SetVertexBufferData(vertices, 0, 0, vertices.Length);
-            mesh.RecalculateBounds();
 
             // 出力のNativeArrayを開放
             vertices.Dispose();

--- a/Assets/VRM10/Runtime/IO/Model/MeshImporterDivided.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshImporterDivided.cs
@@ -276,7 +276,6 @@ namespace UniVRM10
             // VertexBufferを設定
             MeshVertex.SetVertexBufferParamsToMesh(resultMesh, vertices.Length);
             resultMesh.SetVertexBufferData(vertices, 0, 0, vertices.Length);
-            resultMesh.RecalculateBounds();
 
             // 各種バッファを破棄
             foreach (var disposable in disposables)

--- a/Assets/VRM10/Runtime/IO/Model/MeshImporterDivided.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshImporterDivided.cs
@@ -276,6 +276,7 @@ namespace UniVRM10
             // VertexBufferを設定
             MeshVertex.SetVertexBufferParamsToMesh(resultMesh, vertices.Length);
             resultMesh.SetVertexBufferData(vertices, 0, 0, vertices.Length);
+            resultMesh.RecalculateBounds();
 
             // 各種バッファを破棄
             foreach (var disposable in disposables)


### PR DESCRIPTION
v0.89.1 および v0.90.0 で UniGLTF の MeshIO を使用するもので発生。
New Mesh API の対応によって発生していたと考えられる。

従来の Mesh API は `mesh.vertices` のセット時に、自動的に Bounds が計算されていた。
https://docs.unity3d.com/ja/2018.4/ScriptReference/Mesh-vertices.html