### PR TITLE
Ignore duplicated UV expression in migration.

### DIFF
--- a/Assets/VRM10/Runtime/Components/Expression/MaterialValueBindingMerger.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/MaterialValueBindingMerger.cs
@@ -231,21 +231,9 @@ namespace UniVRM10
         {
             {"Standard", new string[]{
                 "_MainTex_ST",
-                "_BumpMap_ST",
-                "_EmissionMap_ST",
-                "_MetallicGlossMap_ST",
-                "_ParallaxMap_ST",
             }},
             {"VRM10/MToon10", new string[]{
                 "_MainTex_ST",
-                "_ShadeTexture_ST",
-                "_BumpMap_ST",
-                "_EmissionMap_ST",
-                "_OutlineWidthTexture_ST",
-                "_ReceiveShadowTexture_ST",
-                "_RimTexture_ST",
-                "_ShadingGradeTexture_ST",
-                "_UvAnimMaskTexture_ST",
             }},
         };
         static string[] DefaultProps = { "_MainTex_ST" };

--- a/Assets/VRM10/Runtime/IO/Vrm10Data.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Data.cs
@@ -34,7 +34,7 @@ namespace UniVRM10
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="data"></param>
         /// <param name="vrm1Data"></param>
@@ -80,21 +80,21 @@ namespace UniVRM10
             {
                 // migration 失敗
                 vrm1Data = default;
-                migration = new MigrationData(ex.Message, oldMeta);
+                migration = new MigrationData(ex.ToString(), oldMeta);
                 return null;
             }
             catch (Exception ex)
             {
                 // その他のエラー
                 vrm1Data = default;
-                migration = new MigrationData(ex.Message, oldMeta);
+                migration = new MigrationData(ex.ToString(), oldMeta);
                 return null;
             }
 
             byte[] debugCopy = null;
             if (VRMShaders.Symbols.VRM_DEVELOP)
             {
-                // load 時の右手左手座標変換でバッファが破壊的変更されるので、コピーを作っている        
+                // load 時の右手左手座標変換でバッファが破壊的変更されるので、コピーを作っている
                 debugCopy = migrated.Select(x => x).ToArray();
             }
 


### PR DESCRIPTION
VRM 0.x -> VRM 1.0 の Migration 時、UV Scale/Offset の Expression 値が多重に登録されてしまうバグを修正。

仕様により、TextureTransformBind は事実上、Material に対してただ一つのみしか存在しない。

https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0-beta/expressions.ja.md#texturetransformbind