### PR TITLE
POSITION の Accessor に min, max を追加

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportUtil.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportUtil.cs
@@ -115,8 +115,7 @@ namespace UniGLTF
                 var indicesAccessorIndex = data.ExtendBufferAndGetAccessorIndex(indices.Select(x => (uint)m_vertexIndexMap[x]).ToArray(), glBufferTarget.ELEMENT_ARRAY_BUFFER);
                 var positions = m_positions.ToArray();
                 var positionAccessorIndex = data.ExtendBufferAndGetAccessorIndex(positions, glBufferTarget.ARRAY_BUFFER);
-                data.GLTF.accessors[positionAccessorIndex].min = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Min(a.x, b.x), Math.Min(a.y, b.y), Mathf.Min(a.z, b.z))).ToArray();
-                data.GLTF.accessors[positionAccessorIndex].max = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Max(a.x, b.x), Math.Max(a.y, b.y), Mathf.Max(a.z, b.z))).ToArray();
+                AccessorsBounds.UpdatePositionAccessorsBounds(data.GLTF.accessors[positionAccessorIndex], positions);
 
                 var normals = m_normals.ToArray();
                 var normalAccessorIndex = data.ExtendBufferAndGetAccessorIndex(normals, glBufferTarget.ARRAY_BUFFER);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportUtil.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportUtil.cs
@@ -115,6 +115,9 @@ namespace UniGLTF
                 var indicesAccessorIndex = data.ExtendBufferAndGetAccessorIndex(indices.Select(x => (uint)m_vertexIndexMap[x]).ToArray(), glBufferTarget.ELEMENT_ARRAY_BUFFER);
                 var positions = m_positions.ToArray();
                 var positionAccessorIndex = data.ExtendBufferAndGetAccessorIndex(positions, glBufferTarget.ARRAY_BUFFER);
+                data.GLTF.accessors[positionAccessorIndex].min = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Min(a.x, b.x), Math.Min(a.y, b.y), Mathf.Min(a.z, b.z))).ToArray();
+                data.GLTF.accessors[positionAccessorIndex].max = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Max(a.x, b.x), Math.Max(a.y, b.y), Mathf.Max(a.z, b.z))).ToArray();
+
                 var normals = m_normals.ToArray();
                 var normalAccessorIndex = data.ExtendBufferAndGetAccessorIndex(normals, glBufferTarget.ARRAY_BUFFER);
                 var uvAccessorIndex0 = data.ExtendBufferAndGetAccessorIndex(m_uv.ToArray(), glBufferTarget.ARRAY_BUFFER);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
@@ -32,8 +32,7 @@ namespace UniGLTF
             var materials = unityMesh.Materials;
             var positions = mesh.vertices.Select(axisInverter.InvertVector3).ToArray();
             var positionAccessorIndex = data.ExtendBufferAndGetAccessorIndex(positions, glBufferTarget.ARRAY_BUFFER);
-            data.GLTF.accessors[positionAccessorIndex].min = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Min(a.x, b.x), Math.Min(a.y, b.y), Mathf.Min(a.z, b.z))).ToArray();
-            data.GLTF.accessors[positionAccessorIndex].max = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Max(a.x, b.x), Math.Max(a.y, b.y), Mathf.Max(a.z, b.z))).ToArray();
+            AccessorsBounds.UpdatePositionAccessorsBounds(data.GLTF.accessors[positionAccessorIndex], positions);
 
             var normalAccessorIndex = data.ExtendBufferAndGetAccessorIndex(mesh.normals.Select(y => axisInverter.InvertVector3(y.normalized)).ToArray(), glBufferTarget.ARRAY_BUFFER);
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/PositionMinMax.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/PositionMinMax.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace UniGLTF
+{
+    /// <summary>
+    /// https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#accessors-bounds
+    /// 
+    /// Animation input and vertex position attribute accessors MUST have accessor.min and accessor.max defined. For all other accessors, these properties are optional.
+    /// </summary>
+    public static class AccessorsBounds
+    {
+        public static void UpdatePositionAccessorsBounds(glTFAccessor accessor, Vector3[] positions)
+        {
+            if (positions.Length == 0)
+            {
+                return;
+            }
+            var minX = positions[0].x;
+            var minY = positions[0].y;
+            var minZ = positions[0].z;
+            var maxX = positions[0].x;
+            var maxY = positions[0].y;
+            var maxZ = positions[0].z;
+            foreach (var position in positions)
+            {
+                minX = Mathf.Min(minX, position.x);
+                minY = Mathf.Min(minY, position.y);
+                minZ = Mathf.Min(minZ, position.z);
+                maxX = Mathf.Max(maxX, position.x);
+                maxY = Mathf.Max(maxY, position.y);
+                maxZ = Mathf.Max(maxZ, position.z);
+            }
+            accessor.min = new float[] { minX, minY, minZ };
+            accessor.max = new float[] { maxX, maxY, maxZ };
+        }
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/PositionMinMax.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/PositionMinMax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ebb201c801060d4a9865057558d1fbd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
SHARED vertex buffer(vrm-0.x と glb) 方式は実装済み。
glb と vrm-1.0 が使う Divided vertex buffer の方に無かった。

#1492

https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#accessors-bounds

> Animation input and vertex position attribute accessors MUST have accessor.min and accessor.max defined. For all other accessors, these properties are optional.

いつの間に・・・