### PR TITLE
[1.0] 親指のボーン名を metacarpal, proximal, distal に変更

### DIFF
--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -50,6 +50,20 @@ namespace UniVRM10
         [SerializeField]
         public VRM10ObjectLookAt.LookAtTargetTypes LookAtTargetType;
 
+        UniHumanoid.Humanoid m_humanoid;
+
+        public UniHumanoid.Humanoid Humanoid
+        {
+            get
+            {
+                if (m_humanoid == null)
+                {
+                    m_humanoid = GetComponent<UniHumanoid.Humanoid>();
+                }
+                return m_humanoid;
+            }
+        }
+
         Vrm10Runtime m_runtime;
 
         /// <summary>
@@ -110,6 +124,16 @@ namespace UniVRM10
                     Gizmos.DrawWireSphere(tail.transform.position, head.m_jointRadius);
                 }
             }
+        }
+
+        public bool TryGetBoneTransform(HumanBodyBones bone, out Transform t)
+        {
+            t = Humanoid.GetBoneTransform(bone);
+            if (t == null)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -27,14 +27,12 @@ namespace UniVRM10
         public Vrm10Runtime(Vrm10Instance target)
         {
             m_target = target;
-            var animator = target.GetComponent<Animator>();
-            if (animator == null)
+
+            if (!target.TryGetBoneTransform(HumanBodyBones.Head, out m_head))
             {
                 throw new Exception();
             }
-
-            m_head = animator.GetBoneTransform(HumanBodyBones.Head);
-            m_lookat = new Vrm10RuntimeLookAt(target.Vrm.LookAt, animator, m_head, target.LookAtTargetType, target.Gaze);
+            m_lookat = new Vrm10RuntimeLookAt(target.Vrm.LookAt, target.Humanoid, m_head, target.LookAtTargetType, target.Gaze);
             m_expression = new Vrm10RuntimeExpression(target, m_lookat, m_lookat.EyeDirectionApplicable);
 
             if (m_constraints == null)

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace UniVRM10
 {
-    public class Vrm10RuntimeLookAt: ILookAtEyeDirectionProvider
+    public class Vrm10RuntimeLookAt : ILookAtEyeDirectionProvider
     {
         VRM10ObjectLookAt m_lookat;
 
@@ -85,13 +85,13 @@ namespace UniVRM10
             throw new NotImplementedException();
         }
 
-        internal Vrm10RuntimeLookAt(VRM10ObjectLookAt lookat, Animator animator, Transform head, VRM10ObjectLookAt.LookAtTargetTypes lookAtTargetType, Transform gaze)
+        internal Vrm10RuntimeLookAt(VRM10ObjectLookAt lookat, UniHumanoid.Humanoid humanoid, Transform head, VRM10ObjectLookAt.LookAtTargetTypes lookAtTargetType, Transform gaze)
         {
             m_lookat = lookat;
 
             m_head = head;
-            m_leftEye = animator.GetBoneTransform(HumanBodyBones.LeftEye);
-            m_rightEye = animator.GetBoneTransform(HumanBodyBones.RightEye);
+            m_leftEye = humanoid.GetBoneTransform(HumanBodyBones.LeftEye);
+            m_rightEye = humanoid.GetBoneTransform(HumanBodyBones.RightEye);
 
             var isRuntimeAsset = true;
 #if UNITY_EDITOR
@@ -122,6 +122,5 @@ namespace UniVRM10
             var (yaw, pitch) = GetLookAtYawPitch(m_head, lookAtTargetType, gaze);
             EyeDirection = new LookAtEyeDirection(yaw, pitch, 0, 0);
         }
-
     }
 }

--- a/Assets/VRM10/Runtime/Format/Vrm/Deserializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/Vrm/Deserializer.g.cs
@@ -378,13 +378,13 @@ public static HumanBones __humanoid_Deserialize_HumanBones(JsonNode parsed)
             continue;
         }
 
