### PR TITLE
While importing in Unity Editor, `Max Size` property is invalid if a texture size was larger than 2048.

### DIFF
--- a/Assets/VRMShaders/GLTF/IO/Editor/Texture/EditorTextureUtility.cs
+++ b/Assets/VRMShaders/GLTF/IO/Editor/Texture/EditorTextureUtility.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace VRMShaders
+{
+    internal static class EditorTextureUtility
+    {
+        public static bool TryGetAsEditorTexture2DAsset(Texture texture, out Texture2D texture2D, out TextureImporter assetImporter)
+        {
+            texture2D = texture as Texture2D;
+            if (texture2D != null)
+            {
+                var path = AssetDatabase.GetAssetPath(texture2D);
+                if (!string.IsNullOrEmpty(path))
+                {
+                    assetImporter = AssetImporter.GetAtPath(path) as TextureImporter;
+                    if (assetImporter != null)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            texture2D = null;
+            assetImporter = null;
+            return false;
+        }
+
+        public static bool TryGetOriginalTexturePixelSize(TextureImporter textureImporter, out Vector2Int size)
+        {
+            // private メソッド TextureImporter.GetWidthAndHeight を無理やり呼ぶ
+            var getSizeMethod = typeof(TextureImporter).GetMethod("GetWidthAndHeight", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (textureImporter != null && getSizeMethod != null)
+            {
+                var args = new object[2] { 0, 0 };
+                getSizeMethod.Invoke(textureImporter, args);
+                var originalWidth = (int)args[0];
+                var originalHeight = (int)args[1];
+
+                size = new Vector2Int(originalWidth, originalHeight);
+                return true;
+            }
+
+            size = default;
+            return false;
+        }
+    }
+}

--- a/Assets/VRMShaders/GLTF/IO/Editor/Texture/EditorTextureUtility.cs.meta
+++ b/Assets/VRMShaders/GLTF/IO/Editor/Texture/EditorTextureUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 20719e2944224be681a607b6db951720
+timeCreated: 1638542710

--- a/Assets/VRMShaders/GLTF/IO/Editor/Texture/Importer/TextureImporterConfigurator.cs
+++ b/Assets/VRMShaders/GLTF/IO/Editor/Texture/Importer/TextureImporterConfigurator.cs
@@ -8,7 +8,7 @@ namespace VRMShaders
 {
     public static class TextureImporterConfigurator
     {
-        private static void ConfigureSize(Texture2D texture, TextureImporter textureImporter)
+        private static void ConfigureSize(TextureImporter textureImporter)
         {
             if (!EditorTextureUtility.TryGetOriginalTexturePixelSize(textureImporter, out var originalSize)) return;
 
@@ -38,33 +38,33 @@ namespace VRMShaders
             textureImporter.wrapModeV = texDesc.Sampler.WrapModesV;
         }
 
-        private static void Configure(TextureDescriptor texDesc, Texture2D texture, TextureImporter importer)
+        private static void Configure(TextureDescriptor texDesc, TextureImporter importer)
         {
             switch (texDesc.TextureType)
             {
                 case TextureImportTypes.NormalMap:
                     {
-                        ConfigureSize(texture, importer);
+                        ConfigureSize(importer);
                         ConfigureNormalMap(importer);
                     }
                     break;
 
                 case TextureImportTypes.StandardMap:
                     {
-                        ConfigureSize(texture, importer);
+                        ConfigureSize(importer);
                         ConfigureLinear(importer);
                     }
                     break;
 
                 case TextureImportTypes.sRGB:
                     {
-                        ConfigureSize(texture, importer);
+                        ConfigureSize(importer);
                     }
                     break;
 
                 case TextureImportTypes.Linear:
                     {
-                        ConfigureSize(texture, importer);
+                        ConfigureSize(importer);
                         ConfigureLinear(importer);
                     }
                     break;
@@ -81,7 +81,7 @@ namespace VRMShaders
             if (!externalMap.TryGetValue(texDesc.SubAssetKey, out var externalTexture)) return;
             if (!EditorTextureUtility.TryGetAsEditorTexture2DAsset(externalTexture, out var texture2D, out var importer)) return;
 
-            Configure(texDesc, texture2D, importer);
+            Configure(texDesc, importer);
             importer.SaveAndReimport();
         }
     }


### PR DESCRIPTION
Editor Import 時に、2048 を超える Texture ファイルに対する MaxSize 指定がうまくいってなかったのを修正

この Issue を修正
https://github.com/vrm-c/UniVRM/issues/1379