### PR TITLE
Fix VRM exported from MigrationVrm class (2)

### DIFF
--- a/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
+++ b/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
@@ -359,6 +359,11 @@ namespace UniVRM10
                 {
                     gltf.extensionsUsed.Add(UniGLTF.Extensions.VRMC_materials_mtoon.VRMC_materials_mtoon.ExtensionName);
                 }
+
+                if (!gltf.extensionsUsed.Contains(glTF_KHR_texture_transform.ExtensionName))
+                {
+                    gltf.extensionsUsed.Add(glTF_KHR_texture_transform.ExtensionName);
+                }
             }
         }
     }


### PR DESCRIPTION
Sequel of #1787

### Description

先のPRについて、追加で `KHR_texture_transform` を `extensionUsed` に追加する必要があったので、これを追加しました。