-        if(key=="leftThumbProximal"){
-            value.LeftThumbProximal = __humanoid__humanBones_Deserialize_LeftThumbProximal(kv.Value);
+        if(key=="leftThumbMetacarpal"){
+            value.LeftThumbMetacarpal = __humanoid__humanBones_Deserialize_LeftThumbMetacarpal(kv.Value);
             continue;
         }
 
-        if(key=="leftThumbIntermediate"){
-            value.LeftThumbIntermediate = __humanoid__humanBones_Deserialize_LeftThumbIntermediate(kv.Value);
+        if(key=="leftThumbProximal"){
+            value.LeftThumbProximal = __humanoid__humanBones_Deserialize_LeftThumbProximal(kv.Value);
             continue;
         }
 
@@ -453,13 +453,13 @@ public static HumanBones __humanoid_Deserialize_HumanBones(JsonNode parsed)
             continue;
         }
 
-        if(key=="rightThumbProximal"){
-            value.RightThumbProximal = __humanoid__humanBones_Deserialize_RightThumbProximal(kv.Value);
+        if(key=="rightThumbMetacarpal"){
+            value.RightThumbMetacarpal = __humanoid__humanBones_Deserialize_RightThumbMetacarpal(kv.Value);
             continue;
         }
 
-        if(key=="rightThumbIntermediate"){
-            value.RightThumbIntermediate = __humanoid__humanBones_Deserialize_RightThumbIntermediate(kv.Value);
+        if(key=="rightThumbProximal"){
+            value.RightThumbProximal = __humanoid__humanBones_Deserialize_RightThumbProximal(kv.Value);
             continue;
         }
 
@@ -1207,7 +1207,7 @@ public static HumanBone __humanoid__humanBones_Deserialize_RightHand(JsonNode pa
     return value;
 }
 
-public static HumanBone __humanoid__humanBones_Deserialize_LeftThumbProximal(JsonNode parsed)
+public static HumanBone __humanoid__humanBones_Deserialize_LeftThumbMetacarpal(JsonNode parsed)
 {
     var value = new HumanBone();
 
@@ -1234,7 +1234,7 @@ public static HumanBone __humanoid__humanBones_Deserialize_LeftThumbProximal(Jso
     return value;
 }
 
-public static HumanBone __humanoid__humanBones_Deserialize_LeftThumbIntermediate(JsonNode parsed)
+public static HumanBone __humanoid__humanBones_Deserialize_LeftThumbProximal(JsonNode parsed)
 {
     var value = new HumanBone();
 
@@ -1612,7 +1612,7 @@ public static HumanBone __humanoid__humanBones_Deserialize_LeftLittleDistal(Json
     return value;
 }
 
-public static HumanBone __humanoid__humanBones_Deserialize_RightThumbProximal(JsonNode parsed)
+public static HumanBone __humanoid__humanBones_Deserialize_RightThumbMetacarpal(JsonNode parsed)
 {
     var value = new HumanBone();
 
@@ -1639,7 +1639,7 @@ public static HumanBone __humanoid__humanBones_Deserialize_RightThumbProximal(Js
     return value;
 }
 
-public static HumanBone __humanoid__humanBones_Deserialize_RightThumbIntermediate(JsonNode parsed)
+public static HumanBone __humanoid__humanBones_Deserialize_RightThumbProximal(JsonNode parsed)
 {
     var value = new HumanBone();
 

--- a/Assets/VRM10/Runtime/Format/Vrm/Format.g.cs
+++ b/Assets/VRM10/Runtime/Format/Vrm/Format.g.cs
@@ -193,10 +193,10 @@ namespace UniGLTF.Extensions.VRMC_vrm
         public HumanBone RightHand;
 
         // Represents a single bone of a Humanoid.
-        public HumanBone LeftThumbProximal;
+        public HumanBone LeftThumbMetacarpal;
 
         // Represents a single bone of a Humanoid.
-        public HumanBone LeftThumbIntermediate;
+        public HumanBone LeftThumbProximal;
 
         // Represents a single bone of a Humanoid.
         public HumanBone LeftThumbDistal;
@@ -238,10 +238,10 @@ namespace UniGLTF.Extensions.VRMC_vrm
         public HumanBone LeftLittleDistal;
 
         // Represents a single bone of a Humanoid.
-        public HumanBone RightThumbProximal;
+        public HumanBone RightThumbMetacarpal;
 
         // Represents a single bone of a Humanoid.
-        public HumanBone RightThumbIntermediate;
+        public HumanBone RightThumbProximal;
 
         // Represents a single bone of a Humanoid.
         public HumanBone RightThumbDistal;

--- a/Assets/VRM10/Runtime/Format/Vrm/Serializer.g.cs
+++ b/Assets/VRM10/Runtime/Format/Vrm/Serializer.g.cs
@@ -366,14 +366,14 @@ public static void __humanoid_Serialize_HumanBones(JsonFormatter f, HumanBones v
         __humanoid__humanBones_Serialize_RightHand(f, value.RightHand);
     }
 
+    if(value.LeftThumbMetacarpal!=null){
+        f.Key("leftThumbMetacarpal");                
+        __humanoid__humanBones_Serialize_LeftThumbMetacarpal(f, value.LeftThumbMetacarpal);
+    }
+
     if(value.LeftThumbProximal!=null){
         f.Key("leftThumbProximal");                
         __humanoid__humanBones_Serialize_LeftThumbProximal(f, value.LeftThumbProximal);
-    }
-
-    if(value.LeftThumbIntermediate!=null){
-        f.Key("leftThumbIntermediate");                
-        __humanoid__humanBones_Serialize_LeftThumbIntermediate(f, value.LeftThumbIntermediate);
     }
 
     if(value.LeftThumbDistal!=null){
@@ -441,14 +441,14 @@ public static void __humanoid_Serialize_HumanBones(JsonFormatter f, HumanBones v
         __humanoid__humanBones_Serialize_LeftLittleDistal(f, value.LeftLittleDistal);
     }
 
+    if(value.RightThumbMetacarpal!=null){
+        f.Key("rightThumbMetacarpal");                
+        __humanoid__humanBones_Serialize_RightThumbMetacarpal(f, value.RightThumbMetacarpal);
+    }
+
     if(value.RightThumbProximal!=null){
         f.Key("rightThumbProximal");                
         __humanoid__humanBones_Serialize_RightThumbProximal(f, value.RightThumbProximal);
-    }
-
-    if(value.RightThumbIntermediate!=null){
-        f.Key("rightThumbIntermediate");                
-        __humanoid__humanBones_Serialize_RightThumbIntermediate(f, value.RightThumbIntermediate);
     }
 
     if(value.RightThumbDistal!=null){
@@ -1094,7 +1094,7 @@ public static void __humanoid__humanBones_Serialize_RightHand(JsonFormatter f, H
     f.EndMap();
 }
 
-public static void __humanoid__humanBones_Serialize_LeftThumbProximal(JsonFormatter f, HumanBone value)
+public static void __humanoid__humanBones_Serialize_LeftThumbMetacarpal(JsonFormatter f, HumanBone value)
 {
     f.BeginMap();
 
@@ -1117,7 +1117,7 @@ public static void __humanoid__humanBones_Serialize_LeftThumbProximal(JsonFormat
     f.EndMap();
 }
 
-public static void __humanoid__humanBones_Serialize_LeftThumbIntermediate(JsonFormatter f, HumanBone value)
+public static void __humanoid__humanBones_Serialize_LeftThumbProximal(JsonFormatter f, HumanBone value)
 {
     f.BeginMap();
 
@@ -1439,7 +1439,7 @@ public static void __humanoid__humanBones_Serialize_LeftLittleDistal(JsonFormatt
     f.EndMap();
 }
 
-public static void __humanoid__humanBones_Serialize_RightThumbProximal(JsonFormatter f, HumanBone value)
+public static void __humanoid__humanBones_Serialize_RightThumbMetacarpal(JsonFormatter f, HumanBone value)
 {
     f.BeginMap();
 
@@ -1462,7 +1462,7 @@ public static void __humanoid__humanBones_Serialize_RightThumbProximal(JsonForma
     f.EndMap();
 }
 
-public static void __humanoid__humanBones_Serialize_RightThumbIntermediate(JsonFormatter f, HumanBone value)
+public static void __humanoid__humanBones_Serialize_RightThumbProximal(JsonFormatter f, HumanBone value)
 {
     f.BeginMap();
 

--- a/Assets/VRM10/Runtime/IO/Model/ModelExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/ModelExporter.cs
@@ -45,7 +45,15 @@ namespace UniVRM10
                     var transform = humanoid.GetBoneTransform(humanBoneType);
                     if (transform != null && Nodes.TryGetValue(transform.gameObject, out VrmLib.Node node))
                     {
-                        node.HumanoidBone = (VrmLib.HumanoidBones)Enum.Parse(typeof(VrmLib.HumanoidBones), humanBoneType.ToString(), true);
+                        switch (humanBoneType)
+                        {
+                            // https://github.com/vrm-c/vrm-specification/issues/380
+                            case HumanBodyBones.LeftThumbProximal: node.HumanoidBone = VrmLib.HumanoidBones.leftThumbMetacarpal; break;
+                            case HumanBodyBones.LeftThumbIntermediate: node.HumanoidBone = VrmLib.HumanoidBones.leftThumbProximal; break;
+                            case HumanBodyBones.RightThumbProximal: node.HumanoidBone = VrmLib.HumanoidBones.rightThumbMetacarpal; break;
+                            case HumanBodyBones.RightThumbIntermediate: node.HumanoidBone = VrmLib.HumanoidBones.rightThumbProximal; break;
+                            default: node.HumanoidBone = (VrmLib.HumanoidBones)Enum.Parse(typeof(VrmLib.HumanoidBones), humanBoneType.ToString(), true); break;
+                        }
                     }
                 }
             }

--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -709,111 +709,58 @@ namespace UniVRM10
                 {
                     case HumanoidBones.hips: vrm.Humanoid.HumanBones.Hips = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
                     case HumanoidBones.spine: vrm.Humanoid.HumanBones.Spine = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.chest: vrm.Humanoid.HumanBones.Chest = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.upperChest: vrm.Humanoid.HumanBones.UpperChest = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.neck: vrm.Humanoid.HumanBones.Neck = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.head: vrm.Humanoid.HumanBones.Head = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftEye: vrm.Humanoid.HumanBones.LeftEye = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightEye: vrm.Humanoid.HumanBones.RightEye = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.jaw: vrm.Humanoid.HumanBones.Jaw = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftUpperLeg: vrm.Humanoid.HumanBones.LeftUpperLeg = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftLowerLeg: vrm.Humanoid.HumanBones.LeftLowerLeg = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftFoot: vrm.Humanoid.HumanBones.LeftFoot = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftToes: vrm.Humanoid.HumanBones.LeftToes = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightUpperLeg: vrm.Humanoid.HumanBones.RightUpperLeg = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightLowerLeg: vrm.Humanoid.HumanBones.RightLowerLeg = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightFoot: vrm.Humanoid.HumanBones.RightFoot = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightToes: vrm.Humanoid.HumanBones.RightToes = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftShoulder: vrm.Humanoid.HumanBones.LeftShoulder = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftUpperArm: vrm.Humanoid.HumanBones.LeftUpperArm = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftLowerArm: vrm.Humanoid.HumanBones.LeftLowerArm = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftHand: vrm.Humanoid.HumanBones.LeftHand = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightShoulder: vrm.Humanoid.HumanBones.RightShoulder = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightUpperArm: vrm.Humanoid.HumanBones.RightUpperArm = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightLowerArm: vrm.Humanoid.HumanBones.RightLowerArm = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightHand: vrm.Humanoid.HumanBones.RightHand = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
+                    case HumanoidBones.leftThumbMetacarpal: vrm.Humanoid.HumanBones.LeftThumbMetacarpal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
                     case HumanoidBones.leftThumbProximal: vrm.Humanoid.HumanBones.LeftThumbProximal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
-                    case HumanoidBones.leftThumbIntermediate: vrm.Humanoid.HumanBones.LeftThumbIntermediate = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftThumbDistal: vrm.Humanoid.HumanBones.LeftThumbDistal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftIndexProximal: vrm.Humanoid.HumanBones.LeftIndexProximal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftIndexIntermediate: vrm.Humanoid.HumanBones.LeftIndexIntermediate = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftIndexDistal: vrm.Humanoid.HumanBones.LeftIndexDistal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftMiddleProximal: vrm.Humanoid.HumanBones.LeftMiddleProximal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftMiddleIntermediate: vrm.Humanoid.HumanBones.LeftMiddleIntermediate = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftMiddleDistal: vrm.Humanoid.HumanBones.LeftMiddleDistal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftRingProximal: vrm.Humanoid.HumanBones.LeftRingProximal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftRingIntermediate: vrm.Humanoid.HumanBones.LeftRingIntermediate = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftRingDistal: vrm.Humanoid.HumanBones.LeftRingDistal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftLittleProximal: vrm.Humanoid.HumanBones.LeftLittleProximal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftLittleIntermediate: vrm.Humanoid.HumanBones.LeftLittleIntermediate = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.leftLittleDistal: vrm.Humanoid.HumanBones.LeftLittleDistal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
+                    case HumanoidBones.rightThumbMetacarpal: vrm.Humanoid.HumanBones.RightThumbMetacarpal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
                     case HumanoidBones.rightThumbProximal: vrm.Humanoid.HumanBones.RightThumbProximal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
-                    case HumanoidBones.rightThumbIntermediate: vrm.Humanoid.HumanBones.RightThumbIntermediate = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightThumbDistal: vrm.Humanoid.HumanBones.RightThumbDistal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightIndexProximal: vrm.Humanoid.HumanBones.RightIndexProximal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightIndexIntermediate: vrm.Humanoid.HumanBones.RightIndexIntermediate = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightIndexDistal: vrm.Humanoid.HumanBones.RightIndexDistal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightMiddleProximal: vrm.Humanoid.HumanBones.RightMiddleProximal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightMiddleIntermediate: vrm.Humanoid.HumanBones.RightMiddleIntermediate = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightMiddleDistal: vrm.Humanoid.HumanBones.RightMiddleDistal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightRingProximal: vrm.Humanoid.HumanBones.RightRingProximal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightRingIntermediate: vrm.Humanoid.HumanBones.RightRingIntermediate = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightRingDistal: vrm.Humanoid.HumanBones.RightRingDistal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightLittleProximal: vrm.Humanoid.HumanBones.RightLittleProximal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightLittleIntermediate: vrm.Humanoid.HumanBones.RightLittleIntermediate = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
-
                     case HumanoidBones.rightLittleDistal: vrm.Humanoid.HumanBones.RightLittleDistal = new UniGLTF.Extensions.VRMC_vrm.HumanBone { Node = i }; break;
                 }
             }

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -722,9 +722,14 @@ namespace UniVRM10
 
         public static HumanBodyBones ToUnity(VrmLib.HumanoidBones bone)
         {
-            if (bone == VrmLib.HumanoidBones.unknown)
+            switch (bone)
             {
-                return HumanBodyBones.LastBone;
+                // https://github.com/vrm-c/vrm-specification/issues/380
+                case VrmLib.HumanoidBones.unknown: return HumanBodyBones.LastBone;
+                case VrmLib.HumanoidBones.leftThumbMetacarpal: return HumanBodyBones.LeftThumbProximal;
+                case VrmLib.HumanoidBones.leftThumbProximal: return HumanBodyBones.LeftThumbIntermediate;
+                case VrmLib.HumanoidBones.rightThumbMetacarpal: return HumanBodyBones.RightThumbProximal;
+                case VrmLib.HumanoidBones.rightThumbProximal: return HumanBodyBones.RightThumbIntermediate;
             }
             return VrmLib.EnumUtil.Cast<HumanBodyBones>(bone);
         }

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -126,8 +126,8 @@ namespace UniVRM10
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftEye, VrmLib.HumanoidBones.leftEye);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightEye, VrmLib.HumanoidBones.rightEye);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.Jaw, VrmLib.HumanoidBones.jaw);
+                    AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftThumbMetacarpal, VrmLib.HumanoidBones.leftThumbMetacarpal);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftThumbProximal, VrmLib.HumanoidBones.leftThumbProximal);
-                    AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftThumbIntermediate, VrmLib.HumanoidBones.leftThumbIntermediate);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftThumbDistal, VrmLib.HumanoidBones.leftThumbDistal);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftIndexProximal, VrmLib.HumanoidBones.leftIndexProximal);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftIndexIntermediate, VrmLib.HumanoidBones.leftIndexIntermediate);
@@ -141,8 +141,8 @@ namespace UniVRM10
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftLittleProximal, VrmLib.HumanoidBones.leftLittleProximal);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftLittleIntermediate, VrmLib.HumanoidBones.leftLittleIntermediate);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.LeftLittleDistal, VrmLib.HumanoidBones.leftLittleDistal);
+                    AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightThumbMetacarpal, VrmLib.HumanoidBones.rightThumbMetacarpal);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightThumbProximal, VrmLib.HumanoidBones.rightThumbProximal);
-                    AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightThumbIntermediate, VrmLib.HumanoidBones.rightThumbIntermediate);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightThumbDistal, VrmLib.HumanoidBones.rightThumbDistal);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightIndexProximal, VrmLib.HumanoidBones.rightIndexProximal);
                     AssignHumanoid(m_model.Nodes, humanoid.HumanBones.RightIndexIntermediate, VrmLib.HumanoidBones.rightIndexIntermediate);

