### PR TITLE
fix Property PROP_NAME already exists in the property sheet with a different type: 5

### DIFF
--- a/Assets/VRM/Runtime/IO/VRMMToonMaterialImporter.cs
+++ b/Assets/VRM/Runtime/IO/VRMMToonMaterialImporter.cs
@@ -9,7 +9,7 @@ namespace VRM
 {
     public static class VRMMToonMaterialImporter
     {
-        static string[] MToonTextureSolots = new string[]{
+        static string[] MToonTextureSlots = new string[]{
             "_MainTex",
             "_ShadeTexture",
             "_BumpMap",
@@ -74,7 +74,7 @@ namespace VRM
             foreach (var kv in vrmMaterial.vectorProperties)
             {
                 // vector4 exclude TextureOffsetScale
-                if (MToonTextureSolots.Contains(kv.Key))
+                if (MToonTextureSlots.Contains(kv.Key))
                 {
                     continue;
                 }

--- a/Assets/VRM/Runtime/IO/VRMMToonMaterialImporter.cs
+++ b/Assets/VRM/Runtime/IO/VRMMToonMaterialImporter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using UniGLTF;
 using UnityEngine;
 using VRMShaders;
@@ -8,6 +9,19 @@ namespace VRM
 {
     public static class VRMMToonMaterialImporter
     {
+        static string[] MToonTextureSolots = new string[]{
+            "_MainTex",
+            "_ShadeTexture",
+            "_BumpMap",
+            "_EmissionMap",
+            "_OutlineWidthTexture",
+            "_ReceiveShadowTexture",
+            "_RimTexture",
+            "_ShadingGradeTexture",
+            "_SphereAdd",
+            "_UvAnimMaskTexture",
+        };
+
         public static bool TryCreateParam(GltfData data, glTF_VRM_extensions vrm, int materialIdx,
             out MaterialDescriptor matDesc)
         {
@@ -60,7 +74,10 @@ namespace VRM
             foreach (var kv in vrmMaterial.vectorProperties)
             {
                 // vector4 exclude TextureOffsetScale
-                if (vrmMaterial.textureProperties.ContainsKey(kv.Key)) continue;
+                if (MToonTextureSolots.Contains(kv.Key))
+                {
+                    continue;
+                }
                 var v = new Vector4(kv.Value[0], kv.Value[1], kv.Value[2], kv.Value[3]);
                 vectors.Add(kv.Key, v);
             }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialFactory.cs
@@ -140,10 +140,16 @@ namespace VRMShaders
                 material.SetColor(kv.Key, kv.Value);
             }
 
-            foreach (var kv in matDesc.Vectors)
-            {
-                material.SetVector(kv.Key, kv.Value);
-            }
+            // Unity-2021 くらいから offset, scale を SetVector すると
+            // `Property PROP_NAME already exists in the property sheet with a different type: 5` というエラーが発生するようになった。
+            // Material.SetTextureOffset と SetTextureScale を使うべし。
+            // 上方の SetTextureOffsetAndScale で既に対処済みです。
+            // よってエラーになる下記をコメントアウトする。
+            // MToon において offset, scale 以外の用途で Vector4 になる property はありません。
+            // foreach (var kv in matDesc.Vectors)
+            // {
+            //     material.SetVector(kv.Key, kv.Value);
+            // }
 
             foreach (var kv in matDesc.FloatValues)
             {

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -140,16 +141,10 @@ namespace VRMShaders
                 material.SetColor(kv.Key, kv.Value);
             }
 
-            // Unity-2021 くらいから offset, scale を SetVector すると
-            // `Property PROP_NAME already exists in the property sheet with a different type: 5` というエラーが発生するようになった。
-            // Material.SetTextureOffset と SetTextureScale を使うべし。
-            // 上方の SetTextureOffsetAndScale で既に対処済みです。
-            // よってエラーになる下記をコメントアウトする。
-            // MToon において offset, scale 以外の用途で Vector4 になる property はありません。
-            // foreach (var kv in matDesc.Vectors)
-            // {
-            //     material.SetVector(kv.Key, kv.Value);
-            // }
+            foreach (var kv in matDesc.Vectors)
+            {
+                material.SetVector(kv.Key, kv.Value);
+            }
 
             foreach (var kv in matDesc.FloatValues)
             {


### PR DESCRIPTION
Unity-2021 では SetVector により offset, scale をセットするとエラー Property PROP_NAME already exists in the property sheet with a different type: 5 が発生する。

#1680 では Unity-2020 で発生とのことで、どのバージョンから発生するか詳細は不明。
Unity-2019 では発生していない。
