### PR TITLE
[1.0] VRM-1.0 の targetNames を Mesh.extras のみに修正

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/gltf_mesh_extras_targetNames.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/gltf_mesh_extras_targetNames.cs
@@ -91,7 +91,7 @@ namespace UniGLTF
             return new glTFExtensionExport().Add(ExtraName, f.GetStore().Bytes);
         }
 
-        public static void Serialize(glTFMesh gltfMesh, IEnumerable<string> targetNames)
+        public static void Serialize(glTFMesh gltfMesh, IEnumerable<string> targetNames, BlendShapeTargetNameLocationFlags blendShapeTargetNameLocation)
         {
             // targetNames
             var f = new JsonFormatter();
@@ -103,13 +103,21 @@ namespace UniGLTF
             f.EndList();
             var targetNamesJson = f.GetStore().Bytes;
 
-            var meshExtras = glTFExtensionExport.GetOrCreate(ref gltfMesh.extras);
-            meshExtras.Add(ExtraName, targetNamesJson);
-
-            foreach (var prim in gltfMesh.primitives)
+            // mesh
+            if (blendShapeTargetNameLocation.HasFlag(BlendShapeTargetNameLocationFlags.Mesh))
             {
-                var primExtras = glTFExtensionExport.GetOrCreate(ref prim.extras);
-                primExtras.Add(ExtraName, targetNamesJson);
+                var meshExtras = glTFExtensionExport.GetOrCreate(ref gltfMesh.extras);
+                meshExtras.Add(ExtraName, targetNamesJson);
+            }
+
+            // primitive
+            if (blendShapeTargetNameLocation.HasFlag(BlendShapeTargetNameLocationFlags.Primitives))
+            {
+                foreach (var prim in gltfMesh.primitives)
+                {
+                    var primExtras = glTFExtensionExport.GetOrCreate(ref prim.extras);
+                    primExtras.Add(ExtraName, targetNamesJson);
+                }
             }
         }
     }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/BlendShapeTargetNameLocationFlags.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/BlendShapeTargetNameLocationFlags.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace UniGLTF
+{
+    /// <summary>
+    /// https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#meshes
+    /// 
+    /// See Implementation Note about `mesh.extras.targetNames`
+    /// </summary>
+    [Flags]
+    public enum BlendShapeTargetNameLocationFlags
+    {
+        None = 0,
+        Mesh = 1,
+        Primitives = 2,
+
+        Both = Mesh | Primitives,
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/BlendShapeTargetNameLocationFlags.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/BlendShapeTargetNameLocationFlags.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 050edaae24c5b4e45b702dd150deee8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_DividedVertexBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_DividedVertexBuffer.cs
@@ -129,7 +129,7 @@ namespace UniGLTF
             }
 
             var targetNames = Enumerable.Range(0, mesh.blendShapeCount).Select(x => mesh.GetBlendShapeName(x)).ToArray();
-            gltf_mesh_extras_targetNames.Serialize(gltfMesh, targetNames);
+            gltf_mesh_extras_targetNames.Serialize(gltfMesh, targetNames, BlendShapeTargetNameLocationFlags.Both);
 
             return (gltfMesh, Enumerable.Range(0, mesh.blendShapeCount).ToDictionary(x => x, x => x));
         }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
@@ -188,7 +188,7 @@ namespace UniGLTF
                     }
                 }
 
-                gltf_mesh_extras_targetNames.Serialize(gltfMesh, targetNames);
+                gltf_mesh_extras_targetNames.Serialize(gltfMesh, targetNames, BlendShapeTargetNameLocationFlags.Both);
             }
 
             return (gltfMesh, blendShapeIndexMap);

--- a/Assets/VRM10/Runtime/IO/Model/MeshWriter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/MeshWriter.cs
@@ -136,7 +136,7 @@ namespace UniVRM10
             }
 
             var targetNames = src.Meshes[0].MorphTargets.Select(x => x.Name).ToArray();
-            gltf_mesh_extras_targetNames.Serialize(gltfMesh, targetNames);
+            gltf_mesh_extras_targetNames.Serialize(gltfMesh, targetNames, BlendShapeTargetNameLocationFlags.Mesh);
 
             return gltfMesh;
         }


### PR DESCRIPTION
targetName

下記参照のこと。

https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#meshes

> A significant number of authoring and client implementations associate names with morph targets. While the glTF 2.0 specification currently does not provide a way to specify names, most tools use an array of strings, mesh.extras.targetNames, for this purpose. The targetNames array and all primitive targets arrays must have the same length.

歴史的事情により、当初 primitive.extras.targetNames を使っていた。

https://github.com/KhronosGroup/glTF/issues/1036