--- a/Assets/VRM10/Runtime/Migration/MigrationCheck.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationCheck.cs
@@ -57,8 +57,8 @@ namespace UniVRM10
                     case "leftEye": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftEye); break;
                     case "rightEye": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightEye); break;
                     case "jaw": CheckBone(boneType, humanoidBone, vrm1.HumanBones.Jaw); break;
+                    case "leftThumbMetacarpal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftThumbMetacarpal); break;
                     case "leftThumbProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftThumbProximal); break;
-                    case "leftThumbIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftThumbIntermediate); break;
                     case "leftThumbDistal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftThumbDistal); break;
                     case "leftIndexProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftIndexProximal); break;
                     case "leftIndexIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftIndexIntermediate); break;
@@ -72,8 +72,8 @@ namespace UniVRM10
                     case "leftLittleProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftLittleProximal); break;
                     case "leftLittleIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftLittleIntermediate); break;
                     case "leftLittleDistal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftLittleDistal); break;
+                    case "rightThumbMetacarpal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightThumbMetacarpal); break;
                     case "rightThumbProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightThumbProximal); break;
-                    case "rightThumbIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightThumbIntermediate); break;
                     case "rightThumbDistal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightThumbDistal); break;
                     case "rightIndexProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightIndexProximal); break;
                     case "rightIndexIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightIndexIntermediate); break;

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmHumanoid.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmHumanoid.cs
@@ -179,7 +179,7 @@ namespace UniVRM10
                     case "rightLittleIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightLittleIntermediate); break;
                     case "rightLittleDistal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightLittleDistal); break;
                     case "upperChest": CheckBone(boneType, humanoidBone, vrm1.HumanBones.UpperChest); break;
