### PR TITLE
Disable WebGl color space check

### DIFF
--- a/Assets/UniGLTF/Editor/EditorSettingsValidator/UnityEditorSettingsValidatorWindow.cs
+++ b/Assets/UniGLTF/Editor/EditorSettingsValidator/UnityEditorSettingsValidatorWindow.cs
@@ -12,7 +12,9 @@ namespace UniGLTF.EditorSettingsValidator
 
         static UnityEditorSettingsValidatorWindow()
         {
+#if !UNITY_WEBGL
             EditorApplication.update += Validate;
+#endif
         }
 
         private static void Validate()
@@ -26,7 +28,9 @@ namespace UniGLTF.EditorSettingsValidator
 
         private void OnProjectChange()
         {
+#if !UNITY_WEBGL
             Validate();
+#endif
         }
 
         private void OnGUI()


### PR DESCRIPTION
Because WebGL not support Liner Color Space.
Execute Liner check will block build on WebGL Platform

[colorspaceをgammaに設定するとLinearに設定変更を促すダイアログが表示され閉じることができなくなる ](https://github.com/vrm-c/UniVRM/issues/1559)