### PR TITLE
[1.0] format に matcapColor 反映

### DIFF
--- a/Assets/VRM10/Runtime/Format/Vrm/Format.g.cs
+++ b/Assets/VRM10/Runtime/Format/Vrm/Format.g.cs
@@ -402,6 +402,7 @@ namespace UniGLTF.Extensions.VRMC_vrm
         color,
         emissionColor,
         shadeColor,
+        matcapColor,
         rimColor,
         outlineColor,
 


### PR DESCRIPTION
https://github.com/vrm-c/vrm-specification/pull/394

に追随。

- submodule の前進
- コード生成の実行 (Format.g.cs)

のみです。
`matcapColor` を使う Import/Export の追記も必用。
