### PR TITLE
MeshUtility.SeparationProcessing を public にする

### DIFF
--- a/Assets/UniGLTF/Editor/MeshUtility/TabMeshSeparator.cs
+++ b/Assets/UniGLTF/Editor/MeshUtility/TabMeshSeparator.cs
@@ -104,7 +104,7 @@ namespace UniGLTF.MeshUtility
         /// </summary>
         /// <param name="go"></param>
         /// <return>(Mesh 分割前, Mesh BlendShape有り、Mesh BlendShape無し)のリストを返す</return>
-        private static List<(Mesh Src, Mesh With, Mesh Without)> SeparationProcessing(GameObject go)
+        public static List<(Mesh Src, Mesh With, Mesh Without)> SeparationProcessing(GameObject go)
         {
             var list = new List<(Mesh Src, Mesh With, Mesh Without)>();
             var skinnedMeshRenderers = go.GetComponentsInChildren<SkinnedMeshRenderer>();

--- a/Assets/UniGLTF/Runtime/UniGLTF/UniGLTFVersion.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/UniGLTFVersion.cs
@@ -5,7 +5,7 @@ namespace UniGLTF
     {
         public const int MAJOR = 2;
         public const int MINOR = 35;
-        public const int PATCH = 0;
-        public const string VERSION = "2.35.0";
+        public const int PATCH = 1;
+        public const string VERSION = "2.35.1";
     }
 }

--- a/Assets/UniGLTF/package.json
+++ b/Assets/UniGLTF/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.vrmc.gltf",
-  "version": "0.99.0",
+  "version": "0.99.1",
   "displayName": "UniGLTF",
   "description": "GLTF importer and exporter",
   "unity": "2019.4",
@@ -11,6 +11,6 @@
     "name": "VRM Consortium"
   },
   "dependencies": {
-    "com.vrmc.vrmshaders": "0.99.0"
+    "com.vrmc.vrmshaders": "0.99.1"
   }
 }

--- a/Assets/VRM/Runtime/Format/VRMVersion.cs
+++ b/Assets/VRM/Runtime/Format/VRMVersion.cs
@@ -5,7 +5,7 @@ namespace VRM
     {
         public const int MAJOR = 0;
         public const int MINOR = 99;
-        public const int PATCH = 0;
-        public const string VERSION = "0.99.0";
+        public const int PATCH = 1;
+        public const string VERSION = "0.99.1";
     }
 }

--- a/Assets/VRM/Samples~/BlendShapeMenu/BlendShapeMenu.cs
+++ b/Assets/VRM/Samples~/BlendShapeMenu/BlendShapeMenu.cs
@@ -78,6 +78,7 @@ namespace VRM.Sample.BlendShapeMenu
             return "Assets" + src.Substring(Application.dataPath.Length);
         }
 
+#if UNITY_EDITOR
         [MenuItem("CONTEXT/BlendShapeAvatar/Add ARKit FaceTracking BlendShapes")]
         public static void AddARKitFaceTrackingBlendShapes(MenuCommand command)
         {
@@ -176,5 +177,6 @@ namespace VRM.Sample.BlendShapeMenu
 
             Debug.Log($"Assign\n" + sb.ToString());
         }
+#endif
     }
 }

--- a/Assets/VRM/package.json
+++ b/Assets/VRM/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.vrmc.univrm",
-  "version": "0.99.0",
+  "version": "0.99.1",
   "displayName": "VRM",
   "description": "VRM importer",
   "unity": "2019.4",
@@ -14,8 +14,8 @@
     "name": "VRM Consortium"
   },
   "dependencies": {
-    "com.vrmc.vrmshaders": "0.99.0",
-    "com.vrmc.gltf": "0.99.0"
+    "com.vrmc.vrmshaders": "0.99.1",
+    "com.vrmc.gltf": "0.99.1"
   },
   "samples": [
     {

--- a/Assets/VRM10/package.json
+++ b/Assets/VRM10/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.vrmc.vrm",
-  "version": "0.99.0",
+  "version": "0.99.1",
   "displayName": "VRM-1.0β",
   "description": "VRM-1.0β importer",
   "unity": "2019.4",
@@ -14,8 +14,8 @@
     "name": "VRM Consortium"
   },
   "dependencies": {
-    "com.vrmc.vrmshaders": "0.99.0",
-    "com.vrmc.gltf": "0.99.0"
+    "com.vrmc.vrmshaders": "0.99.1",
+    "com.vrmc.gltf": "0.99.1"
   },
   "samples": [
     {

--- a/Assets/VRMShaders/package.json
+++ b/Assets/VRMShaders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.vrmc.vrmshaders",
-  "version": "0.99.0",
+  "version": "0.99.1",
   "displayName": "VRM Shaders",
   "description": "VRM Shaders",
   "unity": "2019.4",


### PR DESCRIPTION
`v0.100` から最低バージョンを `Unity-2020` にするので、マイナーバージョンにします。
