### PR TITLE
Added ExportSetting to allow HideFlags ins MeshFilters

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfExportSettings.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfExportSettings.cs
@@ -1,6 +1,7 @@
 
 
 using System;
+using UnityEngine;
 
 namespace UniGLTF
 {
@@ -45,5 +46,12 @@ namespace UniGLTF
         /// Keep VertexColor
         /// </summary>
         public bool KeepVertexColor;
+
+        /// <summary>
+        /// https://github.com/vrm-c/UniVRM/issues/1582
+        /// 
+        /// Allowed hide flags for MeshFilters to be exported
+        /// </summary>
+        public HideFlags MeshFilterAllowedHideFlags = HideFlags.None;
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportInfo.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportInfo.cs
@@ -202,7 +202,7 @@ namespace UniGLTF
             else if (renderer is MeshRenderer mr)
             {
                 var filter = mr.GetComponent<MeshFilter>();
-                if (filter != null && filter.hideFlags == HideFlags.None)
+                if (filter != null && settings.MeshFilterAllowedHideFlags.HasFlag(filter.hideFlags))
                 {
                     if (filter.sharedMesh != null && filter.sharedMesh.vertexCount > 0)
                     {


### PR DESCRIPTION
As described in issue https://github.com/vrm-c/UniVRM/issues/1582 I added an export setting that allows for MeshFilters with HideFlags to be also be catalogued for the runtime export.
It does not change anything if not specifically set in ExportSettings, as the standard value for the setting keeps the status quo as is.
This also enables the use of ProBuilderMeshes.