### PR TITLE
feature: add third argument `vrmMeta` to static Vrm10Exporter.Export

### DIFF
--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -772,7 +772,7 @@ namespace UniVRM10
         /// <param name="go"></param>
         /// <param name="getTextureBytes"></param>
         /// <returns></returns>
-        public static byte[] Export(GameObject go, ITextureSerializer textureSerializer = null)
+        public static byte[] Export(GameObject go, ITextureSerializer textureSerializer = null, VRM10ObjectMeta vrmMeta = null)
         {
             using (var arrayManager = new NativeArrayManager())
             {
@@ -788,7 +788,7 @@ namespace UniVRM10
                 var option = new VrmLib.ExportArgs
                 {
                 };
-                exporter10.Export(go, model, converter, option);
+                exporter10.Export(go, model, converter, option, vrmMeta);
                 return exporter10.Storage.ToGlbBytes();
             }
         }


### PR DESCRIPTION
### Description

`Vrm10Exporter` のstaticの `Export` にoptionalな第三引数 `vrmMeta` を追加しました。
`Vrm10Exporter` のstaticじゃない `Export` メソッドにあったoptionalな `vrmMeta` にそのまま渡します。
