### PR TITLE
SpringBoneの剛性が意図しない方向に働くことがある問題を修正

### DIFF
--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UniVRM10.FastSpringBones.Blittables;
@@ -15,6 +16,8 @@ namespace UniVRM10
         private readonly IVrm10Constraint[] m_constraints;
         private readonly Transform m_head;
         private readonly FastSpringBoneService m_fastSpringBoneService;
+        private readonly Dictionary<Transform, Quaternion> m_initialLocalRotations = new Dictionary<Transform, Quaternion>();
+        private readonly bool m_initialized;
 
         private FastSpringBoneBuffer m_fastSpringBoneBuffer;
 
@@ -51,6 +54,7 @@ namespace UniVRM10
             m_fastSpringBoneService = FastSpringBoneService.Instance;
             m_fastSpringBoneBuffer = CreateFastSpringBoneBuffer(m_target.SpringBone);
             m_fastSpringBoneService.BufferCombiner.Register(m_fastSpringBoneBuffer);
+            m_initialized = true;
         }
 
         /// <summary>
@@ -97,7 +101,11 @@ namespace UniVRM10
                             gravityDir = joint.m_gravityDir,
                             gravityPower = joint.m_gravityPower,
                             stiffnessForce = joint.m_stiffnessForce
-                        }
+                        },
+                        InitialLocalRotation = 
+                            m_initialized && m_initialLocalRotations.TryGetValue(joint.transform, out var initialLocalRotation)
+                                ? initialLocalRotation
+                                : m_initialLocalRotations[joint.transform] = joint.transform.localRotation
                     }).ToArray(),
                 }).ToArray());
         }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -112,9 +112,19 @@ namespace UniVRM10
                             gravityDir = joint.m_gravityDir,
                             gravityPower = joint.m_gravityPower,
                             stiffnessForce = joint.m_stiffnessForce
-                        }
+                        },
+                        DefaultLocalRotation = GetOrAddDefaultTransformState(joint.transform).rotation
                     }).ToArray(),
                 }).ToArray());
+        }
+
+        private (Vector3 position, Quaternion rotation) GetOrAddDefaultTransformState(Transform tf)
+        {
+            if (m_defaultTransformStates.TryGetValue(tf, out var defaultTransformState))
+            {
+                return defaultTransformState;
+            }
+            return m_defaultTransformStates[tf] = (tf.position, tf.rotation);
         }
 
         private static BlittableColliderType TranslateColliderType(VRM10SpringBoneColliderTypes colliderType)

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UniVRM10.FastSpringBones.Blittables;
@@ -16,8 +15,6 @@ namespace UniVRM10
         private readonly IVrm10Constraint[] m_constraints;
         private readonly Transform m_head;
         private readonly FastSpringBoneService m_fastSpringBoneService;
-        private readonly Dictionary<Transform, Quaternion> m_initialLocalRotations = new Dictionary<Transform, Quaternion>();
-        private readonly bool m_initialized;
 
         private FastSpringBoneBuffer m_fastSpringBoneBuffer;
 
@@ -54,7 +51,6 @@ namespace UniVRM10
             m_fastSpringBoneService = FastSpringBoneService.Instance;
             m_fastSpringBoneBuffer = CreateFastSpringBoneBuffer(m_target.SpringBone);
             m_fastSpringBoneService.BufferCombiner.Register(m_fastSpringBoneBuffer);
-            m_initialized = true;
         }
 
         /// <summary>
@@ -101,11 +97,7 @@ namespace UniVRM10
                             gravityDir = joint.m_gravityDir,
                             gravityPower = joint.m_gravityPower,
                             stiffnessForce = joint.m_stiffnessForce
-                        },
-                        InitialLocalRotation = 
-                            m_initialized && m_initialLocalRotations.TryGetValue(joint.transform, out var initialLocalRotation)
-                                ? initialLocalRotation
-                                : m_initialLocalRotations[joint.transform] = joint.transform.localRotation
+                        }
                     }).ToArray(),
                 }).ToArray());
         }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using UniGLTF;
 using UnityEngine;
 using UniVRM10.FastSpringBones.Blittables;
 using UniVRM10.FastSpringBones.System;
