### PR TITLE
Ignore texture compression settings while exporting glTF / VRM.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/GltfTextureExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/GltfTextureExporter.cs
@@ -17,10 +17,10 @@ namespace UniGLTF
         ///
         /// を更新し、textures の index を返す
         ///
+        /// もっとも根本の Exporter クラスのみが呼び出すべきである。
+        /// 他の拡張機能などが呼び出すべきではない。
+        ///
         /// </summary>
-        /// <param name="gltf"></param>
-        /// <param name="bufferIndex"></param>
-        /// <param name="texture"></param>
         /// <returns>gltf texture index</returns>
         public static int PushGltfTexture(ExportingGltfData data, Texture2D texture, ColorSpace textureColorSpace, ITextureSerializer textureSerializer)
         {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
@@ -63,7 +63,8 @@ namespace UniGLTF
             }
         }
 
-        protected TextureExporter TextureExporter { get; private set; }
+        protected ITextureExporter TextureExporter => _textureExporter;
+        private TextureExporter _textureExporter;
 
         GltfExportSettings m_settings;
 
@@ -234,7 +235,7 @@ namespace UniGLTF
             #region Materials and Textures
             Materials = uniqueUnityMeshes.GetUniqueMaterials().ToList();
 
-            TextureExporter = new TextureExporter(textureSerializer);
+            _textureExporter = new TextureExporter(textureSerializer);
 
             var materialExporter = CreateMaterialExporter();
             _gltf.materials = Materials.Select(x => materialExporter.ExportMaterial(x, TextureExporter, m_settings)).ToList();
@@ -376,7 +377,7 @@ namespace UniGLTF
             ExportExtensions(textureSerializer);
 
             // Extension で Texture が増える場合があるので最後に呼ぶ
-            var exported = TextureExporter.Export();
+            var exported = _textureExporter.Export();
             for (var exportedTextureIdx = 0; exportedTextureIdx < exported.Count; ++exportedTextureIdx)
             {
                 var (unityTexture, colorSpace) = exported[exportedTextureIdx];

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
@@ -376,7 +376,7 @@ namespace UniGLTF
             ExportExtensions(textureSerializer);
 
             // Extension で Texture が増える場合があるので最後に呼ぶ
-            var exported = m_textureExporter.Export();
+            var exported = TextureExporter.Export();
             for (var exportedTextureIdx = 0; exportedTextureIdx < exported.Count; ++exportedTextureIdx)
             {
                 var (unityTexture, colorSpace) = exported[exportedTextureIdx];

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
@@ -46,8 +46,6 @@ namespace UniGLTF
             private set;
         }
 
-        public ITextureExporter TextureExporter => m_textureExporter;
-
         protected virtual IMaterialExporter CreateMaterialExporter()
         {
             return new MaterialExporter();
@@ -65,7 +63,7 @@ namespace UniGLTF
             }
         }
 
-        TextureExporter m_textureExporter;
+        protected TextureExporter TextureExporter { get; private set; }
 
         GltfExportSettings m_settings;
 
@@ -236,7 +234,7 @@ namespace UniGLTF
             #region Materials and Textures
             Materials = uniqueUnityMeshes.GetUniqueMaterials().ToList();
 
-            m_textureExporter = new TextureExporter(textureSerializer);
+            TextureExporter = new TextureExporter(textureSerializer);
 
             var materialExporter = CreateMaterialExporter();
             _gltf.materials = Materials.Select(x => materialExporter.ExportMaterial(x, TextureExporter, m_settings)).ToList();

--- a/Assets/VRM/Runtime/IO/VRMExporter.cs
+++ b/Assets/VRM/Runtime/IO/VRMExporter.cs
@@ -118,7 +118,7 @@ namespace VRM
                     VRM.meta.title = meta.Title;
                     if (meta.Thumbnail != null)
                     {
-                        VRM.meta.texture = GltfTextureExporter.PushGltfTexture(_data, meta.Thumbnail, ColorSpace.sRGB, textureSerializer);
+                        VRM.meta.texture = TextureExporter.RegisterExportingAsSRgb(meta.Thumbnail, needsAlpha: true);
                     }
 
                     VRM.meta.licenseType = meta.LicenseType;