-                    default: throw new MigrationException("humanonoid.humanBones[*].bone", boneType);
+                    default: throw new MigrationException("humanoid.humanBones[*].bone", boneType);
                 }
             }
         }

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmHumanoid.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmHumanoid.cs
@@ -70,8 +70,8 @@ namespace UniVRM10
                     case "leftEye": humanoid.HumanBones.LeftEye = MigrateHumanoidBone(humanoidBone); break;
                     case "rightEye": humanoid.HumanBones.RightEye = MigrateHumanoidBone(humanoidBone); break;
                     case "jaw": humanoid.HumanBones.Jaw = MigrateHumanoidBone(humanoidBone); break;
-                    case "leftThumbProximal": humanoid.HumanBones.LeftThumbProximal = MigrateHumanoidBone(humanoidBone); break;
-                    case "leftThumbIntermediate": humanoid.HumanBones.LeftThumbIntermediate = MigrateHumanoidBone(humanoidBone); break;
+                    case "leftThumbProximal": humanoid.HumanBones.LeftThumbMetacarpal = MigrateHumanoidBone(humanoidBone); break;
+                    case "leftThumbIntermediate": humanoid.HumanBones.LeftThumbProximal = MigrateHumanoidBone(humanoidBone); break;
                     case "leftThumbDistal": humanoid.HumanBones.LeftThumbDistal = MigrateHumanoidBone(humanoidBone); break;
                     case "leftIndexProximal": humanoid.HumanBones.LeftIndexProximal = MigrateHumanoidBone(humanoidBone); break;
                     case "leftIndexIntermediate": humanoid.HumanBones.LeftIndexIntermediate = MigrateHumanoidBone(humanoidBone); break;
