### PR TITLE
add LoadPathAsync

### DIFF
--- a/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
+++ b/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
@@ -327,7 +327,7 @@ namespace VRM.SimpleViewer
             string[] cmds = System.Environment.GetCommandLineArgs();
             if (cmds.Length > 1)
             {
-                LoadModelAsync(cmds[1]);
+                LoadPathAsync(cmds[1]);
             }
 
             m_texts.Start();
@@ -391,10 +391,20 @@ namespace VRM.SimpleViewer
                 return;
             }
 
-            LoadModelAsync(path);
+            LoadPathAsync(path);
         }
 
-        async void LoadModelAsync(string path, byte[] bytes = null)
+        async void LoadPathAsync(string path)
+        {
+            if (!File.Exists(path))
+            {
+                Debug.LogWarning($"{path} not exists");
+                return;
+            }
+            LoadModelAsync(path, File.ReadAllBytes(path));
+        }
+
+        async void LoadModelAsync(string path, byte[] bytes)
         {
             var size = bytes != null ? bytes.Length : 0;
             Debug.Log($"LoadModelAsync: {path}: {size}bytes");


### PR DESCRIPTION
https://github.com/vrm-c/UniVRM/pull/1756#issuecomment-1221776178
の修正で null 引数を受けなくなっていたのに追随。

`async void LoadModelAsync(string path, byte[] bytes = null)`

👇

`async void LoadModelAsync(string path, byte[] bytes)`
