### PR TITLE
Invert UV rotation direction of MToon 1.0 import/export.

### DIFF
--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialExporter.cs
@@ -154,9 +154,7 @@ namespace UniVRM10
             }
             // Speed unit Conversion
             const float rotationPerSecToRadianPerSec = Mathf.PI * 2f;
-            // Coords conversion
-            const float unityToGltfCoordsConversion = -1f;
-            mtoon.UvAnimationRotationSpeedFactor = context.UvAnimationRotationSpeedFactor * rotationPerSecToRadianPerSec * unityToGltfCoordsConversion;
+            mtoon.UvAnimationRotationSpeedFactor = context.UvAnimationRotationSpeedFactor * rotationPerSecToRadianPerSec;
 
             // Texture Transforms
             var scale = context.TextureScale;

--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialImporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MToonMaterialImporter.cs
@@ -226,9 +226,7 @@ namespace UniVRM10
             {
                 // Speed unit Conversion
                 const float radianPerSecToRotationPerSec = 1f / (Mathf.PI * 2f);
-                // Coords conversion
-                const float gltfToUnityCoordsConversion = -1f;
-                yield return (MToon10Prop.UvAnimationRotationSpeedFactor.ToUnityShaderLabName(), uvAnimSpeedRotation.Value * radianPerSecToRotationPerSec * gltfToUnityCoordsConversion);
+                yield return (MToon10Prop.UvAnimationRotationSpeedFactor.ToUnityShaderLabName(), uvAnimSpeedRotation.Value * radianPerSecToRotationPerSec);
             }
 
             // UI


### PR DESCRIPTION
https://github.com/vrm-c/UniVRM/pull/1826 was wrong interpretation.
This pull request is correct.

glTF uses U-right V-down space in the texture coords. [[refs]](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#images)
Unity uses U-right V-up space in the texture coords. [[refs]](https://docs.unity3d.com/ScriptReference/Mesh-uv.html)

Directions of the positive rotation value
|\ | glTF (KHR_texture_transform & vrmc_materials_mtoon-1.0) | Unity |
| --- | --- | --- |
| uv in mathematical coords | CW (U-right V-up space) | CCW (U-right V-up space) |
| uv in texture coords | CCW (U-right V-down space) **[specification]** | CCW (U-right V-up space) |
| image on mesh | CW 👍 | CW 👍  |

reference: 
https://github.com/KhronosGroup/glTF/pull/1624