### PR TITLE
Rename Texture2D.Resize to Reinitialize

### DIFF
--- a/Assets/VRM/Editor/BlendShape/BlendShapeClipEditorHelper.cs
+++ b/Assets/VRM/Editor/BlendShape/BlendShapeClipEditorHelper.cs
@@ -294,7 +294,11 @@ namespace VRM
 
             BilinearScale(0, newHeight);
 
+#if UNITY_2021_2_OR_NEWER
+            tex.Reinitialize(newWidth, newHeight);
+#else
             tex.Resize(newWidth, newHeight);
+#endif
             tex.SetPixels(newColors);
             tex.Apply();
         }

--- a/Assets/VRM10/Editor/Components/Expression/ExpressionEditorHelper.cs
+++ b/Assets/VRM10/Editor/Components/Expression/ExpressionEditorHelper.cs
@@ -190,7 +190,11 @@ namespace UniVRM10
 
             BilinearScale(0, newHeight);
 
+#if UNITY_2021_2_OR_NEWER
+            tex.Reinitialize(newWidth, newHeight);
+#else
             tex.Resize(newWidth, newHeight);
+#endif
             tex.SetPixels(newColors);
             tex.Apply();
         }


### PR DESCRIPTION
# 概要
Unity 2021.2以上でTexture2D.Resizeを使用するとAPIの更新が求められます。 

# 詳細
## 再現方法
1. Unity 2021.2でプロジェクトを作成
2. UniVRMとVRMのunitypackageを追加（[リンク](https://github.com/vrm-c/UniVRM/releases/tag/v0.104.1)）

UPMの`Add package from disk...`を使用した場合も同様の結果が得られます

## 発生する問題
以下の2個のファイルに対して、APIの更新が求められます。
* `Assets/VRM/Editor/BlendShape/BlendShapeClipEditorHelper.cs`
* `Assets/VRM10/Editor/Components/Expression/ExpressionEditorHelper.cs`
![](https://user-images.githubusercontent.com/40651807/194043294-fb2cf8a2-b350-4bd8-8585-882f20550dba.png)
![](https://user-images.githubusercontent.com/40651807/194043257-40fe5332-7fc8-4b94-946d-a3c347fa30be.png)

## 解決法
`UNITY_2021_2_OR_NEWER`の#ifディレクティブを追加しました

## 参照
[What's new in Unity 2021.2.0 - Unity](https://unity3d.com/jp/unity/whats-new/2021.2.0)
```
Graphics: Changed: Renamed Texture2D.Resize to Reinitialize. ([1312670](https://issuetracker.unity3d.com/issues/texture2d-dot-resize-toggles-graphicsformat-each-time-its-called-between-linear-and-srgb))
```

[Unity Issue Tracker - Texture2D.Resize toggles GraphicsFormat each time it&#39;s called between linear and sRGB](https://issuetracker.unity3d.com/issues/texture2d-dot-resize-toggles-graphicsformat-each-time-its-called-between-linear-and-srgb)