### PR TITLE
Fix VRM exported from MigrationVrm class

### DIFF
--- a/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
+++ b/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
@@ -354,6 +354,11 @@ namespace UniVRM10
 
                 // Export
                 UniGLTF.Extensions.VRMC_materials_mtoon.GltfSerializer.SerializeTo(ref gltfMaterial.extensions, dst);
+
+                if (!gltf.extensionsUsed.Contains(UniGLTF.Extensions.VRMC_materials_mtoon.VRMC_materials_mtoon.ExtensionName))
+                {
+                    gltf.extensionsUsed.Add(UniGLTF.Extensions.VRMC_materials_mtoon.VRMC_materials_mtoon.ExtensionName);
+                }
             }
         }
     }

--- a/Assets/VRM10/Runtime/Migration/MigrationVrm.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrm.cs
@@ -39,7 +39,14 @@ namespace UniVRM10
             model.ConvertCoordinate(VrmLib.Coordinates.Vrm1);
 
             var (gltf, bin) = MeshUpdater.Execute(data, model);
+
+            // remove existing VRM0 extension
             gltf.extensions = null;
+            if (gltf.extensionsUsed.Contains("VRM"))
+            {
+                gltf.extensionsUsed.Remove("VRM");
+            }
+
             return MigrateVrm(gltf, bin, data.Json.ParseAsJson()["extensions"]["VRM"]);
         }
 
@@ -67,6 +74,7 @@ namespace UniVRM10
                 {
                     SpecVersion = Vrm10Exporter.VRM_SPEC_VERSION
                 };
+                gltf.extensionsUsed.Add(UniGLTF.Extensions.VRMC_vrm.VRMC_vrm.ExtensionName);
 
                 // meta (required)
                 vrm1.Meta = MigrationVrmMeta.Migrate(gltf, vrm0["meta"]);
@@ -132,6 +140,7 @@ namespace UniVRM10
             {
                 var springBone = MigrationVrmSpringBone.Migrate(gltf, vrm0SpringBone);
                 UniGLTF.Extensions.VRMC_springBone.GltfSerializer.SerializeTo(ref gltf.extensions, springBone);
+                gltf.extensionsUsed.Add(UniGLTF.Extensions.VRMC_springBone.VRMC_springBone.ExtensionName);
             }
 
             // Material

--- a/Assets/VRM10/Runtime/Migration/MigrationVrm.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrm.cs
@@ -63,7 +63,10 @@ namespace UniVRM10
 
             {
                 // vrm
-                var vrm1 = new UniGLTF.Extensions.VRMC_vrm.VRMC_vrm();
+                var vrm1 = new UniGLTF.Extensions.VRMC_vrm.VRMC_vrm
+                {
+                    SpecVersion = Vrm10Exporter.VRM_SPEC_VERSION
+                };
 
                 // meta (required)
                 vrm1.Meta = MigrationVrmMeta.Migrate(gltf, vrm0["meta"]);

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmMeta.cs
@@ -32,6 +32,7 @@ namespace UniVRM10
         {
             var meta = new UniGLTF.Extensions.VRMC_vrm.Meta
             {
+                LicenseUrl = Vrm10Exporter.LICENSE_URL_JA,
                 AllowPoliticalOrReligiousUsage = false,
                 AllowExcessivelySexualUsage = false,
                 AllowExcessivelyViolentUsage = false,

--- a/Assets/VRM10/Runtime/Migration/MigrationVrmSpringBone.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmSpringBone.cs
@@ -184,6 +184,7 @@ namespace UniVRM10
         {
             var springBone = new VRMC_springBone
             {
+                SpecVersion = Vrm10Exporter.SPRINGBONE_SPEC_VERSION,
                 Colliders = new List<Collider>(),
                 ColliderGroups = new List<ColliderGroup>(),
                 Springs = new List<Spring>(),


### PR DESCRIPTION
### Description

`MigrationVrm` から出力されたVRMが仕様に適合しないので、これを仕様に適合する形に更新します。

- `specVersion` が抜けていたのを修正しました。
- `licenseUrl` が抜けていたのを修正しました。
- `extensionsUsed` の不整合を修正しました。
