### PR TITLE
Offload reading glTF_VRM_Meta properties to other task

### DIFF
--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -299,15 +299,10 @@ namespace VRM
             }
 
             var meta = ScriptableObject.CreateInstance<VRMMetaObject>();
-            meta.name = "Meta";
+            meta.name            = "Meta";
             meta.ExporterVersion = VRM.exporterVersion;
 
             var gltfMeta = VRM.meta;
-            meta.Version = gltfMeta.version; // model version
-            meta.Author = gltfMeta.author;
-            meta.ContactInformation = gltfMeta.contactInformation;
-            meta.Reference = gltfMeta.reference;
-            meta.Title = gltfMeta.title;
             if (gltfMeta.texture >= 0)
             {
                 if (GltfTextureImporter.TryCreateSrgb(Data, gltfMeta.texture, Vector2.zero, Vector2.one, out var key, out var desc))
@@ -315,14 +310,22 @@ namespace VRM
                     meta.Thumbnail = await TextureFactory.GetTextureAsync(desc, awaitCaller) as Texture2D;
                 }
             }
-            meta.AllowedUser = gltfMeta.allowedUser;
-            meta.ViolentUssage = gltfMeta.violentUssage;
-            meta.SexualUssage = gltfMeta.sexualUssage;
-            meta.CommercialUssage = gltfMeta.commercialUssage;
-            meta.OtherPermissionUrl = gltfMeta.otherPermissionUrl;
+            await awaitCaller.Run(() => 
+            {
+                meta.Version = gltfMeta.version; // model version
+                meta.Author = gltfMeta.author;
+                meta.ContactInformation = gltfMeta.contactInformation;
+                meta.Reference = gltfMeta.reference;
+                meta.Title = gltfMeta.title;
+                meta.AllowedUser = gltfMeta.allowedUser;
+                meta.ViolentUssage = gltfMeta.violentUssage;
+                meta.SexualUssage = gltfMeta.sexualUssage;
+                meta.CommercialUssage = gltfMeta.commercialUssage;
+                meta.OtherPermissionUrl = gltfMeta.otherPermissionUrl;
 
-            meta.LicenseType = gltfMeta.licenseType;
-            meta.OtherLicenseUrl = gltfMeta.otherLicenseUrl;
+                meta.LicenseType = gltfMeta.licenseType;
+                meta.OtherLicenseUrl = gltfMeta.otherLicenseUrl;
+            });
 
             return meta;
         }


### PR DESCRIPTION
`glTF_VRM_Meta` の持つプロパティには、長い時間がかかるものがあります。
このPRは `IAwaitCaller.Run()` を利用し、それを緩和するものです。

## 疑問点

カジュアルに `IAwaitCaller.Run()` を使用していますが、これが許されるものなのか、良く分かっていません。
手元の UnityEditor およびアプリケーションのターゲットでは問題無く動作していますが、WebGL等で困るケースがあり得るのか、事情を理解できていない部分があります。
