### PR TITLE
Fix migration error in MToon & Modify Screen Coords Outline drawing algorithm.

### DIFF
--- a/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
+++ b/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
@@ -298,7 +298,9 @@ namespace UniVRM10
                         break;
                     case OutlineWidthMode.ScreenCoordinates:
                         dst.OutlineWidthMode = UniGLTF.Extensions.VRMC_materials_mtoon.OutlineWidthMode.screenCoordinates;
-                        dst.OutlineWidthFactor = mtoon.Definition.Outline.OutlineWidthValue * oneHundredth;
+                        // NOTE: 従来は、縦幅の半分を 100% としたときの % の値だった。
+                        //       1.0 では縦幅を 1 としたときの値とするので、 1/200 する。
+                        dst.OutlineWidthFactor = mtoon.Definition.Outline.OutlineWidthValue * oneHundredth * 0.5f;
                         break;
                     default:
                         throw new ArgumentOutOfRangeException($"OutlineWidthMode: {(int)mtoon.Definition.Outline.OutlineWidthMode}");

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_define.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_define.hlsl
@@ -138,4 +138,14 @@ inline bool MToon_IsOutlineModeDisabled()
 #endif
 }
 
+// Compile-time constant
+inline bool MToon_UseStrictMode()
+{
+ #if defined(_MTOON_USE_STRICT_MODE)
+    return true;
+#else
+    return false;
+#endif
+}
+
 #endif

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
@@ -24,6 +24,26 @@ inline half MToon_GetOutlineVertex_OutlineWidth(const float2 uv)
     }
 }
 
