### PR TITLE
KHR_materials_emissive_strength を実装

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/KHR_materials_emissive_strength.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/KHR_materials_emissive_strength.cs
@@ -1,0 +1,53 @@
+using System;
+using UniJSON;
+
+namespace UniGLTF
+{
+    /// <summary>
+    /// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_emissive_strength
+    /// </summary>
+    [Serializable]
+    public class glTF_KHR_materials_emissive_strength
+    {
+        public const string ExtensionName = "KHR_materials_emissive_strength";
+        public static readonly Utf8String ExtensionNameUtf8 = Utf8String.From(ExtensionName);
+        public float emissiveStrength = 1.0f;
+
+        static glTF_KHR_materials_emissive_strength Deserialize(JsonNode json)
+        {
+            var extension = new glTF_KHR_materials_emissive_strength();
+            if (json.TryGet(nameof(emissiveStrength), out JsonNode found))
+            {
+                extension.emissiveStrength = found.GetSingle();
+            }
+            return extension;
+        }
+
+        public static bool TryGet(glTFExtension src, out glTF_KHR_materials_emissive_strength extension)
+        {
+            if (src is UniGLTF.glTFExtensionImport extensions)
+            {
+                foreach (var kv in extensions.ObjectItems())
+                {
+                    if (kv.Key.GetUtf8String() == ExtensionNameUtf8)
+                    {
+                        extension = Deserialize(kv.Value);
+                        return true;
+                    }
+                }
+            }
+            extension = default;
+            return false;
+        }
+
+        public static void Serialize(ref glTFExtension materialExtensions, float value)
+        {
+            var f = new JsonFormatter();
+            f.BeginMap();
+            f.Key(nameof(emissiveStrength));
+            f.Value(value);
+            f.EndMap();
+            glTFExtensionExport.GetOrCreate(ref materialExtensions).Add(ExtensionName, f.GetStore().Bytes);
+        }
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/KHR_materials_emissive_strength.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/KHR_materials_emissive_strength.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6a65b35aabda73408a522a2ef8e6a13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/KHR_materials_unlit.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/KHR_materials_unlit.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using UniJSON;
 
 namespace UniGLTF
@@ -43,9 +42,17 @@ namespace UniGLTF
             return false;
         }
 
-        public static glTFExtension Serialize()
+        public static void Serialize(ref glTFExtension materialExtensions)
         {
-            return new glTFExtensionExport().Add(ExtensionName, new ArraySegment<byte>(Raw));
+            glTFExtensionExport.GetOrCreate(ref materialExtensions).Add(ExtensionName, new ArraySegment<byte>(Raw));
+        }
+
+        public static glTFExtensionImport ForTest()
+        {
+            var extensionExport = new glTFExtensionExport();
+            glTFExtension extension = extensionExport;
+            glTF_KHR_materials_unlit.Serialize(ref extension);
+            return extensionExport.Deserialize();
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfExportSettings.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfExportSettings.cs
@@ -38,11 +38,6 @@ namespace UniGLTF
         ;
 
         /// <summary>
-        /// VRMC_materials_hdr_emissiveMultiplier
-        /// </summary>
-        public bool UseEmissiveMultiplier;
-
-        /// <summary>
         /// Keep VertexColor
         /// </summary>
         public bool KeepVertexColor;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfPbrMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfPbrMaterialImporter.cs
@@ -136,7 +136,11 @@ namespace UniGLTF
                 if (src.emissiveFactor != null && src.emissiveFactor.Length == 3)
                 {
                     var emissiveFactor = src.emissiveFactor.ToColor3(ColorSpace.Linear, ColorSpace.Linear);
-                    if (UniGLTF.Extensions.VRMC_materials_hdr_emissiveMultiplier.GltfDeserializer.TryGet(src.extensions,
+                    if (UniGLTF.glTF_KHR_materials_emissive_strength.TryGet(src.extensions, out UniGLTF.glTF_KHR_materials_emissive_strength emissiveStrength))
+                    {
+                        emissiveFactor *= emissiveStrength.emissiveStrength;
+                    }
+                    else if (UniGLTF.Extensions.VRMC_materials_hdr_emissiveMultiplier.GltfDeserializer.TryGet(src.extensions,
                         out UniGLTF.Extensions.VRMC_materials_hdr_emissiveMultiplier.
                             VRMC_materials_hdr_emissiveMultiplier ex))
                     {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/MaterialExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/MaterialExporter.cs
@@ -23,7 +23,7 @@ namespace UniGLTF
             // common params
             material.name = m.name;
             Export_Color(m, textureExporter, material);
-            Export_Emission(m, textureExporter, material, settings.UseEmissiveMultiplier);
+            Export_Emission(m, textureExporter, material);
             Export_Normal(m, textureExporter, material);
             Export_OcclusionMetallicRoughness(m, textureExporter, material);
 
@@ -154,7 +154,7 @@ namespace UniGLTF
             }
         }
 
-        static void Export_Emission(Material m, ITextureExporter textureExporter, glTFMaterial material, bool useEmissiveMultiplier)
+        static void Export_Emission(Material m, ITextureExporter textureExporter, glTFMaterial material)
         {
             if (m.IsKeywordEnabled("_EMISSION") == false)
             {
@@ -168,14 +168,7 @@ namespace UniGLTF
                 {
                     var maxColorComponent = color.maxColorComponent;
                     color /= maxColorComponent;
-                    if (useEmissiveMultiplier)
-                    {
-                        UniGLTF.Extensions.VRMC_materials_hdr_emissiveMultiplier.GltfSerializer.SerializeTo(ref material.extensions,
-                        new Extensions.VRMC_materials_hdr_emissiveMultiplier.VRMC_materials_hdr_emissiveMultiplier
-                        {
-                            EmissiveMultiplier = maxColorComponent,
-                        });
-                    }
+                    UniGLTF.glTF_KHR_materials_emissive_strength.Serialize(ref material.extensions, maxColorComponent);
                 }
                 material.emissiveFactor = color.ToFloat3(ColorSpace.Linear, ColorSpace.Linear);
             }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/GltfPbrURPMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/GltfPbrURPMaterialImporter.cs
@@ -110,7 +110,12 @@ namespace UniGLTF
                 if (src.emissiveFactor != null && src.emissiveFactor.Length == 3)
                 {
                     var emissiveFactor = src.emissiveFactor.ToColor3(ColorSpace.Linear, ColorSpace.Linear);
-                    if (UniGLTF.Extensions.VRMC_materials_hdr_emissiveMultiplier.GltfDeserializer.TryGet(src.extensions,
+                    if (UniGLTF.glTF_KHR_materials_emissive_strength.TryGet(src.extensions,
+                        out UniGLTF.glTF_KHR_materials_emissive_strength emissiveStrength))
+                    {
+                        emissiveFactor *= emissiveStrength.emissiveStrength;
+                    }
+                    else if (UniGLTF.Extensions.VRMC_materials_hdr_emissiveMultiplier.GltfDeserializer.TryGet(src.extensions,
                         out UniGLTF.Extensions.VRMC_materials_hdr_emissiveMultiplier.VRMC_materials_hdr_emissiveMultiplier ex))
                     {
                         emissiveFactor *= ex.EmissiveMultiplier.Value;
@@ -175,7 +180,7 @@ namespace UniGLTF
 
             matDesc = new MaterialDescriptor(
                 GltfMaterialDescriptorGenerator.GetMaterialName(i, src),
-                ShaderName, 
+                ShaderName,
                 null,
                 textureSlots,
                 floatValues,

--- a/Assets/UniGLTF/Tests/UniGLTF/MaterialTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/MaterialTests.cs
@@ -61,8 +61,8 @@ namespace UniGLTF
             }
 
             {
-                var extension = glTF_KHR_materials_unlit.Serialize().Deserialize();
-                var list = extension.ObjectItems().ToArray();
+                var extension = glTF_KHR_materials_unlit.ForTest();
+                var list = extension.Deserialize().ObjectItems().ToArray();
                 Assert.AreEqual(1, list.Length);
                 Assert.AreEqual(glTF_KHR_materials_unlit.ExtensionNameUtf8, list[0].Key.GetUtf8String());
                 Assert.AreEqual(0, list[0].Value.GetObjectCount());
@@ -95,7 +95,7 @@ namespace UniGLTF
                     {
                         baseColorFactor = new float[] { 1, 0, 0, 1 },
                     },
-                    extensions = glTF_KHR_materials_unlit.Serialize().Deserialize(),
+                    extensions = glTF_KHR_materials_unlit.ForTest(),
                 };
                 Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
             }
@@ -112,7 +112,7 @@ namespace UniGLTF
                             index = 0,
                         },
                     },
-                    extensions = glTF_KHR_materials_unlit.Serialize().Deserialize(),
+                    extensions = glTF_KHR_materials_unlit.ForTest(),
                 };
                 Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
             }
@@ -130,7 +130,7 @@ namespace UniGLTF
                             index = 0
                         },
                     },
-                    extensions = glTF_KHR_materials_unlit.Serialize().Deserialize(),
+                    extensions = glTF_KHR_materials_unlit.ForTest(),
                 };
                 Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
             }