--- a/Assets/VRMShaders/GLTF/IO/Editor/Texture/Exporter/EditorTextureSerializer.cs
+++ b/Assets/VRMShaders/GLTF/IO/Editor/Texture/Exporter/EditorTextureSerializer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -8,7 +7,7 @@ namespace VRMShaders
 {
     public sealed class EditorTextureSerializer : ITextureSerializer
     {
-        private readonly RuntimeTextureSerializer m_runtimeSerializer = new RuntimeTextureSerializer();
+        private readonly RuntimeTextureSerializer _runtimeSerializer = new RuntimeTextureSerializer();
 
         /// <summary>
         /// Texture をオリジナルのテクスチャアセット(png/jpg)ファイルのバイト列そのまま出力してよいかどうか判断する。
@@ -56,7 +55,19 @@ namespace VRMShaders
                 return (bytes, mime);
             }
 
-            return m_runtimeSerializer.ExportBytesWithMime(texture, exportColorSpace);
+            return _runtimeSerializer.ExportBytesWithMime(texture, exportColorSpace);
+        }
+
+        /// <summary>
+        /// 出力に使用したいテクスチャに対して、Unity のエディタアセットとしての圧縮設定を OFF にする。
+        /// </summary>
+        public void ModifyTextureAssetBeforeExporting(Texture texture)
+        {
+            if (EditorTextureUtility.TryGetAsEditorTexture2DAsset(texture, out var texture2D, out var assetImporter))
+            {
+                assetImporter.textureCompression = TextureImporterCompression.Uncompressed;
+                assetImporter.SaveAndReimport();
+            }
         }
 
         /// <summary>

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Exporter/ITextureSerializer.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Exporter/ITextureSerializer.cs
@@ -22,5 +22,12 @@ namespace VRMShaders
         /// 具体的には Texture2D をコピーする際に、コピー先の Texture2D の色空間を決定するために使用する。
         /// </summary>
         (byte[] bytes, string mime) ExportBytesWithMime(Texture2D texture, ColorSpace exportColorSpace);
+
+        /// <summary>
+        /// エクスポートに使用したい Texture に対して、事前準備を行う。
+        ///
+        /// たとえば UnityEditor においては、Texture Asset の圧縮設定を OFF にしたりしたい。
+        /// </summary>
+        void ModifyTextureAssetBeforeExporting(Texture texture);
     }
 }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Exporter/RuntimeTextureSerializer.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Exporter/RuntimeTextureSerializer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using UnityEngine;
-using VRMShaders;
 
 namespace VRMShaders
 {
@@ -37,6 +36,11 @@ namespace VRMShaders
                 // 単純に EncodeToPNG できないため、コピーしてから EncodeToPNG する。
                 return CopyTextureAndGetBytesWithMime(texture, exportColorSpace);
             }
+        }
+
+        public void ModifyTextureAssetBeforeExporting(Texture texture)
+        {
+            // NOTE: Do nothing.
         }
 
         private static (byte[] bytes, string mime) CopyTextureAndGetBytesWithMime(Texture2D texture, ColorSpace colorSpace)


### PR DESCRIPTION
waiting merging https://github.com/vrm-c/UniVRM/pull/1402

fix https://github.com/vrm-c/UniVRM/issues/964

glTF や VRM のエクスポート時に、使用するテクスチャアセットの圧縮設定をオフにする。
これにより、ユーザが UniVRM を使用して VRM ファイルをエクスポートするときに、知らずにテクスチャ品質が悪化するのを防ぐ。

ただし Export するとアセットの圧縮設定がオフになったまま放置される。
その挙動がクリティカルに影響するユーザはかなり少ないと思うので、いったんはこう実装する。
エクスポート後に圧縮設定を復元する実装は、できればしたくない。
