### PR TITLE
Fix bug of null access when loading vrm1.0 prefab placed in the scene.

### DIFF
--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -28,7 +28,12 @@ namespace UniVRM10
 
         private FastSpringBoneBuffer m_fastSpringBoneBuffer;
 
+        /// <summary>
+        /// Control Rig may be null.
+        /// Control Rig is generated at loading runtime only.
+        /// </summary>
         public Vrm10RuntimeControlRig ControlRig { get; }
+
         public IVrm10Constraint[] Constraints { get; }
         public Vrm10RuntimeExpression Expression { get; }
         public Vrm10RuntimeLookAt LookAt { get; }
@@ -165,7 +170,7 @@ namespace UniVRM10
         public void Process()
         {
             // 1. Control Rig
-            ControlRig.Process();
+            ControlRig?.Process();
 
             // 2. Constraints
             foreach (var constraint in Constraints)


### PR DESCRIPTION
ControlRig は nullable だがそれを考慮できていない。

ControlRig は初期状態として T ポーズであることを要求するが、それを担保できるのは現状 Rutime Load だけ。
したがって Editor で Prefab 配置した場合は現状 ControlRig は生成できない。