### PR TITLE
Fix uv rotation coords of vrm-1.0

### DIFF
--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
@@ -152,7 +152,9 @@ namespace UniVRM10
                 const float invertY = -1f;
                 mtoon.UvAnimationScrollYSpeedFactor = context.UvAnimationScrollYSpeedFactor * invertY;
             }
-            mtoon.UvAnimationRotationSpeedFactor = context.UvAnimationRotationSpeedFactor;
+            // Speed unit Conversion
+            const float rotationPerSecToRadianPerSec = Mathf.PI * 2f;
+            mtoon.UvAnimationRotationSpeedFactor = context.UvAnimationRotationSpeedFactor * rotationPerSecToRadianPerSec;
 
             // Texture Transforms
             var scale = context.TextureScale;

--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
@@ -154,7 +154,9 @@ namespace UniVRM10
             }
             // Speed unit Conversion
             const float rotationPerSecToRadianPerSec = Mathf.PI * 2f;
-            mtoon.UvAnimationRotationSpeedFactor = context.UvAnimationRotationSpeedFactor * rotationPerSecToRadianPerSec;
+            // Coords conversion
+            const float unityToGltfCoordsConversion = -1f;
+            mtoon.UvAnimationRotationSpeedFactor = context.UvAnimationRotationSpeedFactor * rotationPerSecToRadianPerSec * unityToGltfCoordsConversion;
 
             // Texture Transforms
             var scale = context.TextureScale;

--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialImporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialImporter.cs
@@ -224,7 +224,9 @@ namespace UniVRM10
             var uvAnimSpeedRotation = mToon?.UvAnimationRotationSpeedFactor;
             if (uvAnimSpeedRotation.HasValue)
             {
-                yield return (MToon10Prop.UvAnimationRotationSpeedFactor.ToUnityShaderLabName(), uvAnimSpeedRotation.Value);
+                // Speed unit Conversion
+                const float radianPerSecToRotationPerSec = 1f / (Mathf.PI * 2f);
+                yield return (MToon10Prop.UvAnimationRotationSpeedFactor.ToUnityShaderLabName(), uvAnimSpeedRotation.Value * radianPerSecToRotationPerSec);
             }
 
             // UI

--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialImporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialImporter.cs
@@ -226,7 +226,9 @@ namespace UniVRM10
             {
                 // Speed unit Conversion
                 const float radianPerSecToRotationPerSec = 1f / (Mathf.PI * 2f);
-                yield return (MToon10Prop.UvAnimationRotationSpeedFactor.ToUnityShaderLabName(), uvAnimSpeedRotation.Value * radianPerSecToRotationPerSec);
+                // Coords conversion
+                const float gltfToUnityCoordsConversion = -1f;
+                yield return (MToon10Prop.UvAnimationRotationSpeedFactor.ToUnityShaderLabName(), uvAnimSpeedRotation.Value * radianPerSecToRotationPerSec * gltfToUnityCoordsConversion);
             }
 
             // UI


### PR DESCRIPTION
In vrm 1.0 specification, The uv rotation speed unit is radian per second.
UniVRM implementation uses rotation per second.
It must be converted.

In vrm 1.0 specification, the uv rotation direction is counter-clockwise in uv coords.
And the texture coordinates is different between glTF and Unity.
Therefore, the speed parameter must be inverted.

|\ | glTF | Unity |
| --- | --- | --- |
| rotation speed | positive | positive | 
| uv in uv coords | CCW (Bottom-left origin) | CCW (Bottom-left origin) |
| uv in texture coords | CW (Top-left origin) | CCW (Bottom-left origin) |
| image on mesh | CCW | CW (inverted 😭) |

https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_mtoon-1.0
https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#images