### PR TITLE
UNIGLTF_USE_GAMMA_COLORSPACE

### DIFF
--- a/Assets/UniGLTF/Editor/EditorSettingsValidator/UnityColorSpaceSettingsValidator.cs
+++ b/Assets/UniGLTF/Editor/EditorSettingsValidator/UnityColorSpaceSettingsValidator.cs
@@ -5,12 +5,19 @@ namespace UniGLTF.EditorSettingsValidator
 {
     public sealed class UnityColorSpaceSettingsValidator : IUnitySettingsValidator
     {
-        public bool IsValid => PlayerSettings.colorSpace == UnityEngine.ColorSpace.Linear;
+        public bool IsValid =>
+#if UNIGLTF_USE_GAMMA_COLORSPACE
+                true
+#else
+                PlayerSettings.colorSpace == UnityEngine.ColorSpace.Linear
+#endif
+                ;
+
         public string HeaderDescription => Messages.ColorSpace.Msg();
         public string CurrentValueDescription => PlayerSettings.colorSpace == UnityEngine.ColorSpace.Linear
             ? Messages.ColorSpaceLinear.Msg() : Messages.ColorSpaceGamma.Msg();
         public string RecommendedValueDescription => Messages.ColorSpaceLinear.Msg();
-        
+
         public void Validate()
         {
             PlayerSettings.colorSpace = UnityEngine.ColorSpace.Linear;

--- a/Assets/UniGLTF/Editor/EditorSettingsValidator/UnityEditorSettingsValidatorWindow.cs
+++ b/Assets/UniGLTF/Editor/EditorSettingsValidator/UnityEditorSettingsValidatorWindow.cs
@@ -3,7 +3,6 @@ using UniGLTF.M17N;
 using UnityEditor;
 using UnityEngine;
 
-#if ! VRM_USE_GAMMA
 namespace UniGLTF.EditorSettingsValidator
 {
     [InitializeOnLoad]
@@ -97,4 +96,3 @@ namespace UniGLTF.EditorSettingsValidator
         }
     }
 }
-#endif

--- a/Assets/UniGLTF/Editor/EditorSettingsValidator/UnityEditorSettingsValidatorWindow.cs
+++ b/Assets/UniGLTF/Editor/EditorSettingsValidator/UnityEditorSettingsValidatorWindow.cs
@@ -3,6 +3,7 @@ using UniGLTF.M17N;
 using UnityEditor;
 using UnityEngine;
 
+#if ! VRM_USE_GAMMA
 namespace UniGLTF.EditorSettingsValidator
 {
     [InitializeOnLoad]
@@ -96,3 +97,4 @@ namespace UniGLTF.EditorSettingsValidator
         }
     }
 }
+#endif


### PR DESCRIPTION
#1559

C# シンボル `UNIGLTF_USE_GAMMA_COLORSPACE ` を定義すると、x で閉じると復活しない。

1. シンボルを定義する。Unity 終了(シンボル設定が保存されるように)
2. 設定を Gamma に変える。ダイアログを閉じると復活しません
