### PR TITLE
[Unity-2019] fix `??=`.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/GltfTextureImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/GltfTextureImporter.cs
@@ -151,7 +151,10 @@ namespace UniGLTF
                     {
                         name = TextureImportName.GetUnityObjectName(TextureImportTypes.StandardMap, gltfTexture.name, gltfImage.uri);
                     }
-                    sampler ??= TextureSamplerUtil.CreateSampler(data.GLTF, occlusionTextureIndex.Value);
+                    if (sampler == null)
+                    {
+                        sampler = TextureSamplerUtil.CreateSampler(data.GLTF, occlusionTextureIndex.Value);
+                    }
                     getOcclusionAsync = () => Task.FromResult(GetImageBytesFromImageIndex(data, imageIndex.Value));
                 }
             }


### PR DESCRIPTION
fixed #1840

This is cause `CS1525: Invalid expression term '='` in Unity-2019. 
