### PR TITLE
同一のバイト列を参照するBufferAccessor が複数回、座標変換(右手・左手変換)されるのを回避する

### DIFF
--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterEditorGUI.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterEditorGUI.cs
@@ -120,7 +120,7 @@ namespace UniVRM10
 #if VRM_DEVELOP
                                 if (GUILayout.Button("debug export"))
                                 {
-                                    File.WriteAllBytes("tmp.vrm", UniGLTF.Glb.Create(m_result.Data.Json, m_result.Data.Bin).ToBytes());
+                                    File.WriteAllBytes("tmp.vrm", m_result.MigratedBytes);
                                 }
 #endif
 

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterEditorGUI.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterEditorGUI.cs
@@ -106,13 +106,24 @@ namespace UniVRM10
                                     serializedObject.Update();
                                     EditorGUILayout.HelpBox("Experimental", MessageType.Warning);
                                     EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(VrmScriptedImporter.RenderPipeline)));
+
+
                                     serializedObject.ApplyModifiedProperties();
                                 }
+
                                 ApplyRevertGUI();
                                 break;
 
                             case Vrm10FileType.Vrm0:
                                 EditorGUILayout.HelpBox(m_result.Message, m_model != null ? MessageType.Info : MessageType.Warning);
+
+#if VRM_DEVELOP
+                                if (GUILayout.Button("debug export"))
+                                {
+                                    File.WriteAllBytes("tmp.vrm", UniGLTF.Glb.Create(m_result.Data.Json, m_result.Data.Bin).ToBytes());
+                                }
+#endif
+
                                 // migration check boxs
                                 base.OnInspectorGUI();
                                 break;

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterEditorGUI.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterEditorGUI.cs
@@ -117,12 +117,13 @@ namespace UniVRM10
                             case Vrm10FileType.Vrm0:
                                 EditorGUILayout.HelpBox(m_result.Message, m_model != null ? MessageType.Info : MessageType.Warning);
 
-#if VRM_DEVELOP
-                                if (GUILayout.Button("debug export"))
+                                if (VRMShaders.Symbols.VRM_DEVELOP)
                                 {
-                                    File.WriteAllBytes("tmp.vrm", m_result.MigratedBytes);
+                                    if (GUILayout.Button("debug export"))
+                                    {
+                                        File.WriteAllBytes("tmp.vrm", m_result.MigratedBytes);
+                                    }
                                 }
-#endif
 
                                 // migration check boxs
                                 base.OnInspectorGUI();

--- a/Assets/VRM10/Runtime/IO/Vrm10Data.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Data.cs
@@ -22,6 +22,8 @@ namespace UniVRM10
         public readonly Vrm10FileType FileType;
         public readonly String Message;
 
+        public byte[] MigratedBytes;
+
         public Vrm10Data(GltfData data, VRMC_vrm vrm, Vrm10FileType fileType, string message, Migration.Vrm0Meta oldMeta = null)
         {
             Data = data;
@@ -118,6 +120,10 @@ namespace UniVRM10
                         throw new NullReferenceException("oldMeta");
                     }
                     result = new Vrm10Data(migratedData, vrm, Vrm10FileType.Vrm0, "vrm0: migrated", oldMeta);
+#if VRM_DEVELOP            
+                    // 右手左手座標変換でバッファが破壊的変更されるので、コピーを作っている        
+                    result.MigratedBytes = migrated.Select(x => x).ToArray();
+#endif
                     return true;
                 }
 

--- a/Assets/VRM10/Runtime/IO/Vrm10Data.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Data.cs
@@ -120,10 +120,13 @@ namespace UniVRM10
                         throw new NullReferenceException("oldMeta");
                     }
                     result = new Vrm10Data(migratedData, vrm, Vrm10FileType.Vrm0, "vrm0: migrated", oldMeta);
-#if VRM_DEVELOP            
-                    // 右手左手座標変換でバッファが破壊的変更されるので、コピーを作っている        
-                    result.MigratedBytes = migrated.Select(x => x).ToArray();
-#endif
+
+                    if (VRMShaders.Symbols.VRM_DEVELOP)
+                    {
+                        // 右手左手座標変換でバッファが破壊的変更されるので、コピーを作っている        
+                        result.MigratedBytes = migrated.Select(x => x).ToArray();
+                    }
+
                     return true;
                 }
 

--- a/Assets/VRM10/Runtime/Migration/MeshUpdater.cs
+++ b/Assets/VRM10/Runtime/Migration/MeshUpdater.cs
@@ -159,10 +159,16 @@ namespace UniVRM10
                 gltfNode.translation = node.LocalTranslation.ToFloat3();
                 gltfNode.rotation = node.LocalRotation.ToFloat4();
                 gltfNode.scale = node.LocalScaling.ToFloat3();
+
                 if (gltfNode.mesh >= 0)
                 {
                     if (gltfNode.skin >= 0)
                     {
+                        //
+                        // mesh with skin
+                        // only this case, skin is enable
+                        // [SkinnedMeshRenderer]
+                        //
                         var gltfSkin = skins[gltfNode.skin];
                         // get or create
                         var skinIndex = gltf.skins.IndexOf(gltfSkin);
@@ -172,13 +178,37 @@ namespace UniVRM10
                             gltfSkin.inverseBindMatrices = AddAccessor(node.MeshGroup.Skin.InverseMatrices.GetSpan<Matrix4x4>());
                             gltf.skins.Add(gltfSkin);
                         }
+                        else{
+                            // multi nodes sharing a same skin may be error ?
+                            // edge case.
+                        }
                         // update
                         gltfNode.skin = skinIndex;
+                    }
+                    else
+                    {
+                        //
+                        // mesh without skin
+                        // [MeshRenderer]
+                        //
                     }
                 }
                 else
                 {
-                    gltfNode.skin = -1;
+                    if (gltfNode.skin >= 0)
+                    {
+                        //
+                        // no mesh but skin
+                        // fix error
+                        //
+                        gltfNode.skin = -1;
+                    }
+                    else
+                    {
+                        //
+                        // no mesh no skin
+                        //
+                    }
                 }
             }
 

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Util/Symbols.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Util/Symbols.cs
@@ -1,0 +1,18 @@
+namespace VRMShaders
+{
+    public static class Symbols
+    {
+        /// <summary>
+        /// #if 文を局所化する。
+        /// VRMShaders が最下層になるため、ここに配置している
+        /// </summary>
+        /// <value></value>
+        public const bool VRM_DEVELOP =
+#if VRM_DEVELOP
+true
+#else
+false
+#endif
+        ;
+    }
+}

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Util/Symbols.cs.meta
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Util/Symbols.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ffb4175afef01ea48ad7669a8b12d93f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
glTFフォーマット上はもっと微妙なケースもあり得るのだけど、
Exporter の癖次第。

~本件は、 Blender のエクスポーターで稀に発生する様子。~
#1405 のmigration 時に発生してたー。

今後同様のケースが起こる場合は、バッファのコピーを前もって作る方法にする。

vrmlib の処理なので `vrm-1.0` のみがヒットする。
