### PR TITLE
remove `awaitCaller ?? new ImmediateCaller()`

### DIFF
--- a/Assets/UniGLTF/Runtime/MeshUtility/BoneMeshEraser.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/BoneMeshEraser.cs
@@ -143,15 +143,9 @@ namespace UniGLTF.MeshUtility
         {
             if (awaitCaller == null)
             {
-                awaitCaller = new ImmediateCaller();
+                throw new ArgumentNullException();
             }
 
-            /*
-            Debug.LogFormat("{0} exclude: {1}", 
-                src.name,
-                String.Join(", ", eraseBoneIndices.Select(x => x.ToString()).ToArray())
-                );
-            */
             var mesh = new Mesh();
             mesh.name = src.name + "(erased)";
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -75,11 +75,11 @@ namespace UniGLTF
         };
 
         #region Load. Build unity objects
-        public virtual async Task<RuntimeGltfInstance> LoadAsync(IAwaitCaller awaitCaller = null, Func<string, IDisposable> MeasureTime = null)
+        public virtual async Task<RuntimeGltfInstance> LoadAsync(IAwaitCaller awaitCaller, Func<string, IDisposable> MeasureTime = null)
         {
             if (awaitCaller == null)
             {
-                awaitCaller = new ImmediateCaller();
+                throw new ArgumentNullException();
             }
 
             if (MeasureTime == null)
@@ -248,9 +248,12 @@ namespace UniGLTF
             await awaitCaller.NextFrame();
         }
 
-        public async Task LoadTexturesAsync(IAwaitCaller awaitCaller = null)
+        public async Task LoadTexturesAsync(IAwaitCaller awaitCaller)
         {
-            awaitCaller = awaitCaller ?? new ImmediateCaller();
+            if (awaitCaller == null)
+            {
+                throw new ArgumentNullException();
+            }
 
             var textures = TextureDescriptorGenerator.Get().GetEnumerable();
             foreach (var param in textures)
@@ -259,9 +262,12 @@ namespace UniGLTF
             }
         }
 
