### PR TITLE
Fix migration behaviour of matcap.

### DIFF
--- a/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
+++ b/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
@@ -254,12 +254,17 @@ namespace UniVRM10
                 // Rim Lighting
                 if (mtoon.TextureIndexMap.SphereAdd.HasValue)
                 {
-                    // Matcap behaviour will change in VRM 1.0.
+                    // NOTE: MatCap behaviour will change in VRM 1.0.
+                    // Texture transform is not required.
                     dst.MatcapTexture = new TextureInfo
                     {
                         Index = mtoon.TextureIndexMap.SphereAdd.Value
                     };
-                    // Texture transform is not required.
+                    dst.MatcapFactor = new [] { 1f, 1f, 1f };
+                }
+                else
+                {
+                    dst.MatcapFactor = new[] { 0f, 0f, 0f };
                 }
                 dst.ParametricRimColorFactor = mtoon.Definition.Rim.RimColor.ToFloat3(ColorSpace.sRGB, ColorSpace.Linear);
                 dst.ParametricRimFresnelPowerFactor = mtoon.Definition.Rim.RimFresnelPowerValue;
@@ -279,7 +284,10 @@ namespace UniVRM10
                         );
                     }
                 }
-                dst.RimLightingMixFactor = mtoon.Definition.Rim.RimLightingMixValue;
+                // NOTE: DESTRUCTIVE MIGRATION
+                // Rim Lighting behaviour will be merged with MatCap in VRM 1.0.
+                // So, RimLightingMixFactor set to 1.0, because it is safe appearance.
+                dst.RimLightingMixFactor = 1.0f;
 
                 // Outline
                 const float centimeterToMeter = 0.01f;


### PR DESCRIPTION
`matcapFactor` の追加に伴い、マイグレーションにバグがありました。これを直します。

具体的には MatCap テクスチャが存在するときは `matcapFactor` を `1.0` に設定するようにしました。
また `RimLightingLightingMixFactor` も、 Parametric Rim と Matcap の統合により曖昧なパラメタになっているので
これを一律に安全な見た目に倒すように変更しました。