### PR TITLE
[1.0] migration のエラーハンドリングを修正

### DIFF
--- a/Assets/VRM10/Runtime/IO/Vrm10Data.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Data.cs
@@ -65,11 +65,21 @@ namespace UniVRM10
             }
 
             // try migrate...
-            var migrated = MigrationVrm.Migrate(data);
-            if (migrated == null)
+            byte[] migrated = null;
+            try
+            {
+                migrated = MigrationVrm.Migrate(data);
+                if (migrated == null)
+                {
+                    vrm1Data = default;
+                    migration = new MigrationData("Found vrm0. But fail to migrate", oldMeta);
+                    return null;
+                }
+            }
+            catch (Exception ex)
             {
                 vrm1Data = default;
-                migration = new MigrationData("Found vrm0. But fail to migrate", oldMeta);
+                migration = new MigrationData(ex.Message, oldMeta);
                 return null;
             }
 

--- a/Assets/VRM10/Runtime/IO/Vrm10Data.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Data.cs
@@ -76,8 +76,16 @@ namespace UniVRM10
                     return null;
                 }
             }
+            catch (MigrationException ex)
+            {
+                // migration 失敗
+                vrm1Data = default;
+                migration = new MigrationData(ex.Message, oldMeta);
+                return null;
+            }
             catch (Exception ex)
             {
+                // その他のエラー
                 vrm1Data = default;
                 migration = new MigrationData(ex.Message, oldMeta);
                 return null;

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
@@ -171,8 +171,9 @@ namespace UniVRM10
                 }
                 else
                 {
-                    // different otherLicenseUrl & otherPermissionUrl
-                    throw new MigrationException("otherPermissionUrl", "can not migrate");
+                    // https://github.com/vrm-c/UniVRM/issues/1611
+                    // 両方を記述しエラーとしない
+                    meta.OtherLicenseUrl = $"'{otherLicenseUrl}', '{otherPermissionUrl}'";
                 }
             }
             else if (!string.IsNullOrEmpty(otherLicenseUrl))


### PR DESCRIPTION
* Migration 中発生したエラーを catch して message 表示(Editor)
* otherLicenseUrl と otherPermissionUrl 両方を記述しエラーにしない対応
