### PR TITLE
Fix/optimize readmesh

### DIFF
--- a/Assets/UniGLTF/Runtime/Extensions/ArrayExtensions.cs
+++ b/Assets/UniGLTF/Runtime/Extensions/ArrayExtensions.cs
@@ -100,14 +100,6 @@ namespace UniGLTF
         }
     }
 
-    public static class ListExtensions
-    {
-        public static void Assign<T>(this List<T> dst, NativeArray<T> src, Func<T, T> pred) where T : struct
-        {
-            dst.Capacity = src.Length;
-            dst.AddRange(src.Select(pred));
-        }
-    }
 
     public static class ArraySegmentExtensions
     {

--- a/Assets/UniGLTF/Runtime/Extensions/UnityExtensions.cs
+++ b/Assets/UniGLTF/Runtime/Extensions/UnityExtensions.cs
@@ -30,12 +30,31 @@ namespace UniGLTF
 
         public BlendShape(string name)
         {
-            Name = name;
+            Positions = new List<Vector3>();
+            Normals = new List<Vector3>();
+            Tangents = new List<Vector3>();
         }
 
-        public List<Vector3> Positions = new List<Vector3>();
-        public List<Vector3> Normals = new List<Vector3>();
-        public List<Vector3> Tangents = new List<Vector3>();
+        public BlendShape(string name, int vertexCount, bool hasPositions, bool hasNormals, bool hasTangents)
+        {
+            Name = name;
+            if (hasPositions)
+            {
+                Positions = new List<Vector3>(vertexCount);
+            }
+            if (hasNormals)
+            {
+                Normals = new List<Vector3>(vertexCount);
+            }
+            if (hasTangents)
+            {
+                Tangents = new List<Vector3>(vertexCount);
+            }
+        }
+
+        public List<Vector3> Positions { get; private set; }
+        public List<Vector3> Normals { get; private set; }
+        public List<Vector3> Tangents { get; private set; }
     }
 
     public static class UnityExtensions

--- a/Assets/UniGLTF/Runtime/Extensions/glTFExtensions.cs
+++ b/Assets/UniGLTF/Runtime/Extensions/glTFExtensions.cs
@@ -135,11 +135,22 @@ namespace UniGLTF
             }
         }
 
+        static Dictionary<(string, int, int), bool> s_cache = new Dictionary<(string, int, int), bool>();
+
         public static bool IsGeneratedUniGLTFAndOlder(this glTF gltf, int major, int minor)
         {
             if (gltf == null) return false;
             if (gltf.asset == null) return false;
-            return IsGeneratedUniGLTFAndOlderThan(gltf.asset.generator, major, minor);
+
+            var key = (gltf.asset.generator, major, minor);
+            if (s_cache.TryGetValue(key, out bool isOlder))
+            {
+                return isOlder;
+            }
+
+            var result = IsGeneratedUniGLTFAndOlderThan(gltf.asset.generator, major, minor);
+            s_cache.Add(key, result);
+            return result;
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
@@ -164,23 +164,26 @@ namespace UniGLTF
             return src;
         }
 
-        int GetIndicesCapacity(GltfData data, glTFMesh gltfMesh)
+        (int VertexCapacity, int IndexCapacity) GetCapacity(GltfData data, glTFMesh gltfMesh)
         {
-            var count = 0;
+            var vertexCount = 0;
+            var indexCount = 0;
             foreach (var primitive in gltfMesh.primitives)
             {
+                var positions = data.GLTF.accessors[primitive.attributes.POSITION];
+                vertexCount += positions.count;
+
                 if (primitive.indices == -1)
                 {
-                    var positions = data.GLTF.accessors[primitive.attributes.POSITION];
-                    count += positions.count;
+                    indexCount += positions.count;
                 }
                 else
                 {
                     var accessor = data.GLTF.accessors[primitive.indices];
-                    count += accessor.count;
+                    indexCount += accessor.count;
                 }
             }
-            return count;
+            return (vertexCount, indexCount);
         }
 
         /// <summary>
