### PR TITLE
シーン構成によっては、稀にエラーになるっぽい？

### DIFF
--- a/Assets/UniGLTF/Runtime/MeshUtility/BoneNormalizer.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/BoneNormalizer.cs
@@ -424,7 +424,10 @@ namespace UniGLTF.MeshUtility
             dstRenderer.sharedMaterials = srcRenderer.sharedMaterials;
             if (srcRenderer.rootBone != null)
             {
-                dstRenderer.rootBone = boneMap[srcRenderer.rootBone];
+                if (boneMap.TryGetValue(srcRenderer.rootBone, out Transform found))
+                {
+                    dstRenderer.rootBone = found;
+                }
             }
             dstRenderer.bones = dstBones;
             dstRenderer.sharedMesh = mesh;


### PR DESCRIPTION
#1592

例えば、エクスポート対象ヒエラルキーの外部の GameObject が rootBone セットされている
