### PR TITLE
Add the `GenerateControlRig` option to VRM 1.0 Importer.

### DIFF
--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -50,7 +50,9 @@ namespace UniVRM10
         [SerializeField]
         public VRM10ObjectLookAt.LookAtTargetTypes LookAtTargetType;
 
-        UniHumanoid.Humanoid m_humanoid;
+        private UniHumanoid.Humanoid m_humanoid;
+        private Vrm10Runtime m_runtime;
+        private bool m_generateControlRig = false;
 
         public UniHumanoid.Humanoid Humanoid
         {
@@ -64,8 +66,6 @@ namespace UniVRM10
             }
         }
 
-        Vrm10Runtime m_runtime;
-
         /// <summary>
         /// ランタイム情報
         /// </summary>
@@ -75,10 +75,15 @@ namespace UniVRM10
             {
                 if (m_runtime == null)
                 {
-                    m_runtime = new Vrm10Runtime(this);
+                    m_runtime = new Vrm10Runtime(this, m_generateControlRig);
                 }
                 return m_runtime;
             }
+        }
+
+        internal void InitializeAtRuntime(bool generateControlRig)
+        {
+            m_generateControlRig = generateControlRig;
         }
 
         void Start()

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -42,7 +42,7 @@ namespace UniVRM10
                 throw new Exception();
             }
 
-            ControlRig = new Vrm10RuntimeControlRig(target.Humanoid);
+            ControlRig = new Vrm10RuntimeControlRig(target.Humanoid, m_target.transform);
             Constraints = target.GetComponentsInChildren<IVrm10Constraint>();
             LookAt = new Vrm10RuntimeLookAt(target.Vrm.LookAt, target.Humanoid, m_head, target.LookAtTargetType, target.Gaze);
             Expression = new Vrm10RuntimeExpression(target, LookAt, LookAt.EyeDirectionApplicable);
@@ -67,6 +67,13 @@ namespace UniVRM10
                 m_fastSpringBoneBuffer = CreateFastSpringBoneBuffer(m_target.SpringBone);
                 m_fastSpringBoneService.BufferCombiner.Register(m_fastSpringBoneBuffer);
             }
+        }
+
+        public void Dispose()
+        {
+            ControlRig.Dispose();
+            m_fastSpringBoneService.BufferCombiner.Unregister(m_fastSpringBoneBuffer);
+            m_fastSpringBoneBuffer.Dispose();
         }
 
         /// <summary>
@@ -168,12 +175,6 @@ namespace UniVRM10
 
             // 4. Expression
             Expression.Process();
-        }
-
-        public void Dispose()
-        {
-            m_fastSpringBoneService.BufferCombiner.Unregister(m_fastSpringBoneBuffer);
-            m_fastSpringBoneBuffer.Dispose();
         }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -33,7 +33,7 @@ namespace UniVRM10
         public Vrm10RuntimeExpression Expression { get; }
         public Vrm10RuntimeLookAt LookAt { get; }
 
-        public Vrm10Runtime(Vrm10Instance target)
+        public Vrm10Runtime(Vrm10Instance target, bool generateControlRig)
         {
             m_target = target;
 
@@ -42,7 +42,10 @@ namespace UniVRM10
                 throw new Exception();
             }
 
-            ControlRig = new Vrm10RuntimeControlRig(target.Humanoid, m_target.transform);
+            if (generateControlRig)
+            {
+                ControlRig = new Vrm10RuntimeControlRig(target.Humanoid, m_target.transform);
+            }
             Constraints = target.GetComponentsInChildren<IVrm10Constraint>();
             LookAt = new Vrm10RuntimeLookAt(target.Vrm.LookAt, target.Humanoid, m_head, target.LookAtTargetType, target.Gaze);
             Expression = new Vrm10RuntimeExpression(target, LookAt, LookAt.EyeDirectionApplicable);
@@ -71,7 +74,7 @@ namespace UniVRM10
 
         public void Dispose()
         {
-            ControlRig.Dispose();
+            ControlRig?.Dispose();
             m_fastSpringBoneService.BufferCombiner.Unregister(m_fastSpringBoneBuffer);
             m_fastSpringBoneBuffer.Dispose();
         }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeControlRig.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeControlRig.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using UniHumanoid;
 using UnityEngine;
 
 namespace UniVRM10
@@ -16,7 +18,10 @@ namespace UniVRM10
         private readonly Transform _controlRigRoot;
         private readonly Vrm10ControlBone _hipBone;
         private readonly Dictionary<HumanBodyBones, Vrm10ControlBone> _bones;
