### PR TITLE
[1.0] Migrationのエッジケースを修正

### DIFF
--- a/Assets/UniGLTF/Runtime/UniJSON/ListTreeNode/ListTreeNodeObjectExtensions.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/ListTreeNode/ListTreeNodeObjectExtensions.cs
@@ -52,7 +52,7 @@ namespace UniJSON
                     return kv.Value;
                 }
             }
-            throw new KeyNotFoundException();
+            throw new KeyNotFoundException(key.ToString());
         }
 
         public static bool ContainsKey(this JsonNode self, Utf8String key)

--- a/Assets/VRM10/Runtime/Migration/MigrationVector3.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVector3.cs
@@ -21,5 +21,14 @@ namespace UniVRM10
                 vrm0["z"].GetSingle(),
             };
         }
+
+        public static float[] Migrate(JsonNode parent, string key)
+        {
+            if (!parent.ContainsKey(key))
+            {
+                return new float[] { 0, 0, 0 };
+            }
+            return Migrate(parent[key]);
+        }
     }
 }

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using UniGLTF;
 using UniGLTF.Extensions.VRMC_vrm;
 using UniJSON;
+using UnityEngine;
 
 namespace UniVRM10
 {
@@ -39,14 +41,15 @@ namespace UniVRM10
         {
             // VRM1
             // firstPerson に同居していた LookAt は独立します
-            var lookAt = new LookAt
+            LookAt lookAt = default;
+            lookAt = new LookAt
             {
                 RangeMapHorizontalInner = MigrateLookAtRangeMap(vrm0["lookAtHorizontalInner"]),
                 RangeMapHorizontalOuter = MigrateLookAtRangeMap(vrm0["lookAtHorizontalOuter"]),
                 RangeMapVerticalDown = MigrateLookAtRangeMap(vrm0["lookAtVerticalDown"]),
                 RangeMapVerticalUp = MigrateLookAtRangeMap(vrm0["lookAtVerticalUp"]),
                 Type = MigrateLookAtType(vrm0["lookAtTypeName"]),
-                OffsetFromHeadBone = MigrateVector3.Migrate(vrm0["firstPersonBoneOffset"]),
+                OffsetFromHeadBone = MigrateVector3.Migrate(vrm0, "firstPersonBoneOffset"),
             };
 
             var firstPerson = new FirstPerson

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UniJSON;
+using UnityEngine;
 
 namespace UniVRM10
 {
@@ -152,7 +153,8 @@ namespace UniVRM10
                         break;
 
                     default:
-                        throw new NotImplementedException(key);
+                        Debug.LogWarning($"[meta migration] unknown key: {key}");
+                        break;
                 } // switch
             } // foreach
 


### PR DESCRIPTION
* meta: unknown key で throw せずに warning メッセージ表示に留める
* firstPersonBoneOffset: 無くても動くように修正
* KeyNotFoundException に key.ToString を追加

metaはデフォルト値が不許可に倒してあるので、読み取れなくても制限が緩くなることは無いのでよいということで。

