### PR TITLE
Unity公式モジュールの依存関係が不足している問題を修正

### DIFF
--- a/Assets/UniGLTF/package.json
+++ b/Assets/UniGLTF/package.json
@@ -11,6 +11,7 @@
     "name": "VRM Consortium"
   },
   "dependencies": {
-    "com.vrmc.vrmshaders": "0.97.0"
+    "com.vrmc.vrmshaders": "0.97.0",
+    "com.unity.modules.animation": "1.0.0"
   }
 }

--- a/Assets/VRM/package.json
+++ b/Assets/VRM/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "com.vrmc.vrmshaders": "0.97.0",
-    "com.vrmc.gltf": "0.97.0"
+    "com.vrmc.gltf": "0.97.0",
+    "com.unity.ugui": "1.0.0"
   },
   "samples": [
     {

--- a/Assets/VRMShaders/package.json
+++ b/Assets/VRMShaders/package.json
@@ -10,5 +10,8 @@
   ],
   "author": {
     "name": "VRM Consortium"
+  },
+  "dependencies": {
+    "com.unity.modules.imageconversion": "1.0.0"
   }
 }


### PR DESCRIPTION
# 概要
以下のパッケージでUnity公式モジュールの依存関係が不足していたので追加しました。
* UniGLTF
* VRM
* VRMShaders

# 詳細
## 再現方法
リポジトリ直下にプロジェクトを作成して、manifest.jsonを以下のように設定します。
``` json
{
  "dependencies": {
    "com.vrmc.gltf": "file:../../Assets/UniGLTF",
    "com.vrmc.univrm": "file:../../Assets/VRM",
    "com.vrmc.vrm": "file:../../Assets/VRM10",
    "com.vrmc.vrmshaders": "file:../../Assets/VRMShaders"
  }
}
```
この状態でプロジェクトを開くと次のようなエラーが出ます

### UniGLTF
com.unity.modules.animationに依存している箇所のエラーの例
```
C:\Users\mkc1370\src\UniVRM\Assets\UniGLTF\Runtime\UniHumanoid\AnimationClipUtility.cs(53,70): error CS1069: The type name 'HumanPose' could not be found in the namespace 'UnityEngine'. This type has been forwarded to assembly 'UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' Enable the built in package 'Animation' in the Package Manager window to fix this error.
```

### VRM
com.unity.uguiに依存している箇所のエラーの例
```
C:\Users\mkc1370\src\UniVRM\Assets\VRM\Runtime\FirstPerson\VRMFirstPersonCameraManager.cs(4,19): error CS0234: The type or namespace name 'UI' does not exist in the namespace 'UnityEngine' (are you missing an assembly reference?)
```

### VRMShaders
com.unity.modules.imageconversionに依存している箇所のエラーの例
```
C:\Users\mkc1370\src\UniVRM\Assets\VRMShaders\GLTF\IO\Runtime\Texture\Importer\UnityTextureDeserializer.cs(28,25): error CS1061: 'Texture2D' does not contain a definition for 'LoadImage' and no accessible extension method 'LoadImage' accepting a first argument of type 'Texture2D' could be found (are you missing a using directive or an assembly reference?)
```

## 解決策
以下のようにモジュールへの依存関係を追加しました
* UniGLTF
com.unity.modules.animation 1.0.0
* VRM
com.unity.ugui 1.0.0
* VRMShaders
com.unity.modules.imageconversion 1.0.0