@@ -194,7 +197,9 @@ namespace UniGLTF
         /// <returns></returns>
         public void ImportMeshIndependentVertexBuffer(GltfData data, glTFMesh gltfMesh, IAxisInverter inverter)
         {
-            _indices.Capacity = GetIndicesCapacity(data, gltfMesh);
+            (_vertices.Capacity, _indices.Capacity) = GetCapacity(data, gltfMesh);
+
+            bool isOldVersion = data.GLTF.IsGeneratedUniGLTFAndOlder(1, 16);
 
             foreach (var primitives in gltfMesh.primitives)
             {
@@ -220,7 +225,7 @@ namespace UniGLTF
                     var texCoord0 = Vector2.zero;
                     if (texCoords0 != null)
                     {
-                        if (data.GLTF.IsGeneratedUniGLTFAndOlder(1, 16))
+                        if (isOldVersion)
                         {
 #pragma warning disable 0612
                             // backward compatibility
@@ -341,7 +346,9 @@ namespace UniGLTF
         /// <returns></returns>
         public void ImportMeshSharingVertexBuffer(GltfData data, glTFMesh gltfMesh, IAxisInverter inverter)
         {
-            _indices.Capacity = GetIndicesCapacity(data, gltfMesh);
+            (_vertices.Capacity, _indices.Capacity) = GetCapacity(data, gltfMesh);
+
+            var isOldVersion = data.GLTF.IsGeneratedUniGLTFAndOlder(1, 16);
 
             {
                 //  同じVertexBufferを共有しているので先頭のモノを使う
@@ -364,7 +371,7 @@ namespace UniGLTF
                     var texCoord0 = Vector2.zero;
                     if (texCoords0 != null)
                     {
-                        if (data.GLTF.IsGeneratedUniGLTFAndOlder(1, 16))
+                        if (isOldVersion)
                         {
 #pragma warning disable 0612
                             texCoord0 = texCoords0.Value[i].ReverseY();
@@ -405,29 +412,38 @@ namespace UniGLTF
                 // blendshape
                 if (primitives.targets != null && primitives.targets.Count > 0)
                 {
-                    _blendShapes.AddRange(primitives.targets.Select((x, i) => new BlendShape(i.ToString())));
                     for (int i = 0; i < primitives.targets.Count; ++i)
                     {
-                        //var name = string.Format("target{0}", i++);
-                        var primTarget = primitives.targets[i];
-                        var blendShape = _blendShapes[i];
+                        var blendShape = new BlendShape(i.ToString());
+                        _blendShapes.Add(blendShape);
 
+                        var primTarget = primitives.targets[i];
                         if (primTarget.POSITION != -1)
                         {
-                            blendShape.Positions.Assign(
-                                data.GetArrayFromAccessor<Vector3>(primTarget.POSITION), inverter.InvertVector3);
+                            blendShape.Positions = data.GetArrayFromAccessor<Vector3>(primTarget.POSITION).ToList();
+                            for (var j = 0; j < blendShape.Positions.Count; ++j)
+                            {
+                                blendShape.Positions[j] = inverter.InvertVector3(blendShape.Positions[j]);
+                            }
                         }
 
                         if (primTarget.NORMAL != -1)
                         {
-                            blendShape.Normals.Assign(
-                                data.GetArrayFromAccessor<Vector3>(primTarget.NORMAL), inverter.InvertVector3);
+                            blendShape.Normals = data.GetArrayFromAccessor<Vector3>(primTarget.NORMAL).ToList();
+                            for (var j = 0; j < blendShape.Positions.Count; ++j)
+                            {
+                                blendShape.Normals[j] = inverter.InvertVector3(blendShape.Normals[j]);
+                            }
+
                         }
 
                         if (primTarget.TANGENT != -1)
                         {
-                            blendShape.Tangents.Assign(
-                                data.GetArrayFromAccessor<Vector3>(primTarget.TANGENT), inverter.InvertVector3);
+                            blendShape.Tangents = data.GetArrayFromAccessor<Vector3>(primTarget.TANGENT).ToList();
+                            for (var j = 0; j < blendShape.Tangents.Count; ++j)
+                            {
+                                blendShape.Tangents[j] = inverter.InvertVector3(blendShape.Tangents[j]);
+                            }
                         }
                     }
                 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshContext.cs
@@ -414,35 +414,38 @@ namespace UniGLTF
                 {
                     for (int i = 0; i < primitives.targets.Count; ++i)
                     {
-                        var blendShape = new BlendShape(i.ToString());
+                        var primTarget = primitives.targets[i];
+                        var blendShape = new BlendShape(i.ToString(), positions.Length, primTarget.POSITION != -1, primTarget.NORMAL != -1, primTarget.TANGENT != -1);
                         _blendShapes.Add(blendShape);
 
-                        var primTarget = primitives.targets[i];
                         if (primTarget.POSITION != -1)
                         {
-                            blendShape.Positions = data.GetArrayFromAccessor<Vector3>(primTarget.POSITION).ToList();
+                            var morphPositions = data.GetArrayFromAccessor<Vector3>(primTarget.POSITION);
+                            blendShape.Positions.Capacity = morphPositions.Length;
                             for (var j = 0; j < blendShape.Positions.Count; ++j)
                             {
-                                blendShape.Positions[j] = inverter.InvertVector3(blendShape.Positions[j]);
+                                blendShape.Positions.Add(inverter.InvertVector3(morphPositions[j]));
                             }
                         }
 
                         if (primTarget.NORMAL != -1)
                         {
-                            blendShape.Normals = data.GetArrayFromAccessor<Vector3>(primTarget.NORMAL).ToList();
+                            var morphNormals = data.GetArrayFromAccessor<Vector3>(primTarget.NORMAL);
+                            blendShape.Normals.Capacity = morphNormals.Length;
                             for (var j = 0; j < blendShape.Positions.Count; ++j)
                             {
-                                blendShape.Normals[j] = inverter.InvertVector3(blendShape.Normals[j]);
+                                blendShape.Normals.Add(inverter.InvertVector3(morphNormals[j]));
                             }
 
                         }
 
                         if (primTarget.TANGENT != -1)
                         {
-                            blendShape.Tangents = data.GetArrayFromAccessor<Vector3>(primTarget.TANGENT).ToList();
+                            var morphTangents = data.GetArrayFromAccessor<Vector3>(primTarget.TANGENT);
+                            blendShape.Tangents.Capacity = morphTangents.Length;
                             for (var j = 0; j < blendShape.Tangents.Count; ++j)
                             {
-                                blendShape.Tangents[j] = inverter.InvertVector3(blendShape.Tangents[j]);
+                                blendShape.Tangents.Add(inverter.InvertVector3(morphTangents[j]));
                             }
                         }
                     }


### PR DESCRIPTION
#1495

with deep profile
`400ms` => `60ms`

* ループ内の処理を外に出す(後方互換バージョンチェックが重かった。string)
* GCの出る処理(List, LINQなど)を最初に確保して index アクセスに変える。capacity