+        private readonly Avatar _controlRigAvatar;
 
+        public IReadOnlyDictionary<HumanBodyBones, Vrm10ControlBone> Bones => _bones;
+        public Animator ControlRigAnimator { get; }
         public float InitialHipsHeight { get; }
 
         /// <summary>
@@ -32,10 +37,17 @@ namespace UniVRM10
             _hipBone.ControlBone.SetParent(_controlRigRoot);
 
             InitialHipsHeight = _hipBone.ControlTarget.position.y;
+
+            var transformBonePairs = _bones.Select(kv => (kv.Value.ControlBone, kv.Key));
+            _controlRigAvatar = HumanoidLoader.LoadHumanoidAvatar(_controlRigRoot, transformBonePairs);
+            _controlRigAvatar.name = "Runtime Control Rig";
+            ControlRigAnimator = _controlRigRoot.gameObject.AddComponent<Animator>();
+            ControlRigAnimator.avatar = _controlRigAvatar;
         }
 
         public void Dispose()
         {
+            UnityEngine.Object.Destroy(_controlRigAvatar);
             UnityEngine.Object.Destroy(_controlRigRoot);
         }
 

--- a/Assets/VRM10/Runtime/IO/Vrm10.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10.cs
@@ -27,6 +27,7 @@ namespace UniVRM10
         /// </summary>
         /// <param name="path">vrm file path</param>
         /// <param name="canLoadVrm0X">if true, this loader can load the vrm-0.x model as vrm-1.0 model with migration.</param>
+        /// <param name="generateControlRig">if true, generating the control rig provides bone manipulation like vrm-0.x</param>
         /// <param name="showMeshes">if true, show meshes when loaded.</param>
         /// <param name="awaitCaller">this loader use specified await strategy.</param>
         /// <param name="materialGenerator">this loader use specified material generation strategy.</param>
