### PR TITLE
Fix10/divided migration

### DIFF
--- a/Assets/VRM10/Runtime/Migration/MeshUpdater.cs
+++ b/Assets/VRM10/Runtime/Migration/MeshUpdater.cs
@@ -64,6 +64,12 @@ namespace UniVRM10
             public int? Normal;
         };
 
+        /// <summary>
+        /// bufferView, accessor を push することで bin を再構築する
+        /// (meshの右手左手変換結果の適用など)
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
         public (glTF, ArraySegment<byte>) Update(VrmLib.Model model)
         {
             var gltf = _data.GLTF;
@@ -75,6 +81,7 @@ namespace UniVRM10
                 image.bufferView = AddBuffer(bytes);
             }
 
+            // copy mesh
             if (model.MeshGroups.All(x => x.Meshes.Count == 1))
             {
                 UpdateSharedVertexBuffer(model);
@@ -154,11 +161,16 @@ namespace UniVRM10
 
         }
 
+        /// <summary>
+        /// model はひとつのノードに複数の mesh をぶら下げることができる(meshGroup)
+        /// gltf.meshes[i].primitives[j] <-> model.meshGroups[i].meshes[0].submeshes[j]
+        /// </summary>
+        /// <param name="model"></param>
         void UpdateSharedVertexBuffer(VrmLib.Model model)
         {
             var gltf = _data.GLTF;
 
-            // update Mesh
+            // gltfMeshes[i] <=> MeshGroups[i].Meshes[0] ( MeshGroups[i].Meshes.Count == 1 )
             foreach (var (gltfMesh, mesh) in Enumerable.Zip(gltf.meshes, model.MeshGroups, (l, r) => (l, r.Meshes[0])))
             {
                 NativeArray<uint> indices;
@@ -207,6 +219,7 @@ namespace UniVRM10
                     }).ToArray();
                 }
 
+                // gltfPrim[j] <=> mesh.Submeshes[j]
                 foreach (var (gltfPrim, submesh) in Enumerable.Zip(gltfMesh.primitives, mesh.Submeshes, (l, r) => (l, r)))
                 {
                     var subIndices = indices.GetSubArray(submesh.Offset, submesh.DrawCount);
@@ -229,11 +242,85 @@ namespace UniVRM10
             }
         }
 
+        /// <summary>
+        /// model はひとつのノードに複数の mesh をぶら下げることができる(meshGroup)
+        /// gltf.meshes[i].primitives[j] <-> model.meshGroups[i].meshes[j].submeshes[0]
+        /// </summary>
+        /// <param name="model"></param>
         void UpdateDividedVertexBuffer(VrmLib.Model model)
         {
             var gltf = _data.GLTF;
 
-            throw new NotImplementedException();
+            // gltfMesh[i] <=> meshGroups[i]
+            foreach (var (gltfMesh, meshGroup) in Enumerable.Zip(gltf.meshes, model.MeshGroups, (l, r) => (l, r)))
+            {
+                // gltfPrimitives[j] <=> meshGroup.Meshes[j] (meshGroup.Meshes[j].Submeshes.Count==1)
+                foreach (var (gltfPrim, mesh) in Enumerable.Zip(gltfMesh.primitives, meshGroup.Meshes, (l, r) => (l, r)))
+                {
+                    NativeArray<uint> indices;
+                    switch (mesh.IndexBuffer.Stride)
+                    {
+                        case 1:
+                            {
+                                // byte
+                                var byte_indices = mesh.IndexBuffer.GetSpan<byte>();
+                                indices = _data.NativeArrayManager.Convert(byte_indices, (byte x) => (uint)x);
+                                break;
+                            }
+
+                        case 2:
+                            {
+                                // ushort
+                                var ushort_indices = mesh.IndexBuffer.GetSpan<ushort>();
+                                indices = _data.NativeArrayManager.Convert(ushort_indices, (ushort x) => (uint)x);
+                                break;
+                            }
+
+                        case 4:
+                            {
+                                // uint
+                                indices = mesh.IndexBuffer.GetSpan<uint>();
+                                break;
+                            }
+
+                        default:
+                            throw new NotImplementedException();
+                    }
+
+                    var position = AddAccessor<Vector3>(mesh.VertexBuffer.Positions);
+                    var normal = AddAccessor<Vector3>(mesh.VertexBuffer.Normals);
+                    var uv = AddAccessor<Vector2>(mesh.VertexBuffer.TexCoords);
+                    var weights = AddAccessor<Vector4>(mesh.VertexBuffer.Weights);
+                    var joints = AddAccessor<UShort4>(mesh.VertexBuffer.Joints);
+                    var color = AddAccessor<Vector4>(mesh.VertexBuffer.Colors);
+
+                    var morphTargets = new MorphAccessor[] { };
+                    if (mesh.MorphTargets != null)
+                    {
+                        morphTargets = mesh.MorphTargets.Select(x => new MorphAccessor
+                        {
+                            Position = AddAccessor<Vector3>(x.VertexBuffer.Positions),
+                            Normal = AddAccessor<Vector3>(x.VertexBuffer.Normals),
+                        }).ToArray();
+                    }
+
+                    gltfPrim.indices = AddAccessor(indices);
+                    gltfPrim.attributes.POSITION = position.Value;
+                    gltfPrim.attributes.NORMAL = normal.GetValueOrDefault(-1); // たぶん、ありえる
+                    gltfPrim.attributes.TANGENT = -1;
+                    gltfPrim.attributes.COLOR_0 = color.GetValueOrDefault(-1);
+                    gltfPrim.attributes.TEXCOORD_0 = uv.GetValueOrDefault(-1); // ありえる？
+                    gltfPrim.attributes.TEXCOORD_1 = -1;
+                    gltfPrim.attributes.WEIGHTS_0 = weights.GetValueOrDefault(-1);
+                    gltfPrim.attributes.JOINTS_0 = joints.GetValueOrDefault(-1);
+                    foreach (var (gltfMorph, morph) in Enumerable.Zip(gltfPrim.targets, morphTargets, (l, r) => (l, r)))
+                    {
+                        gltfMorph.POSITION = morph.Position.GetValueOrDefault(-1);
+                        gltfMorph.NORMAL = morph.Normal.GetValueOrDefault(-1);
+                        gltfMorph.TANGENT = -1;
+                    }
+                }
+            }
         }
     }
 }

--- a/Assets/VRM10/Runtime/Migration/MigrationVrm.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrm.cs
@@ -38,7 +38,7 @@ namespace UniVRM10
             // Unity -> VRM1
             model.ConvertCoordinate(VrmLib.Coordinates.Vrm1);
 
-            var (gltf, bin) = new MeshUpdater(data).Update(model);
+            var (gltf, bin) = MeshUpdater.Execute(data, model);
             gltf.extensions = null;
             return MigrateVrm(gltf, bin, data.Json.ParseAsJson()["extensions"]["VRM"]);
         }


### PR DESCRIPTION
#1597
DividedVertexBuffer 様式の vrm-0.x に対するマイグレーションが未実装だった。
実装しました。

GLTF-2.0 には submesh 概念が無いのです(gltfPrimitiveは違う概念)。
