### PR TITLE
ScriptedImporterAttribute.overrideExts の使い方が間違っていた

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GlbScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GlbScriptedImporter.cs
@@ -8,7 +8,11 @@ using UnityEditor.Experimental.AssetImporters;
 namespace UniGLTF
 {
 #if UNITY_2020_2_OR_NEWER
+#if UNIGLTF_DISABLE_DEFAULT_GLB_IMPORTER
     [ScriptedImporter(1, null, overrideExts: new[] { "glb" })]
+#else
+    [ScriptedImporter(1, new[] { "glb" })]
+#endif
 #else
 	[ScriptedImporter(1, new[] { "glb" })]
 #endif

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporter.cs
@@ -8,7 +8,11 @@ using UnityEditor.Experimental.AssetImporters;
 namespace UniGLTF
 {
 #if UNITY_2020_2_OR_NEWER
+#if UNIGLTF_DISABLE_DEFAULT_GLTF_IMPORTER
     [ScriptedImporter(1, null, overrideExts: new[] { "gltf" })]
+#else
+    [ScriptedImporter(1, new[] { "gltf" })]
+#endif
 #else
 	[ScriptedImporter(1, new[] { "gltf" })]
 #endif


### PR DESCRIPTION
* 新規の glb/gltf を asset に投入したときに、importer が発動しなくなっていた