### PR TITLE
Can export metallic roughness occlusion correct.

### DIFF
--- a/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Exporter/TextureExportParam.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Exporter/TextureExportParam.cs
@@ -36,10 +36,8 @@ namespace VRMShaders
                 case TextureExportTypes.Normal:
                     return PrimaryTexture == other.PrimaryTexture;
                 case TextureExportTypes.OcclusionMetallicRoughness:
-                    var primaryDifference = PrimaryTexture != other.PrimaryTexture ? 1 : 0;
-                    var secondaryDifference = SecondaryTexture != other.SecondaryTexture ? 1 : 0;
-                    var difference = primaryDifference + secondaryDifference;
-                    return difference < 2;
+                    return PrimaryTexture == other.PrimaryTexture &&
+                           SecondaryTexture == other.SecondaryTexture;
                 default:
                     throw new ArgumentOutOfRangeException();
             }


### PR DESCRIPTION
metallic roughness occlusion テクスチャの Export 時の修正。

旧来「metallic か occlusion どちらかのテクスチャが同じであれば同じとみなす」としていたコードを
「metallic も occlusion もどちらのテクスチャも同じであれば同じとみなす」とした。

テクスチャが増える場合はあるだろうが、厳密性を優先。


具体的には「Metallic テクスチャは存在するが、Occlusion テクスチャは存在しない」マテリアルが複数ある時に
`null == null` -> `true` となって、同じテクスチャを出力すればよい、と判定されてしまっていた。