### PR TITLE
BlendShapeClipが削除された後に様々な場所でエラーが出る問題を修正

### DIFF
--- a/Assets/VRM/Editor/BlendShape/BlendShapeClipSelector.cs
+++ b/Assets/VRM/Editor/BlendShape/BlendShapeClipSelector.cs
@@ -46,8 +46,6 @@ namespace VRM
 
         public BlendShapeClipSelector(BlendShapeAvatar avatar, Action<BlendShapeClip> onSelected)
         {
-            avatar.RemoveNullClip();
-
             m_avatar = avatar;
             m_onSelected = onSelected;
 

--- a/Assets/VRM/Editor/BlendShape/BlendShapeClipSelector.cs
+++ b/Assets/VRM/Editor/BlendShape/BlendShapeClipSelector.cs
@@ -46,6 +46,8 @@ namespace VRM
 
         public BlendShapeClipSelector(BlendShapeAvatar avatar, Action<BlendShapeClip> onSelected)
         {
+            avatar.RemoveNullClip();
+
             m_avatar = avatar;
             m_onSelected = onSelected;
 

--- a/Assets/VRM/Editor/BlendShape/VRMBlendShapeProxyValidator.cs
+++ b/Assets/VRM/Editor/BlendShape/VRMBlendShapeProxyValidator.cs
@@ -57,6 +57,12 @@ namespace VRM
             // 参照が生きているか
             foreach (var c in p.BlendShapeAvatar.Clips)
             {
+                if (c == null)
+                {
+                    yield return Validation.Warning($"BlendShapeName({c.BlendShapeName})'s BlendShapeClip is not found");
+                    continue;
+                }
+                
                 for (int i = 0; i < c.Values.Length; ++i)
                 {
                     var v = c.Values[i];

--- a/Assets/VRM/Editor/Format/VRMBlendShapeExportFilter.cs
+++ b/Assets/VRM/Editor/Format/VRMBlendShapeExportFilter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UniGLTF;
 using UnityEngine;
 
@@ -11,6 +12,11 @@ namespace VRM
         {
             foreach (var c in clips)
             {
+                if (c == null)
+                {
+                    continue;
+                }
+                
                 if (onlyPreset)
                 {
                     if (c.Preset == BlendShapePreset.Unknown)
@@ -44,7 +50,7 @@ namespace VRM
                 {
                     if (proxy.BlendShapeAvatar != null)
                     {
-                        Clips.AddRange(proxy.BlendShapeAvatar.Clips);
+                        Clips.AddRange(proxy.BlendShapeAvatar.Clips.Where(x => x != null));
                     }
                 }
             }

--- a/Assets/VRM/Editor/Format/VRMEditorExporter.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorExporter.cs
@@ -49,6 +49,11 @@ namespace VRM
             avatar.Clips = new List<BlendShapeClip>();
             foreach (var clip in src.Clips)
             {
+                if (clip == null)
+                {
+                    continue;
+                }
+                
                 if (removeUnknown && clip.Preset == BlendShapePreset.Unknown)
                 {
                     continue;
@@ -70,7 +75,8 @@ namespace VRM
             if (mesh.blendShapeCount == 0) return;
 
             // Mesh から BlendShapeClip からの参照がある blendShape の index を集める
-            var usedBlendshapeIndexArray = copyBlendShapeAvatar.Clips
+            var copyBlendShapeAvatarClips = copyBlendShapeAvatar.Clips.Where(x => x != null).ToArray();
+            var usedBlendshapeIndexArray = copyBlendShapeAvatarClips
                 .SelectMany(clip => clip.Values)
                 .Where(val => target.transform.Find(val.RelativePath) == smr.transform)
                 .Select(val => val.Index)
@@ -95,7 +101,7 @@ namespace VRM
             var indexMapper = usedBlendshapeIndexArray
                 .Select((x, i) => new { x, i })
                 .ToDictionary(pair => pair.x, pair => pair.i);
-            foreach (var clip in copyBlendShapeAvatar.Clips)
+            foreach (var clip in copyBlendShapeAvatarClips)
             {
                 for (var i = 0; i < clip.Values.Length; ++i)
                 {

--- a/Assets/VRM/Editor/Format/VRMExporterWizard.cs
+++ b/Assets/VRM/Editor/Format/VRMExporterWizard.cs
@@ -358,26 +358,26 @@ namespace VRM
                 return;
             }
 
-            m_merger = new BlendShapeMerger(avatar.Clips, proxy.transform);
+            m_merger = new BlendShapeMerger(avatar.Clips.Where(x => x != null), proxy.transform);
 
 
             GUILayout.Space(20);
 
             EditorGUILayout.HelpBox(BlendShapeTabMessages.SCENE_MESSAGE.Msg(), MessageType.Info);
 
-            var options = avatar.Clips.Select(x => x.ToString()).ToArray();
+            var options = avatar.Clips.Where(x => x != null).Select(x => x.ToString()).ToArray();
             m_selected = EditorGUILayout.Popup("select blendshape", m_selected, options);
 
             if (GUILayout.Button(BlendShapeTabMessages.APPLY_BLENDSHAPECLIP_BUTTON.Msg()))
             {
-                m_merger.SetValues(avatar.Clips.Select((x, i) => new KeyValuePair<BlendShapeKey, float>(x.Key, i == m_selected ? 1 : 0)));
+                m_merger.SetValues(avatar.Clips.Where(x => x != null).Select((x, i) => new KeyValuePair<BlendShapeKey, float>(x.Key, i == m_selected ? 1 : 0)));
                 m_merger.Apply();
                 m_settings.PoseFreeze = true;
             }
 
             if (GUILayout.Button(BlendShapeTabMessages.CLEAR_BLENDSHAPE_BUTTON.Msg()))
             {
-                m_merger.SetValues(avatar.Clips.Select(x => new KeyValuePair<BlendShapeKey, float>(x.Key, 0)));
+                m_merger.SetValues(avatar.Clips.Where(x => x != null).Select(x => new KeyValuePair<BlendShapeKey, float>(x.Key, 0)));
                 m_merger.Apply();
             }
         }

--- a/Assets/VRM/Runtime/BlendShape/BlendShapeAvatar.cs
+++ b/Assets/VRM/Runtime/BlendShape/BlendShapeAvatar.cs
@@ -31,7 +31,7 @@ namespace VRM
         /// <summary>
         /// NullのClipを削除して詰める
         /// </summary>
-        public void RemoveNullClip()
+        private void RemoveNullClip()
         {
             if (clips == null)
             {

--- a/Assets/VRM/Runtime/BlendShape/BlendShapeAvatar.cs
+++ b/Assets/VRM/Runtime/BlendShape/BlendShapeAvatar.cs
@@ -16,24 +16,6 @@ namespace VRM
         [SerializeField]
         public List<BlendShapeClip> Clips = new List<BlendShapeClip>();
 
-        /// <summary>
-        /// NullのClipを削除して詰める
-        /// </summary>
-        public void RemoveNullClip()
-        {
-            if (Clips == null)
-            {
-                return;
-            }
-            for (int i = Clips.Count - 1; i >= 0; --i)
-            {
-                if (Clips[i] == null)
-                {
-                    Clips.RemoveAt(i);
-                }
-            }
-        }
-
 #if UNITY_EDITOR
         [ContextMenu("Restore")]
         void Restore()

--- a/Assets/VRM/Runtime/BlendShape/BlendShapeAvatar.cs
+++ b/Assets/VRM/Runtime/BlendShape/BlendShapeAvatar.cs
@@ -31,7 +31,7 @@ namespace VRM
         /// <summary>
         /// NullのClipを削除して詰める
         /// </summary>
-        private void RemoveNullClip()
+        public void RemoveNullClip()
         {
             if (clips == null)
             {

--- a/Assets/VRM/Runtime/BlendShape/BlendShapeAvatar.cs
+++ b/Assets/VRM/Runtime/BlendShape/BlendShapeAvatar.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using UniGLTF;
 using System.IO;
+using UnityEngine.Serialization;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -13,23 +14,34 @@ namespace VRM
     [CreateAssetMenu(menuName = "VRM/BlendShapeAvatar")]
     public class BlendShapeAvatar : ScriptableObject
     {
+        [FormerlySerializedAs("Clips")]
         [SerializeField]
-        public List<BlendShapeClip> Clips = new List<BlendShapeClip>();
+        private List<BlendShapeClip> clips = new List<BlendShapeClip>();
+
+        public List<BlendShapeClip> Clips
+        {
+            get
+            {
+                RemoveNullClip();
+                return clips;
+            }
+            set => clips = value;
+        }
 
         /// <summary>
         /// NullのClipを削除して詰める
         /// </summary>
         public void RemoveNullClip()
         {
-            if (Clips == null)
+            if (clips == null)
             {
                 return;
             }
-            for (int i = Clips.Count - 1; i >= 0; --i)
+            for (int i = clips.Count - 1; i >= 0; --i)
             {
-                if (Clips[i] == null)
+                if (clips[i] == null)
                 {
-                    Clips.RemoveAt(i);
+                    clips.RemoveAt(i);
                 }
             }
         }

--- a/Assets/VRM/Runtime/BlendShape/BlendShapeAvatar.cs
+++ b/Assets/VRM/Runtime/BlendShape/BlendShapeAvatar.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using UniGLTF;
 using System.IO;
-using UnityEngine.Serialization;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -14,34 +13,23 @@ namespace VRM
     [CreateAssetMenu(menuName = "VRM/BlendShapeAvatar")]
     public class BlendShapeAvatar : ScriptableObject
     {
-        [FormerlySerializedAs("Clips")]
         [SerializeField]
-        private List<BlendShapeClip> clips = new List<BlendShapeClip>();
-
-        public List<BlendShapeClip> Clips
-        {
-            get
-            {
-                RemoveNullClip();
-                return clips;
-            }
-            set => clips = value;
-        }
+        public List<BlendShapeClip> Clips = new List<BlendShapeClip>();
 
         /// <summary>
         /// NullのClipを削除して詰める
         /// </summary>
         public void RemoveNullClip()
         {
-            if (clips == null)
+            if (Clips == null)
             {
                 return;
             }
-            for (int i = clips.Count - 1; i >= 0; --i)
+            for (int i = Clips.Count - 1; i >= 0; --i)
             {
-                if (clips[i] == null)
+                if (Clips[i] == null)
                 {
-                    clips.RemoveAt(i);
+                    Clips.RemoveAt(i);
                 }
             }
         }

--- a/Assets/VRM/Tests/SampleTests/VRMImportExportTests.cs
+++ b/Assets/VRM/Tests/SampleTests/VRMImportExportTests.cs
@@ -113,6 +113,10 @@ namespace VRM.Samples
                     {
                         var gltfBlendShapeClip = context.VRM.blendShapeMaster.blendShapeGroups[i];
                         var unityBlendShapeClip = blendshapeProxy.BlendShapeAvatar.Clips[i];
+                        if (unityBlendShapeClip == null)
+                        {
+                            continue;
+                        }
                         Assert.AreEqual(Enum.Parse(typeof(BlendShapePreset), gltfBlendShapeClip.presetName, true), unityBlendShapeClip.Preset);
                     }
                 }

--- a/Assets/VRM_Samples/BlendShapeMenu/BlendShapeMenu.cs
+++ b/Assets/VRM_Samples/BlendShapeMenu/BlendShapeMenu.cs
@@ -103,7 +103,7 @@ namespace VRM.Sample.BlendShapeMenu
             var sb = new StringBuilder();
             foreach (var name in NAMES)
             {
-                if (avatar.Clips.Find(x => x.Preset == BlendShapePreset.Unknown && x.BlendShapeName == name))
+                if (avatar.Clips.Find(x => x != null && x.Preset == BlendShapePreset.Unknown && x.BlendShapeName == name))
                 {
                     // already exists
                     continue;


### PR DESCRIPTION
# 概要
BlendShapeClipのファイルが削除された後に表情の変更やVRMのエクスポートをしようとするとエラーが発生します。
これは、BlendShapeVatar.Clips内の削除したBlendShapeClipがnullになるためです。

# 詳細
## 再現方法
1. VRMファイルを読み込む
2. 作成されたPrefabをScene上に配置
3. 1個以上のBlendShapeClipのアセットファイルを削除
4. 2.で作成したGameObjectにAIUEOをアタッチ
5. Playする

## 発生するエラー
エラー抜粋
```
NullReferenceException: Object reference not set to an instance of an object
VRM.BlendShapeKey.GetHashCode () (at Assets/VRM/Runtime/BlendShape/BlendShapeKey.cs:128)
```
<details>
<summary>エラー全文</summary>

```
NullReferenceException: Object reference not set to an instance of an object
VRM.BlendShapeKey.GetHashCode () (at Assets/VRM/Runtime/BlendShape/BlendShapeKey.cs:128)
System.Collections.Generic.GenericEqualityComparer`1[T].GetHashCode (T obj) (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement] (System.Collections.Generic.List`1[T] source, System.Func`2[T,TResult] keySelector, System.Func`2[T,TResult] elementSelector, System.Collections.Generic.IEqualityComparer`1[T] comparer) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] keySelector, System.Func`2[T,TResult] elementSelector, System.Collections.Generic.IEqualityComparer`1[T] comparer) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] keySelector, System.Func`2[T,TResult] elementSelector) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
VRM.BlendShapeMerger..ctor (System.Collections.Generic.IEnumerable`1[T] clips, UnityEngine.Transform root) (at Assets/VRM/Runtime/BlendShape/BlendShapeMerger.cs:33)
VRM.VRMBlendShapeProxy.Start () (at Assets/VRM/Runtime/BlendShape/VRMBlendShapeProxy.cs:41)
```
</details>

## 解決策
以下の方法で解決しました。
* BlendShapeAvatar.Clipsから取得する際にRemoveNullClipを呼ぶように変更
* Clipsはclipsに変更しFormerlySerializedAs属性を追加
* BlendShapeClipSelectorのRemoveNullClipが不要になるのでRemoveNullClipをprivateに変更

## 解決策の問題点など
BlendShapeClipのファイルが削除されたイベントを監視してその都度RemoveNullClipをするような実装も考えましたが、Unityを再起動した場合やUnityを起動していないタイミングでの削除には対応できないため諦めました。
また、Clipsにアクセスした際に勝手にnullな要素を削除するのは直感的では無いとも思うので、素直にClipsを参照している全ての場所にnullチェックを追加する方が良いかもしれません。