### PR TITLE
[SpringBone]非Play時にもSpringのGizmoを表示する

### DIFF
--- a/Assets/VRM/Runtime/SpringBone/VRMSpringBone.cs
+++ b/Assets/VRM/Runtime/SpringBone/VRMSpringBone.cs
@@ -16,8 +16,6 @@ namespace VRM
         [SerializeField]
         public string m_comment;
 
-        [SerializeField] [Header("Gizmo")] private bool m_drawGizmo = default;
-
         [SerializeField] private Color m_gizmoColor = Color.yellow;
 
         [SerializeField]
@@ -320,10 +318,8 @@ namespace VRM
             }
         }
 
-        private void OnDrawGizmos()
+        private void OnDrawGizmosSelected()
         {
-            if (!m_drawGizmo) return;
-
             foreach (var verlet in m_verlet)
             {
                 verlet.DrawGizmo(m_center, m_gizmoColor);

--- a/Assets/VRM/Runtime/SpringBone/VRMSpringBone.cs
+++ b/Assets/VRM/Runtime/SpringBone/VRMSpringBone.cs
@@ -318,11 +318,50 @@ namespace VRM
             }
         }
 
+        void EditorGizmo(Transform head)
+        {
+            Vector3 childPosition;
+            Vector3 scale;
+            if (head.childCount == 0)
+            {
+                // 子ノードが無い。7cm 固定
+                var delta = head.position - head.parent.position;
+                childPosition = head.position + delta.normalized * 0.07f * head.UniformedLossyScale();
+                scale = head.lossyScale;
+            }
+            else
+            {
+                var firstChild = GetChildren(head).First();
+                childPosition = firstChild.position;
+                scale = firstChild.lossyScale;
+            }
+
+            Gizmos.DrawLine(head.position, childPosition);
+            Gizmos.DrawWireSphere(childPosition, m_hitRadius * scale.x);
+
+            foreach (Transform child in head) EditorGizmo(child);
+        }
+
         private void OnDrawGizmosSelected()
         {
-            foreach (var verlet in m_verlet)
+            if (Application.isPlaying)
             {
-                verlet.DrawGizmo(m_center, m_gizmoColor);
+                foreach (var verlet in m_verlet)
+                {
+                    verlet.DrawGizmo(m_center, m_gizmoColor);
+                }
+            }
+            else
+            {
+                // Editor
+                Gizmos.color = m_gizmoColor;
+                foreach (var root in RootBones)
+                {
+                    if (root != null)
+                    {
+                        EditorGizmo(root.transform);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
#1508

* 表示非表示の bool を廃止
* OnDrawGizmosSelected に変更
* `!Application.isPlaying` 時の Gizmo を追加

![springbone_editor_gizmo](https://user-images.githubusercontent.com/68057/154894620-63bf95a9-5d68-4621-8de1-9deb83e71ebf.jpg)