@@ -15,6 +17,7 @@ namespace UniVRM10
         private readonly IVrm10Constraint[] m_constraints;
         private readonly Transform m_head;
         private readonly FastSpringBoneService m_fastSpringBoneService;
+        private readonly Dictionary<Transform, (Vector3 position, Quaternion rotation)> m_defaultTransformStates;
 
         private FastSpringBoneBuffer m_fastSpringBoneBuffer;
 
@@ -46,6 +49,18 @@ namespace UniVRM10
             {
                 // for UnitTest
                 return;
+            }
+            
+            var instance = target.GetComponent<RuntimeGltfInstance>();
+            if (instance != null)
+            {
+                // ランタイムインポートならここに到達してほぼゼロコストになる
+                m_defaultTransformStates = instance.Nodes.ToDictionary(tf=> tf, tf=>(tf.position, tf.rotation));
+            }
+            else
+            {
+                // エディタでプレハブ配置してる奴ならこっちに到達して収集する
+                m_defaultTransformStates = target.GetComponentsInChildren<Transform>().ToDictionary(tf=> tf, tf=>(tf.position, tf.rotation));
             }
 
             m_fastSpringBoneService = FastSpringBoneService.Instance;

--- a/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneBuffer.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneBuffer.cs
@@ -108,7 +108,7 @@ namespace UniVRM10.FastSpringBones.System
                         parentTransformIndex = parent != null ? transformIndexDictionary[parent] : -1,
                         currentTail = currentTail,
                         prevTail = currentTail,
-                        localRotation = joint.Transform.localRotation,
+                        localRotation = joint.DefaultLocalRotation,
                         boneAxis = localChildPosition.normalized,
                         length = localChildPosition.magnitude
                     });

--- a/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneBuffer.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneBuffer.cs
@@ -108,7 +108,7 @@ namespace UniVRM10.FastSpringBones.System
                         parentTransformIndex = parent != null ? transformIndexDictionary[parent] : -1,
                         currentTail = currentTail,
                         prevTail = currentTail,
-                        localRotation = joint.Transform.localRotation,
+                        localRotation = joint.InitialLocalRotation,
                         boneAxis = localChildPosition.normalized,
                         length = localChildPosition.magnitude
                     });

--- a/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneBuffer.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneBuffer.cs
@@ -108,7 +108,7 @@ namespace UniVRM10.FastSpringBones.System
                         parentTransformIndex = parent != null ? transformIndexDictionary[parent] : -1,
                         currentTail = currentTail,
                         prevTail = currentTail,
-                        localRotation = joint.InitialLocalRotation,
+                        localRotation = joint.Transform.localRotation,
                         boneAxis = localChildPosition.normalized,
                         length = localChildPosition.magnitude
                     });

--- a/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneJoint.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneJoint.cs
@@ -9,6 +9,5 @@ namespace UniVRM10.FastSpringBones.System
     {
         public Transform Transform;
         public BlittableJoint Joint;
-        public Quaternion InitialLocalRotation;
     }
 }

--- a/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneJoint.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneJoint.cs
@@ -9,5 +9,6 @@ namespace UniVRM10.FastSpringBones.System
     {
         public Transform Transform;
         public BlittableJoint Joint;
+        public Quaternion InitialLocalRotation;
     }
 }

--- a/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneJoint.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/InputPorts/FastSpringBoneJoint.cs
@@ -9,5 +9,6 @@ namespace UniVRM10.FastSpringBones.System
     {
         public Transform Transform;
         public BlittableJoint Joint;
+        public Quaternion DefaultLocalRotation;
     }
 }


### PR DESCRIPTION
`Vrm10Runtime.ReconstructSpringBone()` を呼ぶと、呼んだ時点のSpringBoneの変形した形状を維持する方向に剛性が働くようになってしまう問題を修正しました。