### PR TITLE
Fix/osx multi extensions

### DIFF
--- a/Assets/UniGLTF/Editor/TopMenuImplementation.cs
+++ b/Assets/UniGLTF/Editor/TopMenuImplementation.cs
@@ -15,7 +15,14 @@ namespace UniGLTF
 
         public static void ImportGltfFileToGameObject()
         {
-            var path = EditorUtility.OpenFilePanel("open glb", "", "gltf,glb,zip");
+            var path = EditorUtility.OpenFilePanel("open glb", "",
+#if UNITY_EDITOR_OSX
+                // https://github.com/vrm-c/UniVRM/issues/1837
+                "glb"
+#else
+                "gltf,glb,zip"
+#endif
+);
             if (string.IsNullOrEmpty(path))
             {
                 return;

--- a/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/SaveFileDialog.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/SaveFileDialog.cs
@@ -7,6 +7,18 @@ namespace UniGLTF
     public static class SaveFileDialog
     {
         static string m_lastExportDir;
+
+        static string extensionString(string[] extensions)
+        {
+#if UNITY_EDITOR_OSX
+            // in OSX multi extension cause exception.
+            // https://github.com/vrm-c/UniVRM/issues/1837
+            return extensions.Length > 0 ? extensions[0] : "";
+#else
+            return string.Join(",", extensions);
+#endif
+        }
+
         public static string GetPath(string title, string name, params string[] extensions)
         {
             string directory = m_lastExportDir;
@@ -15,7 +27,7 @@ namespace UniGLTF
                 directory = Directory.GetParent(Application.dataPath).ToString();
             }
 
-            var path = EditorUtility.SaveFilePanel(title, directory, name, string.Join(",", extensions));
+            var path = EditorUtility.SaveFilePanel(title, directory, name, extensionString(extensions));
             if (!string.IsNullOrEmpty(path))
             {
                 m_lastExportDir = Path.GetDirectoryName(path).Replace("\\", "/");

--- a/Assets/UniGLTF_Samples/GltfViewer/OpenFileDialog/OpenFileDialog.cs
+++ b/Assets/UniGLTF_Samples/GltfViewer/OpenFileDialog/OpenFileDialog.cs
@@ -7,6 +7,7 @@ namespace UniGLTF.GltfViewer
 #if UNITY_STANDALONE_WIN
             return VRMShaders.PathObject.FromFullPath(FileDialogForWindows.FileDialog(title, extensions));
 #else
+            Debug.LogWarning("Non-Windows runtime file dialogs are not yet implemented.");
             return default;
 #endif
         }

--- a/Assets/VRM_Samples/SimpleViewer/FileDialog/FileUtil.cs
+++ b/Assets/VRM_Samples/SimpleViewer/FileDialog/FileUtil.cs
@@ -5,7 +5,7 @@ namespace VRM.SimpleViewer
         public static string OpenFileDialog(string title, params string[] extensions)
         {
 #if UNITY_STANDALONE_WIN
-            return FileDialogForWindows.FileDialog("open VRM", "vrm", "bvh");
+            return FileDialogForWindows.FileDialog(title, extensions);
 #elif UNITY_WEBGL
             // Open WebGLFileDialog
             // see: Assets\VRM_Samples\SimpleViewer\Plugins\OpenFile.jslib
@@ -15,9 +15,11 @@ namespace VRM.SimpleViewer
 #elif UNITY_EDITOR
             // EditorUtility.OpenFilePanel
             // TODO: How to specify multiple extensions on OSX?
-            return UnityEditor.EditorUtility.OpenFilePanel("Open VRM", "", "vrm");
+            // https://github.com/vrm-c/UniVRM/issues/1837
+            return UnityEditor.EditorUtility.OpenFilePanel(title, "", extensions[0]);
 #else
             // fall back constant path
+            Debug.LogWarning("Non-Windows runtime file dialogs are not yet implemented.");
             return Application.dataPath + "/default.vrm";
 #endif
         }


### PR DESCRIPTION
`#if UNITY_EDITOR_OSX` で複数拡張子が関数に渡らないようにした