@@ -144,7 +144,7 @@ namespace UniGLTF
                     {
                         baseColorFactor = new float[] { 1, 0, 0, 1 },
                     },
-                    extensions = glTF_KHR_materials_unlit.Serialize().Deserialize(),
+                    extensions = glTF_KHR_materials_unlit.ForTest(),
                 };
                 Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
             }
@@ -161,7 +161,7 @@ namespace UniGLTF
                             index = 0,
                         },
                     },
-                    extensions = glTF_KHR_materials_unlit.Serialize().Deserialize(),
+                    extensions = glTF_KHR_materials_unlit.ForTest(),
                 };
                 Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
             }
@@ -179,7 +179,7 @@ namespace UniGLTF
                             index = 0,
                         },
                     },
-                    extensions = glTF_KHR_materials_unlit.Serialize().Deserialize(),
+                    extensions = glTF_KHR_materials_unlit.ForTest(),
                 };
                 Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
             }
@@ -196,7 +196,7 @@ namespace UniGLTF
                             index = 0,
                         },
                     },
-                    extensions = glTF_KHR_materials_unlit.Serialize().Deserialize(),
+                    extensions = glTF_KHR_materials_unlit.ForTest(),
                 };
                 Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
             }
@@ -214,7 +214,7 @@ namespace UniGLTF
                             index = 0,
                         },
                     },
