### PR TITLE
Suppress compler warning `unreachable code detected warning` when `VRM_DEVELOP` symbol is undefined.

### DIFF
--- a/Assets/VRMShaders/GLTF/IO/Runtime/Util/Symbols.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Util/Symbols.cs
@@ -7,12 +7,16 @@ namespace VRMShaders
         /// VRMShaders が最下層になるため、ここに配置している
         /// </summary>
         /// <value></value>
-        public const bool VRM_DEVELOP =
+        public static bool VRM_DEVELOP
+        {
+            get
+            {
 #if VRM_DEVELOP
-true
+                return true;
 #else
-false
+                return false;
 #endif
-        ;
+            }
+        }
     }
 }


### PR DESCRIPTION
VRM_DEVELOP シンボル未定義時に unreachable code detected warning が出るのを抑制