### PR TITLE
change (1.0, constraint): Change max range of weights to 1.0

### DIFF
--- a/Assets/VRM10/Runtime/Components/Constraint/Vrm10AimConstraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/Vrm10AimConstraint.cs
@@ -16,7 +16,7 @@ namespace UniVRM10
         public Transform Source = default;
 
         [SerializeField]
-        [Range(0, 10.0f)]
+        [Range(0, 1.0f)]
         public float Weight = 1.0f;
 
         [SerializeField]

--- a/Assets/VRM10/Runtime/Components/Constraint/Vrm10RollConstraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/Vrm10RollConstraint.cs
@@ -16,7 +16,7 @@ namespace UniVRM10
         public Transform Source = default;
 
         [SerializeField]
-        [Range(0, 10.0f)]
+        [Range(0, 1.0f)]
         public float Weight = 1.0f;
 
         [SerializeField]

--- a/Assets/VRM10/Runtime/Components/Constraint/Vrm10RotationConstraint.cs
+++ b/Assets/VRM10/Runtime/Components/Constraint/Vrm10RotationConstraint.cs
@@ -14,7 +14,7 @@ namespace UniVRM10
         public Transform Source = default;
 
         [SerializeField]
-        [Range(0, 10.0f)]
+        [Range(0, 1.0f)]
         public float Weight = 1.0f;
 
         Quaternion _srcRestLocalQuatInverse;


### PR DESCRIPTION
### Description

改めて、コンストレイント対応ありがとうございました！

現状、仕様ではweightの最大値は1.0となっているので、UI上もこれに従うのが良いと思います。

See: https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_node_constraint-1.0_draft/README.ja.md#weight