@@ -85,8 +85,8 @@ namespace UniVRM10
                     case "leftLittleProximal": humanoid.HumanBones.LeftLittleProximal = MigrateHumanoidBone(humanoidBone); break;
                     case "leftLittleIntermediate": humanoid.HumanBones.LeftLittleIntermediate = MigrateHumanoidBone(humanoidBone); break;
                     case "leftLittleDistal": humanoid.HumanBones.LeftLittleDistal = MigrateHumanoidBone(humanoidBone); break;
-                    case "rightThumbProximal": humanoid.HumanBones.RightThumbProximal = MigrateHumanoidBone(humanoidBone); break;
-                    case "rightThumbIntermediate": humanoid.HumanBones.RightThumbIntermediate = MigrateHumanoidBone(humanoidBone); break;
+                    case "rightThumbProximal": humanoid.HumanBones.RightThumbMetacarpal = MigrateHumanoidBone(humanoidBone); break;
+                    case "rightThumbIntermediate": humanoid.HumanBones.RightThumbProximal = MigrateHumanoidBone(humanoidBone); break;
                     case "rightThumbDistal": humanoid.HumanBones.RightThumbDistal = MigrateHumanoidBone(humanoidBone); break;
                     case "rightIndexProximal": humanoid.HumanBones.RightIndexProximal = MigrateHumanoidBone(humanoidBone); break;
                     case "rightIndexIntermediate": humanoid.HumanBones.RightIndexIntermediate = MigrateHumanoidBone(humanoidBone); break;