-                    extensions = glTF_KHR_materials_unlit.Serialize().Deserialize(),
+                    extensions = glTF_KHR_materials_unlit.ForTest(),
                 };
                 Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
             }
@@ -223,8 +223,17 @@ namespace UniGLTF
                 // default
                 var gltfMaterial = new glTFMaterial
                 {
-                    extensions = glTF_KHR_materials_unlit.Serialize().Deserialize(),
+                    extensions = glTF_KHR_materials_unlit.ForTest(),
                 };
+                Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
+            }
+
+            {
+                // emission
+                var gltfMaterial = new glTFMaterial
+                {
+                };
+                glTF_KHR_materials_unlit.ForTest();
                 Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
             }
         }

--- a/Assets/UniGLTF/Tests/UniGLTF/MaterialTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/MaterialTests.cs
@@ -227,15 +227,22 @@ namespace UniGLTF
                 };
                 Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
             }
+        }
 
-            {
-                // emission
-                var gltfMaterial = new glTFMaterial
-                {
-                };
-                glTF_KHR_materials_unlit.ForTest();
-                Assert.IsTrue(glTF_KHR_materials_unlit.IsEnable(gltfMaterial));
-            }
+        [Test]
+        public void MaterialEmissiveStrengthTest()
+        {
+            // serialize
+            var material = new glTFMaterial();
+            glTF_KHR_materials_emissive_strength.Serialize(ref material.extensions, 5.0f);
+            var json = material.ToJson();
+            var parsed = json.ParseAsJson();
+            Assert.AreEqual(parsed["extensions"]["KHR_materials_emissive_strength"]["emissiveStrength"].GetSingle(), 5.0f);
+
+            // deserialize
+            var imported = GltfDeserializer.Deserialize_gltf_materials_ITEM(parsed);
+            Assert.True(glTF_KHR_materials_emissive_strength.TryGet(imported.extensions, out glTF_KHR_materials_emissive_strength extension));
+            Assert.AreEqual(extension.emissiveStrength, 5.0f);
         }
 
         [Test]


### PR DESCRIPTION
https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_emissive_strength

の実装です。