+inline float MToon_GetOutlineVertex_ScreenCoordinatesWidthMultiplier(const float4 positionCS)
+{
+    // NOTE: VRM 1.0 の仕様にはない実装なので、ユーザが任意で機能を外せるようにする.
+    if (MToon_UseStrictMode())
+    {
+        return 1.0f;
+    }
+    else
+    {
+        const float maxViewFrustumPlaneHeight = 2.0f;
+        const float invTangentHalfVerticalFov = unity_CameraProjection[1][1];
+        // NOTE: viewFrustumPlaneHeight = tan(halfFov) * viewDirDistance * 2.0
+        //           -> viewDirDistance = viewFrustumPlaneHeight / (tan(halfFov) * 2.0)
+        const float widthScaledMaxDistance = maxViewFrustumPlaneHeight * invTangentHalfVerticalFov * 0.5f;
+        // NOTE: VR などの高視野角カメラでは、純粋な実装では太くなりすぎる.
+        //       よってある距離での視錐台平面が高さ 2m 以上になったらスケールをやめる.
+        return min(positionCS.w, widthScaledMaxDistance);
+    }
+}
+
 inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const half3 normalOS, const float2 uv)
 {
     if (MToon_IsOutlineModeWorldCoordinates())
@@ -45,30 +65,20 @@ inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const 
         const float4 nearUpperRight = mul(unity_CameraInvProjection, float4(1, 1, UNITY_NEAR_CLIP_VALUE, _ProjectionParams.y));
         const half aspect = abs(nearUpperRight.y / nearUpperRight.x);
 
-        float4 positionCS = UnityObjectToClipPos(positionOS);
+        const float4 positionCS = UnityObjectToClipPos(positionOS);
         const half3 normalVS = MToon_GetObjectToViewNormal(normalOS);
         const half3 normalCS = TransformViewToProjection(normalVS.xyz);
 
-        const float maxViewFrustumPlaneHeight = 2.0f;
-        const float invTangentHalfVerticalFov = unity_CameraProjection[1][1];
-        // NOTE: viewFrustumPlaneHeight = tan(halfFov) * viewDirDistance * 2.0
-        //           -> viewDirDistance = viewFrustumPlaneHeight / (tan(halfFov) * 2.0)
-        const float widthScaledMaxMeter = maxViewFrustumPlaneHeight * invTangentHalfVerticalFov * 0.5f;
-        // NOTE: VR などの高視野角カメラでは、純粋な実装では太くなりすぎる.
-        //       よってある距離での視錐台平面が高さ 2m 以上になったらスケールをやめる.
-        const half outlineWidthMultiplier = outlineWidth * min(positionCS.w, widthScaledMaxMeter);
-
         half2 normalProjectedCS = normalize(normalCS.xy);
         const float clipSpaceHeight = 2.0f;
-        normalProjectedCS *= clipSpaceHeight * outlineWidthMultiplier;
+        normalProjectedCS *= clipSpaceHeight * outlineWidth * MToon_GetOutlineVertex_ScreenCoordinatesWidthMultiplier(positionCS);
         normalProjectedCS.x *= aspect;
         // NOTE: カメラ方向軸を向く法線を持つ頂点が XY 方向にだけずれると困るので、それを抑制する.
         normalProjectedCS.xy *= saturate(1 - normalVS.z * normalVS.z);
-        positionCS.xy += normalProjectedCS.xy;
 
         VertexPositionInfo output;
         output.positionWS = float4(positionWS, 1);
-        output.positionCS = positionCS;
+        output.positionCS = float4(positionCS.xy + normalProjectedCS.xy, positionCS.zw);
         return output;
     }
     else

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
@@ -26,8 +26,6 @@ inline half MToon_GetOutlineVertex_OutlineWidth(const float2 uv)
 
 inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const half3 normalOS, const float2 uv)
 {
-    const float minWidthInPixel = 1.5f;
-
     if (MToon_IsOutlineModeWorldCoordinates())
     {
         const float3 positionWS = mul(unity_ObjectToWorld, float4(positionOS, 1)).xyz;
@@ -51,9 +49,7 @@ inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const 
         const half3 normalVS = MToon_GetObjectToViewNormal(normalOS);
         const half3 normalCS = TransformViewToProjection(normalVS.xyz);
 
-        const float onePixelMultiplier = positionCS.w * 2.0f / _ScreenParams.y;
         const float widthScaledMaxMeter = 1.0f;
-
         half2 normalProjectedCS = normalize(normalCS.xy);
         // NOTE: VR などの高視野角カメラでは、純粋な実装では太くなりすぎる.
         //       よって 1m 以上離れたら、それ以上太くならないようにする.

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
@@ -34,15 +34,8 @@ inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const 
         const half3 normalWS = UnityObjectToWorldNormal(normalOS);
         const half outlineWidth = MToon_GetOutlineVertex_OutlineWidth(uv);
 
-        const float viewDirWS = length(MToon_GetWorldSpaceViewDir(positionWS));
-        const float tangentHalfVerticalFov = 1.0f / unity_CameraProjection[1][1];
-        const float onePixelWidth = tangentHalfVerticalFov * viewDirWS * 2.0f / _ScreenParams.y;
-        // NOTE: 線幅が World Space で一定なので、カメラから離れるとすぐに 1 pixel 未満になりエリアシングしてしまう.
-        //       よって 1.5 pixel 未満から徐々に輪郭線を細くし、1 pixel 未満では幅ゼロにする.
-        const float antiAliasingOutlineWidth = mtoon_linearstep(onePixelWidth, onePixelWidth * minWidthInPixel, outlineWidth) * outlineWidth;
-
         VertexPositionInfo output;
-        output.positionWS = float4(positionWS + normalWS * antiAliasingOutlineWidth, 1);
+        output.positionWS = float4(positionWS + normalWS * outlineWidth, 1);
         output.positionCS = UnityWorldToClipPos(output.positionWS);
         return output;
     }
@@ -64,10 +57,8 @@ inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const 
         half2 normalProjectedCS = normalize(normalCS.xy);
         // NOTE: VR などの高視野角カメラでは、純粋な実装では太くなりすぎる.
         //       よって 1m 以上離れたら、それ以上太くならないようにする.
-        //       また、World Coords 輪郭線と同様のエリアシング対策もする.
-        const half multiplier = outlineWidth * min(positionCS.w, widthScaledMaxMeter);
-        const half antiAliasingMultiplier = mtoon_linearstep(onePixelMultiplier, onePixelMultiplier * minWidthInPixel, multiplier) * multiplier;
-        normalProjectedCS *= antiAliasingMultiplier;
+        const half outlineWidthMultiplier = outlineWidth * min(positionCS.w, widthScaledMaxMeter);
+        normalProjectedCS *= outlineWidthMultiplier;
         normalProjectedCS.x *= aspect;
         // NOTE: カメラ方向軸を向く法線を持つ頂点が XY 方向にだけずれると困るので、それを抑制する.
         normalProjectedCS.xy *= saturate(1 - normalVS.z * normalVS.z);

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
@@ -59,13 +59,13 @@ inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const 
         const half3 normalCS = TransformViewToProjection(normalVS.xyz);
 
         const float onePixelMultiplier = positionCS.w * 2.0f / _ScreenParams.y;
-        const float oneMeter = 1.0f;
+        const float widthScaledMaxMeter = 1.0f;
 
         half2 normalProjectedCS = normalize(normalCS.xy);
         // NOTE: VR などの高視野角カメラでは、純粋な実装では太くなりすぎる.
         //       よって 1m 以上離れたら、それ以上太くならないようにする.
         //       また、World Coords 輪郭線と同様のエリアシング対策もする.
-        const half multiplier = outlineWidth * min(positionCS.w, oneMeter);
+        const half multiplier = outlineWidth * min(positionCS.w, widthScaledMaxMeter);
         const half antiAliasingMultiplier = mtoon_linearstep(onePixelMultiplier, onePixelMultiplier * minWidthInPixel, multiplier) * multiplier;
         normalProjectedCS *= antiAliasingMultiplier;
         normalProjectedCS.x *= aspect;

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
@@ -49,12 +49,14 @@ inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const 
         const half3 normalVS = MToon_GetObjectToViewNormal(normalOS);
         const half3 normalCS = TransformViewToProjection(normalVS.xyz);
 
+        const float clipSpaceHeight = 2.0f;
         const float widthScaledMaxMeter = 1.0f;
+
         half2 normalProjectedCS = normalize(normalCS.xy);
         // NOTE: VR などの高視野角カメラでは、純粋な実装では太くなりすぎる.
         //       よって 1m 以上離れたら、それ以上太くならないようにする.
         const half outlineWidthMultiplier = outlineWidth * min(positionCS.w, widthScaledMaxMeter);
-        normalProjectedCS *= outlineWidthMultiplier;
+        normalProjectedCS *= clipSpaceHeight * outlineWidthMultiplier;
         normalProjectedCS.x *= aspect;
         // NOTE: カメラ方向軸を向く法線を持つ頂点が XY 方向にだけずれると困るので、それを抑制する.
         normalProjectedCS.xy *= saturate(1 - normalVS.z * normalVS.z);

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_utility.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_utility.hlsl
@@ -7,6 +7,11 @@
 static const float PI_2 = 6.28318530718;
 static const float EPS_COL = 0.00001;
 
+inline half mtoon_linearstep(const half start, const half end, const half t)
+{
+    return min(max((t - start) / (end - start), 0.0), 1.0);
+}
+
 inline half3 mtoon_linearstep(const half3 start, const half3 end, const half t)
 {
     return min(max((t - start) / (end - start), 0.0), 1.0);
@@ -15,6 +20,20 @@ inline half3 mtoon_linearstep(const half3 start, const half3 end, const half t)
 inline bool MToon_IsPerspective()
 {
     return unity_OrthoParams.w != 1.0;
+}
+
+inline float3 MToon_GetWorldSpaceViewDir(const float3 positionWS)
+{
+    if (MToon_IsPerspective())
+    {
+        return _WorldSpaceCameraPos.xyz - positionWS;
+    }
+    else
+    {
+        const float3 cameraForwardWS = normalize(UNITY_MATRIX_V[2].xyz);
+        const float3 viewDirWS = _WorldSpaceCameraPos.xyz - positionWS;
+        return cameraForwardWS * dot(cameraForwardWS, viewDirWS);
+    }
 }
 
 inline float3 MToon_GetWorldSpaceNormalizedViewDir(const float3 positionWS)


### PR DESCRIPTION
VRM 0.x -> 1.0 のマイグレーション時にエラーがあったので修正。
マイグレーションと 1.0 の実装の双方が間違っていたので、得られる結果の見た目自体は変わらない。

具体的には、スクリーン座標系輪郭線の幅の変換が間違っていた。
従来の MToon 0.x の幅は、スクリーンの縦幅の半分を 100 としたときの値だった。
一方で MToon 1.0 の幅は、スクリーンの縦幅を 1 としたときの値となる。

したがってマイグレーション時には値を `1/200` 倍する必要がある。
しかし `1/100` 倍になっていた。


またスクリーン座標系輪郭線に関連して、VR などの高視野角カメラ環境においてスクリーン座標系輪郭線が太くなりすぎる問題があったので、仕様の範囲外でこれを抑制した。

これがうまくいくようなら、仕様にも提案したい。