@@ -148,8 +148,8 @@ namespace UniVRM10
                     case "leftEye": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftEye); break;
                     case "rightEye": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightEye); break;
                     case "jaw": CheckBone(boneType, humanoidBone, vrm1.HumanBones.Jaw); break;
-                    case "leftThumbProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftThumbProximal); break;
-                    case "leftThumbIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftThumbIntermediate); break;
+                    case "leftThumbProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftThumbMetacarpal); break;
+                    case "leftThumbIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftThumbProximal); break;
                     case "leftThumbDistal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftThumbDistal); break;
                     case "leftIndexProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftIndexProximal); break;
                     case "leftIndexIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftIndexIntermediate); break;
@@ -163,8 +163,8 @@ namespace UniVRM10
                     case "leftLittleProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftLittleProximal); break;
                     case "leftLittleIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftLittleIntermediate); break;
                     case "leftLittleDistal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.LeftLittleDistal); break;
-                    case "rightThumbProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightThumbProximal); break;
-                    case "rightThumbIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightThumbIntermediate); break;
+                    case "rightThumbProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightThumbMetacarpal); break;
+                    case "rightThumbIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightThumbProximal); break;
                     case "rightThumbDistal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightThumbDistal); break;
                     case "rightIndexProximal": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightIndexProximal); break;
                     case "rightIndexIntermediate": CheckBone(boneType, humanoidBone, vrm1.HumanBones.RightIndexIntermediate); break;

