### PR TITLE
BREAKING CHANGE: Add interface method IAwaitCaller.NextFrameIfTimedOut which invokes NextFrame if timed out

### DIFF
--- a/Assets/VRMShaders/GLTF/IO/Runtime/AwaitCaller/IAwaitCaller.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/AwaitCaller/IAwaitCaller.cs
@@ -31,5 +31,11 @@ namespace VRMShaders
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         Task<T> Run<T>(Func<T> action);
+
+        /// <summary>
+        /// 指定した時間が経過している場合のみ、NextFrame() を使って1フレーム待つ
+        /// </summary>
+        /// <returns>タイムアウト時はNextFrame()を呼び出す。そうではない場合、Task.CompletedTaskを返す</returns>
+        Task NextFrameIfTimedOut();
     }
 }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/AwaitCaller/ImmediateCaller.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/AwaitCaller/ImmediateCaller.cs
@@ -23,5 +23,7 @@ namespace VRMShaders
         {
             return Task.FromResult(action());
         }
+
+        public Task NextFrameIfTimedOut() => NextFrame();
     }
 }


### PR DESCRIPTION
edit : IAwaitCallerに正規のインターフェスとしてNextFrameIfTimedOutを追加する形式に修正

## RuntimeOnlyAwaitCallerに指定時間経過後のみNextFrameを呼ぶ疑似メソッドNextFrameIfTimedOutを追加

アプリ内でRuntimeOnlyAwaitCallerを使用する際、UniVRMによるVRMファイルロード時のメインスレッドCPU処理スパイク (一時的な処理量の増加) を積極的に軽減したい場合があります。

UniVRMには既に `RuntimeOnlyAwaitCaller.NextFrame()` によるスパイク軽減が実装されていますが、処理量によらず常に次のフレームを待つため、処理時間および待ち時間の粒度が大きく異なる傾向があります。
この点を改善するため、この変更では `RuntimeOnlyAwaitCaller.NextFrameIfTimedOut()` という疑似メソッドを追加し、一定時間経過した場合のみ `NextFrame()` を自動的に呼び出せるようにします。

この変更内には、実際にこの疑似メソッドを呼び出す部分はありませんが、例えば以下のようなコードのループ内への追加を行うことで、CPU処理量の大きな変動の抑制が可能になります。

```c#
public class VRMImporterContext : ImporterContext {
  protected override async Task OnLoadHierarchy(IAwaitCaller awaitCaller, ...) {
    ...
    var blendShapeList = VRM.blendShapeMaster.blendShapeGroups;
    if (blendShapeList != null && blendShapeList.Count > 0) {
      foreach (var x in blendShapeList) {
        await awaitCaller.NextFrameIfTimedOut(); /* -- 追加 -- */
        BlendShapeAvatar.Clips.Add(await LoadBlendShapeBind(awaitCaller, x, transformMeshTable));
      }
    }
    ...
  }
}
```


## 問題を感じる点

`IAwaitCaller` のインターフェースを増やせると良いのですが、実施すると `VRMShaders` の public なインターフェースに対する破壊的な変更になるため、 `RuntimeOnlyAwaitCaller` のみの変更に留めています。
C#8 の [default interface methods](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/default-interface-methods) が使用できると、コード上の変更が少なくて良いと思うのですが、この機能は [Unity 2020.3 では使えませんでした](http://answers.unity.com/answers/1801471/view.html)。

この結果として、 `RuntimeOnlyAwaitCaller.NextFrameIfTimedOut()` はエクステンションによる疑似的なメソッドになっており、コードの見通しが悪いです。

破壊的な変更になることを許容しつつ、 `IAwaitCaller` にメソッドを追加するほうが望ましい場合、その形式に書き換えようと思っています。
