### PR TITLE
MeshVertexのdefault colorをwhiteにした

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
@@ -142,7 +142,7 @@ namespace UniGLTF
                     var joints = jointsGetter?.Invoke(i) ?? (0, 0, 0, 0);
                     var weights = weightsGetter != null ? NormalizeBoneWeight(weightsGetter(i)) : (0, 0, 0, 0);
 
-                    var color = colors != null ? colors[i] : Color.black;
+                    var color = colors != null ? colors[i] : Color.white;
                     _vertices.Add(
                         new MeshVertex(
                             position,
@@ -275,7 +275,7 @@ namespace UniGLTF
                     }
 
                     var texCoord1 = texCoords1 != null ? texCoords1[i].ReverseUV() : Vector2.zero;
-                    var color = colors != null ? colors[i] : Color.black;
+                    var color = colors != null ? colors[i] : Color.white;
                     var joints = jointsGetter?.Invoke(i) ?? (0, 0, 0, 0);
                     var weights = weightsGetter != null ? NormalizeBoneWeight(weightsGetter(i)) : (0, 0, 0, 0);
 


### PR DESCRIPTION
MeshVertexのdefault colorをwhiteにしました
color bufferがnullだったときに白で描画されるようになり、一部状況で黒くなってしまうバグが修正されます