--- a/Assets/VRM10/vrmlib/Runtime/Humanoid/Humanoid.cs
+++ b/Assets/VRM10/vrmlib/Runtime/Humanoid/Humanoid.cs
@@ -78,7 +78,7 @@ namespace VrmLib
         public Node Distal;
     }
 
-    struct HumanoidThumbnail
+    struct HumanoidThumb
     {
         public Node Metacarpal;
         public Node Proximal;
@@ -88,7 +88,7 @@ namespace VrmLib
 
     struct HumanoidFingers
     {
-        public HumanoidThumbnail Thumb;
+        public HumanoidThumb Thumb;
         public HumanoidFinger Index;
         public HumanoidFinger Middle;
         public HumanoidFinger Ring;

--- a/Assets/VRM10/vrmlib/Runtime/Humanoid/Humanoid.cs
+++ b/Assets/VRM10/vrmlib/Runtime/Humanoid/Humanoid.cs
@@ -78,9 +78,17 @@ namespace VrmLib
         public Node Distal;
     }
 
+    struct HumanoidThumbnail
+    {
+        public Node Metacarpal;
+        public Node Proximal;
+        public Node Distal;
+    }
+
+
     struct HumanoidFingers
     {
-        public HumanoidFinger Thumb;
+        public HumanoidThumbnail Thumb;
         public HumanoidFinger Index;
         public HumanoidFinger Middle;
         public HumanoidFinger Ring;
@@ -294,8 +302,8 @@ namespace VrmLib
                 case HumanoidBones.rightFoot: RightLeg.Foot = node; break;
                 case HumanoidBones.rightToes: RightLeg.Toe = node; break;
 
+                case HumanoidBones.leftThumbMetacarpal: LeftFingers.Thumb.Metacarpal = node; break;
                 case HumanoidBones.leftThumbProximal: LeftFingers.Thumb.Proximal = node; break;
-                case HumanoidBones.leftThumbIntermediate: LeftFingers.Thumb.Intermediate = node; break;
                 case HumanoidBones.leftThumbDistal: LeftFingers.Thumb.Distal = node; break;
                 case HumanoidBones.leftIndexProximal: LeftFingers.Index.Proximal = node; break;
                 case HumanoidBones.leftIndexIntermediate: LeftFingers.Index.Intermediate = node; break;
@@ -310,8 +318,8 @@ namespace VrmLib
                 case HumanoidBones.leftLittleIntermediate: LeftFingers.Little.Intermediate = node; break;
                 case HumanoidBones.leftLittleDistal: LeftFingers.Little.Distal = node; break;
 
+                case HumanoidBones.rightThumbMetacarpal: RightFingers.Thumb.Metacarpal = node; break;
                 case HumanoidBones.rightThumbProximal: RightFingers.Thumb.Proximal = node; break;
-                case HumanoidBones.rightThumbIntermediate: RightFingers.Thumb.Intermediate = node; break;
                 case HumanoidBones.rightThumbDistal: RightFingers.Thumb.Distal = node; break;
                 case HumanoidBones.rightIndexProximal: RightFingers.Index.Proximal = node; break;
                 case HumanoidBones.rightIndexIntermediate: RightFingers.Index.Intermediate = node; break;
@@ -410,8 +418,8 @@ namespace VrmLib
                 case HumanoidBones.rightFoot: value = RightLeg.Foot; return true;
                 case HumanoidBones.rightToes: value = RightLeg.Toe; return true;
 
+                case HumanoidBones.leftThumbMetacarpal: value = LeftFingers.Thumb.Metacarpal; return true;
                 case HumanoidBones.leftThumbProximal: value = LeftFingers.Thumb.Proximal; return true;
-                case HumanoidBones.leftThumbIntermediate: value = LeftFingers.Thumb.Intermediate; return true;
                 case HumanoidBones.leftThumbDistal: value = LeftFingers.Thumb.Distal; return true;
                 case HumanoidBones.leftIndexProximal: value = LeftFingers.Index.Proximal; return true;
                 case HumanoidBones.leftIndexIntermediate: value = LeftFingers.Index.Intermediate; return true;
@@ -427,7 +435,7 @@ namespace VrmLib
                 case HumanoidBones.leftLittleDistal: value = LeftFingers.Little.Distal; return true;
 
                 case HumanoidBones.rightThumbProximal: value = LeftFingers.Thumb.Proximal; return true;
-                case HumanoidBones.rightThumbIntermediate: value = LeftFingers.Thumb.Intermediate; return true;
+                case HumanoidBones.rightThumbMetacarpal: value = LeftFingers.Thumb.Metacarpal; return true;
                 case HumanoidBones.rightThumbDistal: value = LeftFingers.Thumb.Distal; return true;
                 case HumanoidBones.rightIndexProximal: value = LeftFingers.Index.Proximal; return true;
                 case HumanoidBones.rightIndexIntermediate: value = LeftFingers.Index.Intermediate; return true;

--- a/Assets/VRM10/vrmlib/Runtime/Humanoid/HumanoidBones.cs
+++ b/Assets/VRM10/vrmlib/Runtime/Humanoid/HumanoidBones.cs
@@ -68,8 +68,8 @@ namespace VrmLib
         jaw,
 
         #region fingers
+        leftThumbMetacarpal,
         leftThumbProximal,
-        leftThumbIntermediate,
         leftThumbDistal,
         leftIndexProximal,
         leftIndexIntermediate,
@@ -83,8 +83,8 @@ namespace VrmLib
         leftLittleProximal,
         leftLittleIntermediate,
         leftLittleDistal,
+        rightThumbMetacarpal,
         rightThumbProximal,
-        rightThumbIntermediate,
         rightThumbDistal,
         rightIndexProximal,
         rightIndexIntermediate,


### PR DESCRIPTION
https://github.com/vrm-c/vrm-specification/issues/380 に追随

Unity では proximal, intermediate, distal であることに注意。
import / export での変換(Enum.Parse)を修正。
