### PR TITLE
Fix10/fix springbone migration

### DIFF
--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneCollider.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneCollider.cs
@@ -33,10 +33,14 @@ namespace UniVRM10
             switch (ColliderType)
             {
                 case VRM10SpringBoneColliderTypes.Sphere:
+                    Gizmos.color = Color.magenta;
                     Gizmos.DrawWireSphere(Offset, Radius);
                     break;
 
                 case VRM10SpringBoneColliderTypes.Capsule:
+                    Gizmos.color = Color.cyan;
+                    Gizmos.DrawWireSphere(Offset, Radius);
+                    Gizmos.DrawWireSphere(Tail, Radius);
                     break;
             }
         }

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -106,12 +106,13 @@ namespace UniVRM10
 
         private void OnDrawGizmos()
         {
+            Gizmos.color = Color.green;
             foreach (var spring in SpringBone.Springs)
             {
                 foreach (var (head, tail) in spring.EnumHeadTail())
                 {
                     Gizmos.DrawLine(head.transform.position, tail.transform.position);
-                    Gizmos.DrawSphere(tail.transform.position, head.m_jointRadius);
+                    Gizmos.DrawWireSphere(tail.transform.position, head.m_jointRadius);
                 }
             }
         }

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmSpringBone.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmSpringBone.cs
@@ -168,9 +168,16 @@ namespace UniVRM10
                 // },
                 if (x.ContainsKey("bones"))
                 {
+                    var comment = x.GetObjectValueOrDefault("comment", "");
+                    var dragForce = x["dragForce"].GetSingle();
+                    var gravityDir = MigrateVector3.Migrate(x["gravityDir"]);
+                    var gravityPower = x["gravityPower"].GetSingle();
+                    var hitRadius = x["hitRadius"].GetSingle();
+                    var stiffiness = x["stiffiness"].GetSingle();
                     foreach (var y in x["bones"].ArrayItems())
                     {
-                        var comment = x.GetObjectValueOrDefault("comment", "");
+                        var rootBoneIndex = y.GetInt32();
+
                         var spring = new UniGLTF.Extensions.VRMC_springBone.Spring
                         {
                             Name = comment,
@@ -178,16 +185,18 @@ namespace UniVRM10
                             Joints = new List<UniGLTF.Extensions.VRMC_springBone.SpringBoneJoint>(),
                         };
 
-                        foreach (var z in TraverseFirstChild(gltf.nodes, gltf.nodes[y.GetInt32()]))
+                        // create joints
+                        foreach (var z in TraverseFirstChild(gltf.nodes, gltf.nodes[rootBoneIndex]))
                         {
+                            var nodeIndex = gltf.nodes.IndexOf(z);
                             spring.Joints.Add(new UniGLTF.Extensions.VRMC_springBone.SpringBoneJoint
                             {
-                                Node = gltf.nodes.IndexOf(z),
-                                DragForce = x["dragForce"].GetSingle(),
-                                GravityDir = MigrateVector3.Migrate(x["gravityDir"]),
-                                GravityPower = x["gravityPower"].GetSingle(),
-                                HitRadius = x["hitRadius"].GetSingle(),
-                                Stiffness = x["stiffiness"].GetSingle(),
+                                Node = nodeIndex,
+                                DragForce = dragForce,
+                                GravityDir = gravityDir,
+                                GravityPower = gravityPower,
+                                HitRadius = hitRadius,
+                                Stiffness = stiffiness,
                             });
                         }
 


### PR DESCRIPTION
vrm-0.x の仕様、`枝分かれした spring の分岐も揺れる` をマイグレーションで再現。
下記のような場合に、枝の Spring 設定を追加した。
分岐一本目(×のところ)は揺れない仕様。

```
* node 〇
    * node1 〇
        * node12 〇
    * node2 × 
        * node22 〇 必用
            * node23 〇 必用
```

合わせて、末尾に tail を追加する処理を改めて修正しました。
