### PR TITLE
Fix NewMesh API error.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
@@ -30,7 +30,7 @@ namespace UniGLTF
         public void UploadMeshVertices(Mesh mesh)
         {
             var vertexAttributeDescriptor = MeshVertex.GetVertexAttributeDescriptor();
-            
+
             // Weight情報等は存在しないパターンがあり、かつこの存在の有無によって内部的に条件分岐が走ってしまうため、
             // Streamを分けて必要に応じてアップロードする
             if (_skinnedMeshVertices.Count > 0)
@@ -428,6 +428,7 @@ namespace UniGLTF
             Profiler.BeginSample("MeshContext.DropUnusedVertices");
             var maxIndex = _indices.Max();
             Truncate(_vertices, maxIndex);
+            Truncate(_skinnedMeshVertices, maxIndex);
             foreach (var blendShape in _blendShapes)
             {
                 Truncate(blendShape.Positions, maxIndex);


### PR DESCRIPTION
下記エラーに対するバグ修正。

```
SetVertexData() with out-of-bounds arguments; would need to copy XXXXX bytes at offset 0 into a YYYYY byte buffer
UnityEngine.Mesh:SetVertexBufferData<UniGLTF.SkinnedMeshVertex> (System.Collections.Generic.List`1<UniGLTF.SkinnedMeshVertex>,int,int,int,int,UnityEngine.Rendering.MeshUpdateFlags)
```

下記 PR で、Truncate するべき配列の追加ができていなかった。
https://github.com/vrm-c/UniVRM/pull/1479