-        public async Task LoadMaterialsAsync(IAwaitCaller awaitCaller = null)
+        public async Task LoadMaterialsAsync(IAwaitCaller awaitCaller)
         {
-            awaitCaller = awaitCaller ?? new ImmediateCaller();
+            if (awaitCaller == null)
+            {
+                throw new ArgumentNullException();
+            }
 
             if (Data.GLTF.materials == null || Data.GLTF.materials.Count == 0)
             {

--- a/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
@@ -75,7 +75,7 @@ namespace VRM
             //
             // convert images(metallic roughness, occlusion map)
             //
-            var task = m_context.LoadMaterialsAsync();
+            var task = m_context.LoadMaterialsAsync(new ImmediateCaller());
             if (!task.IsCompleted)
             {
                 throw new Exception();
@@ -93,7 +93,7 @@ namespace VRM
             }
 
             // Convert thumbnail image
-            var task2 = m_context.ReadMetaAsync();
+            var task2 = m_context.ReadMetaAsync(new ImmediateCaller());
             if (!task2.IsCompleted || task2.IsCanceled || task2.IsFaulted)
             {
                 throw new Exception();

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -39,7 +39,7 @@ namespace VRM
 
             using (MeasureTime("VRM LoadMeta"))
             {
-                await LoadMetaAsync();
+                await LoadMetaAsync(awaitCaller);
             }
             await awaitCaller.NextFrame();
 
@@ -68,9 +68,13 @@ namespace VRM
             }
         }
 
-        async Task LoadMetaAsync()
+        async Task LoadMetaAsync(IAwaitCaller awaitCaller)
         {
-            var meta = await ReadMetaAsync();
+            if (awaitCaller == null)
+            {
+                throw new ArgumentNullException();
+            }
+            var meta = await ReadMetaAsync(awaitCaller);
             var _meta = Root.AddComponent<VRMMeta>();
             _meta.Meta = meta;
             Meta = meta;
@@ -276,9 +280,12 @@ namespace VRM
         public BlendShapeAvatar BlendShapeAvatar;
         public VRMMetaObject Meta;
 
-        public async Task<VRMMetaObject> ReadMetaAsync(IAwaitCaller awaitCaller = null, bool createThumbnail = false)
+        public async Task<VRMMetaObject> ReadMetaAsync(IAwaitCaller awaitCaller, bool createThumbnail = false)
         {
-            awaitCaller = awaitCaller ?? new ImmediateCaller();
+            if (awaitCaller == null)
+            {
+                throw new ArgumentNullException();
+            }
 
             var meta = ScriptableObject.CreateInstance<VRMMetaObject>();
             meta.name = "Meta";

--- a/Assets/VRM/Runtime/IO/VrmUtility.cs
+++ b/Assets/VRM/Runtime/IO/VrmUtility.cs
@@ -36,7 +36,7 @@ namespace VRM
                     {
                         if (metaCallback != null)
                         {
-                            var meta = await loader.ReadMetaAsync(new ImmediateCaller(), true);
+                            var meta = await loader.ReadMetaAsync(awaitCaller, true);
                             metaCallback(meta);
                         }
                         return await loader.LoadAsync(awaitCaller);

--- a/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
@@ -136,11 +136,11 @@ namespace UniVRM10
         /// <param name="thirdPersonOnlyLayer">layer VRMThirdPersonOnly ir 10</param>
         /// <param name="awaitCaller">Headless mesh creation task scheduler. By default, creation is immediate</param>
         /// <returns></returns>
-        public async Task SetupAsync(GameObject go, bool isSelf = true, int? firstPersonOnlyLayer = default, int? thirdPersonOnlyLayer = default, IAwaitCaller awaitCaller = default)
+        public async Task SetupAsync(GameObject go, IAwaitCaller awaitCaller, bool isSelf = true, int? firstPersonOnlyLayer = default, int? thirdPersonOnlyLayer = default)
         {
             if (awaitCaller == null)
             {
-                awaitCaller = new ImmediateCaller();
+                throw new ArgumentNullException();
             }
 
             var layer = (

--- a/Assets/VRM10/Runtime/IO/Vrm10.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10.cs
@@ -108,9 +108,7 @@ namespace UniVRM10
 
             if (awaitCaller == null)
             {
-                awaitCaller = Application.isPlaying
-                    ? (IAwaitCaller) new RuntimeOnlyAwaitCaller()
-                    : (IAwaitCaller) new ImmediateCaller();
+                throw new ArgumentNullException();
             }
 
             using (var gltfData = new GlbLowLevelParser(name, bytes).Parse())

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -79,9 +79,12 @@ namespace UniVRM10
             }
         }
 
-        public override async Task<RuntimeGltfInstance> LoadAsync(IAwaitCaller awaitCaller = null, Func<string, IDisposable> MeasureTime = null)
+        public override async Task<RuntimeGltfInstance> LoadAsync(IAwaitCaller awaitCaller, Func<string, IDisposable> MeasureTime = null)
         {
-            awaitCaller = awaitCaller ?? new ImmediateCaller();
+            if (awaitCaller == null)
+            {
+                throw new ArgumentNullException();
+            }
 
             // NOTE: VRM データに対して、Load 前に必要なヘビーな変換処理を行う.
             //       ヘビーなため、別スレッドで Run する.

--- a/Assets/VRM_Samples/FirstPersonSample/VRMRuntimeLoader.cs
+++ b/Assets/VRM_Samples/FirstPersonSample/VRMRuntimeLoader.cs
@@ -114,7 +114,7 @@ namespace VRM.FirstPersonSample
             var loaded = default(RuntimeGltfInstance);
             if (m_loadAsync)
             {
-                loaded = await context.LoadAsync();
+                loaded = await context.LoadAsync(new VRMShaders.RuntimeOnlyAwaitCaller());
             }
             else
             {


### PR DESCRIPTION
#1216

引き数 `IAwaitCaller = null` で受けて、

```cs
            if (awaitCaller == null)
            {
                awaitCaller = new ImmediateCaller();
            }
```

としているところをデフォルト引数をやめて、明示的に引数を渡すように変更。

```cs
throw new ArgumentNullException();
```

とした。
