### PR TITLE
Fix a error in migrating FirstPerson.

### DIFF
--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -21,14 +21,12 @@ namespace UniVRM10
                     OutputScale = yRangeNode.GetSingle(),
                 };
             }
-            else
+
+            return new LookAtRangeMap
             {
-                return new LookAtRangeMap
-                {
-                    InputMaxValue = defaultXRange,
-                    OutputScale = defaultYRange,
-                };
-            }
+                InputMaxValue = defaultXRange,
+                OutputScale = defaultYRange,
+            };
         }
 
         private static LookAtType MigrateLookAtType(JsonNode vrm0, string key)

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -65,6 +65,17 @@ namespace UniVRM10
             return FirstPersonType.auto;
         }
 
+        private static int? MigrateFirstPersonMeshIndex(JsonNode vrm0, string key, glTF gltf)
+        {
+            if (vrm0.TryGet(key, out var meshIndexNode))
+            {
+                var meshIndex = meshIndexNode.GetInt32();
+                return FindRenderNodeIndexFromMeshIndex(gltf, meshIndex);
+            }
+
+            return default;
+        }
+
         public static (LookAt, FirstPerson) Migrate(glTF gltf, JsonNode vrm0)
         {
             // VRM1
@@ -93,9 +104,7 @@ namespace UniVRM10
             {
                 foreach (var x in meshAnnotationArrayNode.ArrayItems())
                 {
-                    if (!x.TryGet("mesh", out var meshIndexNode)) continue;
-
-                    var renderNodeIndex = FindRenderNodeIndexFromMeshIndex(gltf, meshIndexNode.GetInt32());
+                    var renderNodeIndex = MigrateFirstPersonMeshIndex(x, "mesh", gltf);
                     if (renderNodeIndex.HasValue)
                     {
                         firstPerson.MeshAnnotations.Add(new MeshAnnotation

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -45,9 +45,9 @@ namespace UniVRM10
             return LookAtType.bone;
         }
 
-        private static FirstPersonType MigrateFirstPersonType(JsonNode firstPersonJsonNode, string key)
+        private static FirstPersonType MigrateFirstPersonType(JsonNode meshAnnotationJsonNode, string key)
         {
-            if (firstPersonJsonNode.TryGet(key, out var firstPersonTypeStringJsonNode))
+            if (meshAnnotationJsonNode.TryGet(key, out var firstPersonTypeStringJsonNode))
             {
                 switch (firstPersonTypeStringJsonNode.GetString().ToLowerInvariant())
                 {
@@ -109,17 +109,17 @@ namespace UniVRM10
                 // NOTE: VRM 1.0 では firstPersonBoneOffset は FirstPerson 拡張ではなく LookAt 拡張の OffsetFromHeadBone に移行します.
                 MeshAnnotations = new List<MeshAnnotation>(),
             };
-            if (firstPersonJsonNode.TryGet("meshAnnotations", out var meshAnnotationArrayNode))
+            if (firstPersonJsonNode.TryGet("meshAnnotations", out var meshAnnotationArrayJsonNode))
             {
-                foreach (var x in meshAnnotationArrayNode.ArrayItems())
+                foreach (var meshAnnotationJsonNode in meshAnnotationArrayJsonNode.ArrayItems())
                 {
-                    var renderNodeIndex = MigrateFirstPersonMeshIndex(x, "mesh", gltf);
+                    var renderNodeIndex = MigrateFirstPersonMeshIndex(meshAnnotationJsonNode, "mesh", gltf);
                     if (renderNodeIndex.HasValue)
                     {
                         firstPerson.MeshAnnotations.Add(new MeshAnnotation
                         {
                             Node = renderNodeIndex.Value,
-                            Type = MigrateFirstPersonType(x, "firstPersonFlag"),
+                            Type = MigrateFirstPersonType(meshAnnotationJsonNode, "firstPersonFlag"),
                         });
                     }
                 }

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -1,8 +1,8 @@
-using System;
 using System.Collections.Generic;
 using UniGLTF;
 using UniGLTF.Extensions.VRMC_vrm;
 using UniJSON;
+using UnityEngine;
 
 namespace UniVRM10
 {
@@ -19,15 +19,19 @@ namespace UniVRM10
             };
         }
 
-        static LookAtType MigrateLookAtType(JsonNode vrm0)
+        private static LookAtType MigrateLookAtType(JsonNode vrm0)
         {
-            switch (vrm0.GetString().ToLower())
+            var typeString = vrm0.GetString().ToLowerInvariant();
+            switch (typeString)
             {
-                case "bone": return LookAtType.bone;
-                case "blendshape": return LookAtType.expression;
-
+                case "bone":
+                    return LookAtType.bone;
+                case "blendshape":
+                    return LookAtType.expression;
+                default:
+                    Debug.LogWarning($"Unknown {nameof(LookAtType)}: {typeString}");
+                    return LookAtType.bone;
             }
-            throw new NotImplementedException();
         }
 
         private static FirstPersonType MigrateFirstPersonType(JsonNode vrm0)

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -1,68 +1,86 @@
+using System;
 using System.Collections.Generic;
 using UniGLTF;
 using UniGLTF.Extensions.VRMC_vrm;
 using UniJSON;
-using UnityEngine;
 
 namespace UniVRM10
 {
     public static class MigrationVrmLookAtAndFirstPerson
     {
-        static LookAtRangeMap MigrateLookAtRangeMap(JsonNode vrm0)
+        private static LookAtRangeMap MigrateLookAtRangeMap(JsonNode vrm0, string key, float defaultXRange, float defaultYRange)
         {
-            // VRM1
-            // curve は廃止されます
-            return new LookAtRangeMap
+            // NOTE: Curve は VRM 1.0 では廃止されるため, 考慮しません.
+            if (vrm0.TryGet(key, out var curveMapperNode) &&
+                curveMapperNode.TryGet("xRange", out var xRangeNode) &&
+                curveMapperNode.TryGet("yRange", out var yRangeNode))
             {
-                InputMaxValue = vrm0["xRange"].GetSingle(),
-                OutputScale = vrm0["yRange"].GetSingle(),
-            };
-        }
-
-        private static LookAtType MigrateLookAtType(JsonNode vrm0)
-        {
-            var typeString = vrm0.GetString().ToLowerInvariant();
-            switch (typeString)
+                return new LookAtRangeMap
+                {
+                    InputMaxValue = xRangeNode.GetSingle(),
+                    OutputScale = yRangeNode.GetSingle(),
+                };
+            }
+            else
             {
-                case "bone":
-                    return LookAtType.bone;
-                case "blendshape":
-                    return LookAtType.expression;
-                default:
-                    Debug.LogWarning($"Unknown {nameof(LookAtType)}: {typeString}");
-                    return LookAtType.bone;
+                return new LookAtRangeMap
+                {
+                    InputMaxValue = defaultXRange,
+                    OutputScale = defaultYRange,
+                };
             }
         }
 
-        private static FirstPersonType MigrateFirstPersonType(JsonNode vrm0)
+        private static LookAtType MigrateLookAtType(JsonNode vrm0, string key)
         {
-            switch (vrm0.GetString().ToLowerInvariant())
+            if (vrm0.TryGet(key, out var lookAtTypeStringNode))
             {
-                case "auto":
-                    return FirstPersonType.auto;
-                case "both":
-                    return FirstPersonType.both;
-                case "thirdpersononly":
-                    return FirstPersonType.thirdPersonOnly;
-                case "firstpersononly":
-                    return FirstPersonType.firstPersonOnly;
-                default:
-                    return FirstPersonType.auto;
+                switch (lookAtTypeStringNode.GetString().ToLowerInvariant())
+                {
+                    case "bone":
+                        return LookAtType.bone;
+                    case "blendshape":
+                        return LookAtType.expression;
+                }
             }
+
+            return LookAtType.bone;
+        }
+
+        private static FirstPersonType MigrateFirstPersonType(JsonNode vrm0, string key)
+        {
+            if (vrm0.TryGet(key, out var firstPersonTypeStringNode))
+            {
+                switch (firstPersonTypeStringNode.GetString().ToLowerInvariant())
+                {
+                    case "auto":
+                        return FirstPersonType.auto;
+                    case "both":
+                        return FirstPersonType.both;
+                    case "thirdpersononly":
+                        return FirstPersonType.thirdPersonOnly;
+                    case "firstpersononly":
+                        return FirstPersonType.firstPersonOnly;
+                }
+            }
+
+            return FirstPersonType.auto;
         }
 
         public static (LookAt, FirstPerson) Migrate(glTF gltf, JsonNode vrm0)
         {
             // VRM1
             // firstPerson に同居していた LookAt は独立します
-            LookAt lookAt = default;
-            lookAt = new LookAt
+            var lookAtType = MigrateLookAtType(vrm0, "lookAtTypeName");
+            var defaultXRangeValue = 90f;
+            var defaultYRangeValue = GetDefaultCurveMapperYRangeValue(lookAtType);
+            var lookAt = new LookAt
             {
-                RangeMapHorizontalInner = MigrateLookAtRangeMap(vrm0["lookAtHorizontalInner"]),
-                RangeMapHorizontalOuter = MigrateLookAtRangeMap(vrm0["lookAtHorizontalOuter"]),
-                RangeMapVerticalDown = MigrateLookAtRangeMap(vrm0["lookAtVerticalDown"]),
-                RangeMapVerticalUp = MigrateLookAtRangeMap(vrm0["lookAtVerticalUp"]),
-                Type = MigrateLookAtType(vrm0["lookAtTypeName"]),
+                Type = lookAtType,
+                RangeMapHorizontalInner = MigrateLookAtRangeMap(vrm0, "lookAtHorizontalInner", defaultXRangeValue, defaultYRangeValue),
+                RangeMapHorizontalOuter = MigrateLookAtRangeMap(vrm0, "lookAtHorizontalOuter", defaultXRangeValue, defaultYRangeValue),
+                RangeMapVerticalDown = MigrateLookAtRangeMap(vrm0, "lookAtVerticalDown", defaultXRangeValue, defaultYRangeValue),
+                RangeMapVerticalUp = MigrateLookAtRangeMap(vrm0, "lookAtVerticalUp", defaultXRangeValue, defaultYRangeValue),
                 OffsetFromHeadBone = MigrateVector3.Migrate(vrm0, "firstPersonBoneOffset"),
             };
 
@@ -78,7 +96,6 @@ namespace UniVRM10
                 foreach (var x in meshAnnotationArrayNode.ArrayItems())
                 {
                     if (!x.TryGet("mesh", out var meshIndexNode)) continue;
-                    if (!x.TryGet("firstPersonFlag", out var firstPersonFlagNode)) continue;
 
                     var renderNodeIndex = FindRenderNodeIndexFromMeshIndex(gltf, meshIndexNode.GetInt32());
                     if (renderNodeIndex.HasValue)
@@ -86,7 +103,7 @@ namespace UniVRM10
                         firstPerson.MeshAnnotations.Add(new MeshAnnotation
                         {
                             Node = renderNodeIndex.Value,
-                            Type = MigrateFirstPersonType(firstPersonFlagNode),
+                            Type = MigrateFirstPersonType(x, "firstPersonFlag"),
                         });
                     }
                 }
@@ -108,6 +125,19 @@ namespace UniVRM10
 
             // NOTE: VRM をベースに改造した VRM モデルなど、Renderer の増減に対して FirstPerson の設定が追従しないまま null が出力されていることが多い.
             return default;
+        }
+
+        private static float GetDefaultCurveMapperYRangeValue(LookAtType type)
+        {
+            switch (type)
+            {
+                case LookAtType.bone:
+                    return 10f;
+                case LookAtType.expression:
+                    return 1f;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
+            }
         }
     }
 }

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -65,9 +65,9 @@ namespace UniVRM10
             return FirstPersonType.auto;
         }
 
-        private static int? MigrateFirstPersonMeshIndex(JsonNode firstPersonJsonNode, string key, glTF gltf)
+        private static int? MigrateFirstPersonMeshIndex(JsonNode meshAnnotationJsonNode, string key, glTF gltf)
         {
-            if (firstPersonJsonNode.TryGet(key, out var meshIndexJsonNode))
+            if (meshAnnotationJsonNode.TryGet(key, out var meshIndexJsonNode))
             {
                 var meshIndex = meshIndexJsonNode.GetInt32();
 

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -67,12 +67,20 @@ namespace UniVRM10
 
         private static int? MigrateFirstPersonMeshIndex(JsonNode vrm0, string key, glTF gltf)
         {
-            if (vrm0.TryGet(key, out var meshIndexNode))
+            if (vrm0.TryGet(key, out var meshIndexJsonNode))
             {
-                var meshIndex = meshIndexNode.GetInt32();
-                return FindRenderNodeIndexFromMeshIndex(gltf, meshIndex);
+                var meshIndex = meshIndexJsonNode.GetInt32();
+                for (var gltfNodeIndex = 0; gltfNodeIndex < gltf.nodes.Count; ++gltfNodeIndex)
+                {
+                    var node = gltf.nodes[gltfNodeIndex];
+                    if (node.mesh == meshIndex)
+                    {
+                        return gltfNodeIndex;
+                    }
+                }
             }
 
+            // NOTE: VRM をベースに改造した VRM モデルなど、Renderer の増減に対して FirstPerson の設定が追従しないまま null が出力されていることが多い.
             return default;
         }
 
@@ -117,21 +125,6 @@ namespace UniVRM10
             };
 
             return (lookAt, firstPerson);
-        }
-
-        private static int? FindRenderNodeIndexFromMeshIndex(glTF gltf, int meshIndex)
-        {
-            for (var i = 0; i < gltf.nodes.Count; ++i)
-            {
-                var node = gltf.nodes[i];
-                if (node.mesh == meshIndex)
-                {
-                    return i;
-                }
-            }
-
-            // NOTE: VRM をベースに改造した VRM モデルなど、Renderer の増減に対して FirstPerson の設定が追従しないまま null が出力されていることが多い.
-            return default;
         }
 
         private static float GetDefaultCurveMapperYRangeValue(LookAtType type)

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -29,9 +29,21 @@ namespace UniVRM10
             throw new NotImplementedException();
         }
 
-        static FirstPersonType MigrateFirstPersonType(JsonNode vrm0)
+        private static FirstPersonType MigrateFirstPersonType(JsonNode vrm0)
         {
-            return (FirstPersonType)Enum.Parse(typeof(FirstPersonType), vrm0.GetString(), true);
+            switch (vrm0.GetString().ToLowerInvariant())
+            {
+                case "auto":
+                    return FirstPersonType.auto;
+                case "both":
+                    return FirstPersonType.both;
+                case "thirdpersononly":
+                    return FirstPersonType.thirdPersonOnly;
+                case "firstpersononly":
+                    return FirstPersonType.firstPersonOnly;
+                default:
+                    return FirstPersonType.auto;
+            }
         }
 
         public static (LookAt, FirstPerson) Migrate(glTF gltf, JsonNode vrm0)

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UniGLTF;
 using UniGLTF.Extensions.VRMC_vrm;
 using UniJSON;
@@ -66,19 +67,22 @@ namespace UniVRM10
                 // VRM1
                 // firstPersonBoneOffset は廃止されます。LookAt.OffsetFromHeadBone を使ってください。
                 // firstPersonBone は廃止されます。Head 固定です。
-                MeshAnnotations = new System.Collections.Generic.List<MeshAnnotation>(),
+                MeshAnnotations = new List<MeshAnnotation>(),
             };
-            if (vrm0.TryGet("meshAnnotations", out JsonNode meshAnnotations))
+            if (vrm0.TryGet("meshAnnotations", out var meshAnnotationArrayNode))
             {
-                foreach (var x in meshAnnotations.ArrayItems())
+                foreach (var x in meshAnnotationArrayNode.ArrayItems())
                 {
-                    var renderNodeIndex = FindRenderNodeIndexFromMeshIndex(gltf, x["mesh"].GetInt32());
+                    if (!x.TryGet("mesh", out var meshIndexNode)) continue;
+                    if (!x.TryGet("firstPersonFlag", out var firstPersonFlagNode)) continue;
+
+                    var renderNodeIndex = FindRenderNodeIndexFromMeshIndex(gltf, meshIndexNode.GetInt32());
                     if (renderNodeIndex.HasValue)
                     {
                         firstPerson.MeshAnnotations.Add(new MeshAnnotation
                         {
                             Node = renderNodeIndex.Value,
-                            Type = MigrateFirstPersonType(x["firstPersonFlag"]),
+                            Type = MigrateFirstPersonType(firstPersonFlagNode),
                         });
                     }
                 }


### PR DESCRIPTION
`throw new NotImplementedException("mesh is not used");`

に到達するモデルでマイグレーションが失敗していました。
このようなモデルは、VRM ファイルを入力に改造した VRM ファイルなどにおいて
Renderer の数が増減しているにもかかわらず FirstPerson の設定を変更し忘れていた場合に
過去の UniVRM で出力しえたようです。

またこのマイグレーションにおいて null アクセスがありえた部分をすべて TryGet に直しました。