### PR TITLE
image.uri から mime を決定する

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs
@@ -339,12 +339,16 @@ namespace UniGLTF
             {
                 return null;
             }
-            var ext = System.IO.Path.GetExtension(uri).ToLower();
+            var ext = System.IO.Path.GetExtension(uri).ToLowerInvariant();
             switch (ext)
             {
-                case ".png": return "image/png";
-                case ".jpg": return "image/jpeg";
-                default: return null;
+                case ".png":
+                    return "image/png";
+                case ".jpg":
+                case ".jpeg":
+                    return "image/jpeg";
+                default:
+                    return null;
             }
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs
@@ -333,6 +333,21 @@ namespace UniGLTF
             return result;
         }
 
+        static string GuessMimeFromUri(string uri)
+        {
+            if (string.IsNullOrEmpty(uri))
+            {
+                return null;
+            }
+            var ext = System.IO.Path.GetExtension(uri).ToLower();
+            switch (ext)
+            {
+                case ".png": return "image/png";
+                case ".jpg": return "image/jpeg";
+                default: return null;
+            }
+        }
+
         public (NativeArray<byte> binary, string mimeType)? GetBytesFromImage(int imageIndex)
         {
             if (imageIndex < 0 || imageIndex >= GLTF.images.Count) return default;
@@ -340,11 +355,13 @@ namespace UniGLTF
             var image = GLTF.images[imageIndex];
             if (string.IsNullOrEmpty(image.uri))
             {
+                // use bufferView(glb)
                 return (GetBytesFromBufferView(image.bufferView), image.mimeType);
             }
             else
             {
-                return (GetBytesFromUri(image.uri), image.mimeType);
+                // use uri(gltf)
+                return (GetBytesFromUri(image.uri), image.mimeType ?? GuessMimeFromUri(image.uri));
             }
         }
 


### PR DESCRIPTION
警告 `Texture image MIME type `{textureInfo.DataMimeType}` is not supported.` の防止。


https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#images

glb のときは mime を省略不可。
> a reference to a bufferView; in that case mimeType MUST be defined.