@@ -36,6 +37,7 @@ namespace UniVRM10
         public static async Task<Vrm10Instance> LoadPathAsync(
             string path,
             bool canLoadVrm0X = true,
+            bool generateControlRig = true,
             bool showMeshes = true,
             IAwaitCaller awaitCaller = null,
             IMaterialDescriptorGenerator materialGenerator = null,
@@ -53,6 +55,7 @@ namespace UniVRM10
                 path,
                 System.IO.File.ReadAllBytes(path),
                 canLoadVrm0X,
+                generateControlRig,
                 showMeshes,
                 awaitCaller,
                 materialGenerator,
@@ -68,6 +71,7 @@ namespace UniVRM10
         /// </summary>
         /// <param name="bytes">vrm file data</param>
         /// <param name="canLoadVrm0X">if true, this loader can load the vrm-0.x model as vrm-1.0 model with migration.</param>
+        /// <param name="generateControlRig">if true, generating the control rig provides bone manipulation like vrm-0.x</param>
         /// <param name="showMeshes">if true, show meshes when loaded.</param>
         /// <param name="awaitCaller">this loader use specified await strategy.</param>
         /// <param name="materialGenerator">this loader use specified material generation strategy.</param>
@@ -77,6 +81,7 @@ namespace UniVRM10
         public static async Task<Vrm10Instance> LoadBytesAsync(
             byte[] bytes,
             bool canLoadVrm0X = true,
+            bool generateControlRig = true,
             bool showMeshes = true,
             IAwaitCaller awaitCaller = null,
             IMaterialDescriptorGenerator materialGenerator = null,
@@ -94,6 +99,7 @@ namespace UniVRM10
                 string.Empty,
                 bytes,
                 canLoadVrm0X,
+                generateControlRig,
                 showMeshes,
                 awaitCaller,
                 materialGenerator,
@@ -105,6 +111,7 @@ namespace UniVRM10
             string name,
             byte[] bytes,
             bool canLoadVrm0X,
+            bool generateControlRig,
             bool showMeshes,
             IAwaitCaller awaitCaller,
             IMaterialDescriptorGenerator materialGenerator,
@@ -122,6 +129,7 @@ namespace UniVRM10
                 // 1. Try loading as vrm-1.0
                 var instance = await TryLoadingAsVrm10Async(
                     gltfData,
+                    generateControlRig,
                     showMeshes,
                     awaitCaller,
                     materialGenerator,
@@ -146,6 +154,7 @@ namespace UniVRM10
                 // 3. Try migration from vrm-0.x into vrm-1.0
                 var migratedInstance = await TryMigratingFromVrm0XAsync(
                     gltfData,
+                    generateControlRig,
                     showMeshes,
                     awaitCaller,
                     materialGenerator,
@@ -168,6 +177,7 @@ namespace UniVRM10
 
         private static async Task<Vrm10Instance> TryLoadingAsVrm10Async(
             GltfData gltfData,
+            bool generateControlRig,
             bool showMeshes,
             IAwaitCaller awaitCaller,
             IMaterialDescriptorGenerator materialGenerator,
@@ -192,6 +202,7 @@ namespace UniVRM10
             return await LoadVrm10DataAsync(
                 vrm10Data,
                 null,
+                generateControlRig,
                 showMeshes,
                 awaitCaller,
                 materialGenerator,
@@ -201,6 +212,7 @@ namespace UniVRM10
 
         private static async Task<Vrm10Instance> TryMigratingFromVrm0XAsync(
             GltfData gltfData,
+            bool generateControlRig,
             bool showMeshes,
             IAwaitCaller awaitCaller,
             IMaterialDescriptorGenerator materialGenerator,
@@ -227,6 +239,7 @@ namespace UniVRM10
                 var migratedVrm10Instance = await LoadVrm10DataAsync(
                     migratedVrm10Data,
                     migrationData,
+                    generateControlRig,
                     showMeshes,
                     awaitCaller,
                     materialGenerator,
@@ -243,6 +256,7 @@ namespace UniVRM10
         private static async Task<Vrm10Instance> LoadVrm10DataAsync(
             Vrm10Data vrm10Data,
             MigrationData migrationData,
+            bool generateControlRig,
             bool showMeshes,
             IAwaitCaller awaitCaller,
             IMaterialDescriptorGenerator materialGenerator,
@@ -260,7 +274,7 @@ namespace UniVRM10
                 throw new ArgumentNullException(nameof(vrm10Data));
             }
 
-            using (var loader = new Vrm10Importer(vrm10Data, materialGenerator: materialGenerator))
+            using (var loader = new Vrm10Importer(vrm10Data, generateControlRig: generateControlRig, materialGenerator: materialGenerator))
             {
                 // 1. Load meta information if callback was available.
                 if (vrmMetaInformationCallback != null)

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -15,11 +15,15 @@ namespace UniVRM10
     /// </summary>
     public class Vrm10Importer : UniGLTF.ImporterContext
     {
-        VrmLib.Model m_model;
+        private readonly Vrm10Data m_vrm;
+        /// VrmLib.Model の オブジェクトと UnityEngine.Object のマッピングを記録する
+        private readonly ModelMap m_map = new ModelMap();
 
-        readonly Vrm10Data m_vrm;
-
-        IReadOnlyDictionary<SubAssetKey, UnityEngine.Object> m_externalMap;
+        private VrmLib.Model m_model;
+        private IReadOnlyDictionary<SubAssetKey, UnityEngine.Object> m_externalMap;
+        private Avatar m_humanoid;
+        private VRM10Object m_vrmObject;
+        private List<(ExpressionPreset Preset, VRM10Expression Clip)> m_expressions = new List<(ExpressionPreset, VRM10Expression)>();
 
         public Vrm10Importer(
             Vrm10Data vrm,
@@ -43,18 +47,6 @@ namespace UniVRM10
                 m_externalMap = new Dictionary<SubAssetKey, UnityEngine.Object>();
             }
         }
-
-        public class ModelMap
-        {
-            public readonly Dictionary<VrmLib.Node, GameObject> Nodes = new Dictionary<VrmLib.Node, GameObject>();
-            public readonly Dictionary<VrmLib.MeshGroup, UnityEngine.Mesh> Meshes = new Dictionary<VrmLib.MeshGroup, UnityEngine.Mesh>();
-        }
-
-        /// <summary>
-        /// VrmLib.Model の オブジェクトと UnityEngine.Object のマッピングを記録する
-        /// </summary>
-        /// <returns></returns>
-        readonly ModelMap m_map = new ModelMap();
 
         static void AssignHumanoid(List<VrmLib.Node> nodes, UniGLTF.Extensions.VRMC_vrm.HumanBone humanBone, VrmLib.HumanoidBones key)
         {
@@ -236,10 +228,6 @@ namespace UniVRM10
                 await awaitCaller.NextFrame();
             }
         }
-
-        UnityEngine.Avatar m_humanoid;
-        VRM10Object m_vrmObject;
-        List<(ExpressionPreset Preset, VRM10Expression Clip)> m_expressions = new List<(ExpressionPreset, VRM10Expression)>();
 
         protected override async Task OnLoadHierarchy(IAwaitCaller awaitCaller, Func<string, IDisposable> MeasureTime)
         {
@@ -846,6 +834,12 @@ namespace UniVRM10
             m_expressions.Clear();
 
             base.Dispose();
+        }
+
+        public sealed class ModelMap
+        {
+            public readonly Dictionary<VrmLib.Node, GameObject> Nodes = new Dictionary<VrmLib.Node, GameObject>();
+            public readonly Dictionary<VrmLib.MeshGroup, UnityEngine.Mesh> Meshes = new Dictionary<VrmLib.MeshGroup, UnityEngine.Mesh>();
         }
     }
 }

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -18,6 +18,7 @@ namespace UniVRM10
         private readonly Vrm10Data m_vrm;
         /// VrmLib.Model の オブジェクトと UnityEngine.Object のマッピングを記録する
         private readonly ModelMap m_map = new ModelMap();
+        private readonly bool m_generateControlRig;
 
         private VrmLib.Model m_model;
         private IReadOnlyDictionary<SubAssetKey, UnityEngine.Object> m_externalMap;
@@ -29,7 +30,8 @@ namespace UniVRM10
             Vrm10Data vrm,
             IReadOnlyDictionary<SubAssetKey, UnityEngine.Object> externalObjectMap = null,
             ITextureDeserializer textureDeserializer = null,
-            IMaterialDescriptorGenerator materialGenerator = null)
+            IMaterialDescriptorGenerator materialGenerator = null,
+            bool generateControlRig = false)
             : base(vrm.Data, externalObjectMap, textureDeserializer)
         {
             if (vrm == null)
@@ -37,6 +39,7 @@ namespace UniVRM10
                 throw new ArgumentNullException("vrm");
             }
             m_vrm = vrm;
+            m_generateControlRig = generateControlRig;
 
             TextureDescriptorGenerator = new Vrm10TextureDescriptorGenerator(Data);
             MaterialDescriptorGenerator = materialGenerator ?? new Vrm10MaterialDescriptorGenerator();
@@ -243,6 +246,7 @@ namespace UniVRM10
 
             // VrmController
             var controller = Root.AddComponent<Vrm10Instance>();
+            controller.InitializeAtRuntime(m_generateControlRig);
             controller.enabled = false;
 
             // vrm

--- a/Assets/VRM10/Tests/ExpressionTests.cs
+++ b/Assets/VRM10/Tests/ExpressionTests.cs
@@ -32,7 +32,7 @@ namespace UniVRM10.Test
             controller.Vrm.Expression.Aa.MaterialColorBindings = src.ToArray();
 
             // ok if no exception
-            var r = new Vrm10Runtime(controller);
+            var r = new Vrm10Runtime(controller, false);
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace UniVRM10.Test
             controller.Vrm.Expression.Aa.MaterialUVBindings = src.ToArray();
 
             // ok if no exception
-            var r = new Vrm10Runtime(controller);
+            var r = new Vrm10Runtime(controller, false);
         }
     }
 }

--- a/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerUI.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerUI.cs
@@ -301,7 +301,7 @@ namespace UniVRM10.VRM10Viewer
 
                         if (bone == HumanBodyBones.Hips)
                         {
-                            controlRigBone.position = bvhBone.position * controlRig.InitialHipsHeight;
+                            controlRigBone.localPosition = bvhBone.localPosition * controlRig.InitialHipsHeight;
                         }
                     }
                     else


### PR DESCRIPTION
API Breaking Change です。

Control Rig を生成するオプションが VRM 1.0 Importer に `generateControlRig` として追加されます。
Control Rig は `Vrm10RuntimeControlRig` として実装されます。
Control Rig は、すべてのボーンの `localRotation` が `Quaternion.identity` であるとき、VRM の T-Pose になるリグです。
Control Rig は、その姿勢を VRM モデルのボーンに Vrm10Runtime の指定されたタイミングで適用します。
Control Rig は、VRM モデルのインスタンス Root の子に生成されます。
Control Rig は、VRM モデルの `Animator` とは別に、独自の `Animator` を生成します。

![image](https://user-images.githubusercontent.com/328204/188850819-4b4d5c8c-e92a-42ac-9f7b-99d41dee9b6b.png)
