### PR TITLE
Fix/renderer lost message

### DIFF
--- a/Assets/VRM/Editor/BlendShape/BlendShapeClipEditorHelper.cs
+++ b/Assets/VRM/Editor/BlendShape/BlendShapeClipEditorHelper.cs
@@ -21,17 +21,25 @@ namespace VRM
                 var y = position.y;
                 var rect = new Rect(position.x, y, position.width, height);
                 int pathIndex;
-                if (StringPopup(rect, property.FindPropertyRelative("RelativePath"), scene.SkinnedMeshRendererPathList, out pathIndex))
+                var (relChanged, oldIndex) = StringPopup(rect, property.FindPropertyRelative("RelativePath"), scene.SkinnedMeshRendererPathList, out pathIndex);
+                if (relChanged)
                 {
                     changed = true;
                 }
 
                 y += height;
                 rect = new Rect(position.x, y, position.width, height);
-                int blendShapeIndex;
-                if (IntPopup(rect, property.FindPropertyRelative("Index"), scene.GetBlendShapeNames(pathIndex), out blendShapeIndex))
+                if (!relChanged && oldIndex == -1)
                 {
-                    changed = true;
+                    EditorGUI.HelpBox(rect, "renderer not found ! please fix", MessageType.Error);
+                }
+                else
+                {
+                    int blendShapeIndex;
+                    if (IntPopup(rect, property.FindPropertyRelative("Index"), scene.GetBlendShapeNames(pathIndex), out blendShapeIndex))
+                    {
+                        changed = true;
+                    }
                 }
 
                 y += height;
@@ -58,7 +66,7 @@ namespace VRM
                 var y = position.y;
                 var rect = new Rect(position.x, y, position.width, height);
                 int materialIndex;
-                if (StringPopup(rect, property.FindPropertyRelative("MaterialName"), scene.MaterialNames, out materialIndex))
+                if (StringPopup(rect, property.FindPropertyRelative("MaterialName"), scene.MaterialNames, out materialIndex).Item1)
                 {
                     changed = true;
                 }
@@ -73,7 +81,7 @@ namespace VRM
 
                         // プロパティ名のポップアップ
                         int propIndex;
-                        if (StringPopup(rect, property.FindPropertyRelative("ValueName"), materialItem.PropNames, out propIndex))
+                        if (StringPopup(rect, property.FindPropertyRelative("ValueName"), materialItem.PropNames, out propIndex).Item1)
                         {
                             changed = true;
                         }
@@ -122,12 +130,12 @@ namespace VRM
         }
 
         #region Private
-        static bool StringPopup(Rect rect, SerializedProperty prop, string[] options, out int newIndex)
+        static (bool, int?) StringPopup(Rect rect, SerializedProperty prop, string[] options, out int newIndex)
         {
             if (options == null)
             {
                 newIndex = -1;
-                return false;
+                return (false, default);
             }
 
             var oldIndex = Array.IndexOf(options, prop.stringValue);
@@ -135,11 +143,11 @@ namespace VRM
             if (newIndex != oldIndex && newIndex >= 0 && newIndex < options.Length)
             {
                 prop.stringValue = options[newIndex];
-                return true;
+                return (true, oldIndex);
             }
             else
             {
-                return false;
+                return (false, oldIndex);
             }
         }
 

--- a/Assets/VRM/Editor/BlendShape/VRMBlendShapeProxyValidator.cs
+++ b/Assets/VRM/Editor/BlendShape/VRMBlendShapeProxyValidator.cs
@@ -59,7 +59,7 @@ namespace VRM
                     var target = p.transform.Find(v.RelativePath);
                     if (target == null)
                     {
-                        yield return Validation.Warning($"{c}.Values[{i}].RelativePath({v.RelativePath} is not found");
+                        yield return Validation.Warning($"{c}.Values[{i}].RelativePath({v.RelativePath}) is not found", ValidationContext.Create(c));
                     }
                 }
 

--- a/Assets/VRM/Runtime/Extensions/glTF_VRMExtensions.cs
+++ b/Assets/VRM/Runtime/Extensions/glTF_VRMExtensions.cs
@@ -32,7 +32,7 @@ namespace VRM
             if (found == null)
             {
                 var name = binding.RelativePath.Split('/').Last();
-                found = root.GetComponentsInChildren<Transform>().Where(x => x.name == name).FirstOrDefault();
+                found = root.GetComponentsInChildren<Transform>().FirstOrDefault(x => x.name == name);
                 if (found == null)
                 {
                     Debug.LogWarning($"{binding.RelativePath} not found");


### PR DESCRIPTION
Renderer参照が不正である表示を改善

![renderer_not_found](https://user-images.githubusercontent.com/68057/149739424-e438934b-74f0-4ca9-a2e6-42fceb2a067f.jpg)

#1241 