### PR TITLE
[1.0] don't export the springBone extension if there are no colliders and springs

### DIFF
--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -334,6 +334,17 @@ namespace UniVRM10
 
         static UniGLTF.Extensions.VRMC_springBone.VRMC_springBone ExportSpringBone(Vrm10Instance controller, Model model, ModelExporter converter)
         {
+            var colliders = controller.GetComponentsInChildren<VRM10SpringBoneCollider>();
+
+            // if colliders, collider groups and springs don't exist, don't export the extension
+            if (
+                colliders.Length == 0 &&
+                controller.SpringBone.ColliderGroups.Count == 0 &&
+                controller.SpringBone.Springs.Count == 0
+            ) {
+                return null;
+            }
+
             var springBone = new UniGLTF.Extensions.VRMC_springBone.VRMC_springBone
             {
                 Colliders = new List<UniGLTF.Extensions.VRMC_springBone.Collider>(),
@@ -348,7 +359,6 @@ namespace UniVRM10
                 return model.Nodes.IndexOf(node);
             };
 
-            var colliders = controller.GetComponentsInChildren<VRM10SpringBoneCollider>();
             foreach (var c in colliders)
             {
                 springBone.Colliders.Add(new UniGLTF.Extensions.VRMC_springBone.Collider


### PR DESCRIPTION
#1500 のついでに

### Description

springBone拡張ですが、colliderやspringsがない場合においても空の拡張がエクスポートされていたため、（特に仕様的に問題はない挙動ではありますが）これをエクスポートしないように変更しました。

### Points need review

- [x] ロジックに問題はないですか？
