### PR TITLE
サポートされていないシェーダーが含まれるモデルのプレビューをできるように

### DIFF
--- a/Assets/VRM10/Editor/Components/Expression/VRM10ExpressionEditor.cs
+++ b/Assets/VRM10/Editor/Components/Expression/VRM10ExpressionEditor.cs
@@ -317,5 +317,11 @@ namespace UniVRM10
 
             serializedObject.ApplyModifiedProperties();
         }
+
+        public override string GetInfoString()
+        {
+            if (m_scene == null) return "";
+            return m_scene.hasError ? "An error occurred while previewing. Check the console log for details." : "";
+        }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMaterialUtil.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMaterialUtil.cs
@@ -9,9 +9,9 @@ namespace UniVRM10
 {
     public static class PreviewMaterialUtil
     {
-        public static PreviewMaterialItem CreateForPreview(Material material)
+        public static bool TryCreateForPreview(Material material, out PreviewMaterialItem item)
         {
-            var item = new PreviewMaterialItem(material);
+            item = new PreviewMaterialItem(material);
 
             var propNames = new List<string>();
             for (int i = 0; i < ShaderUtil.GetPropertyCount(material.shader); ++i)
@@ -24,11 +24,24 @@ namespace UniVRM10
                     case ShaderUtil.ShaderPropertyType.Color:
                         // 色
                         {
-                            var bindType = PreviewMaterialItem.GetBindType(name);
+                            if (!PreviewMaterialItem.TryGetBindType(name, out var bindType))
+                            {
+                                Debug.LogError($"{material.shader.name}.{name} is unsupported property name");
+                                item = null;
+                                return false;
+                            }
+
+                            if (!Enum.TryParse(propType.ToString(), true, out ShaderPropertyType propertyType))
+                            {
+                                Debug.LogError($"{material.shader.name}.{propertyType.ToString()} is unsupported property type");
+                                item = null;
+                                return false;
+                            }
+                            
                             item.PropMap.Add(bindType, new PropItem
                             {
                                 Name = name,
-                                PropertyType = (UniVRM10.ShaderPropertyType)Enum.Parse(typeof(UniVRM10.ShaderPropertyType), propType.ToString(), true),
+                                PropertyType = propertyType,
                                 DefaultValues = material.GetColor(name),
                             });
                             propNames.Add(name);
@@ -40,7 +53,7 @@ namespace UniVRM10
                 }
             }
             item.PropNames = propNames.ToArray();
-            return item;
+            return true;
         }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMaterialUtil.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMaterialUtil.cs
@@ -14,6 +14,7 @@ namespace UniVRM10
             item = new PreviewMaterialItem(material);
 
             var propNames = new List<string>();
+            var hasError = false;
             for (int i = 0; i < ShaderUtil.GetPropertyCount(material.shader); ++i)
             {
                 var propType = ShaderUtil.GetPropertyType(material.shader, i);
@@ -27,15 +28,15 @@ namespace UniVRM10
                             if (!PreviewMaterialItem.TryGetBindType(name, out var bindType))
                             {
                                 Debug.LogError($"{material.shader.name}.{name} is unsupported property name");
-                                item = null;
-                                return false;
+                                hasError = true;
+                                continue;
                             }
 
                             if (!Enum.TryParse(propType.ToString(), true, out ShaderPropertyType propertyType))
                             {
                                 Debug.LogError($"{material.shader.name}.{propertyType.ToString()} is unsupported property type");
-                                item = null;
-                                return false;
+                                hasError = true;
+                                continue;
                             }
                             
                             item.PropMap.Add(bindType, new PropItem
@@ -53,7 +54,8 @@ namespace UniVRM10
                 }
             }
             item.PropNames = propNames.ToArray();
-            return true;
+
+            return !hasError;
         }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
@@ -13,6 +13,8 @@ namespace UniVRM10
     {
         public GameObject Prefab;
 
+        public bool hasError;
+
 #if UNITY_EDITOR
         public static PreviewSceneManager GetOrCreate(GameObject prefab)
         {
@@ -75,6 +77,8 @@ namespace UniVRM10
 #if UNITY_EDITOR
         private void Initialize(GameObject prefab)
         {
+            hasError = false;
+            
             //Debug.LogFormat("[PreviewSceneManager.Initialize] {0}", prefab);
             Prefab = prefab;
 
@@ -97,6 +101,7 @@ namespace UniVRM10
                     
                     if (!PreviewMaterialUtil.TryCreateForPreview(dst, out var previewMaterialItem))
                     {
+                        hasError = true;
                         // Return cloned material for preview
                         return dst;
                     }

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
@@ -94,10 +94,17 @@ namespace UniVRM10
                 {
                     dst = new Material(src);
                     map.Add(src, dst);
+                    
+                    if (!PreviewMaterialUtil.TryCreateForPreview(dst, out var previewMaterialItem))
+                    {
+                        // Return cloned material for preview
+                        return dst;
+                    }
+                    
+                    m_materialMap.Add(src.name, previewMaterialItem);
 
                     //Debug.LogFormat("add material {0}", src.name);
                     materialNames.Add(src.name);
-                    m_materialMap.Add(src.name, PreviewMaterialUtil.CreateForPreview(dst));
                 }
                 return dst;
             };

--- a/Assets/VRM10/Runtime/Components/Expression/PreviewMaterialItem.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/PreviewMaterialItem.cs
@@ -85,34 +85,39 @@ namespace UniVRM10
         public static readonly string SHADE_COLOR_PROPERTY = MToon10Prop.ShadeColorFactor.ToUnityShaderLabName();
         public static readonly string MATCAP_COLOR_PROPERTY = MToon10Prop.MatcapColorFactor.ToUnityShaderLabName();
 
-        public static MaterialColorType GetBindType(string property)
+        public static bool TryGetBindType(string property, out MaterialColorType type)
         {
             if (property == COLOR_PROPERTY)
             {
-                return MaterialColorType.color;
+                type = MaterialColorType.color;
             }
-            if (property == EMISSION_COLOR_PROPERTY)
+            else if (property == EMISSION_COLOR_PROPERTY)
             {
-                return MaterialColorType.emissionColor;
+                type = MaterialColorType.emissionColor;
             }
-            if (property == RIM_COLOR_PROPERTY)
+            else if (property == RIM_COLOR_PROPERTY)
             {
-                return MaterialColorType.rimColor;
+                type = MaterialColorType.rimColor;
             }
-            if (property == OUTLINE_COLOR_PROPERTY)
+            else if (property == OUTLINE_COLOR_PROPERTY)
             {
-                return MaterialColorType.outlineColor;
+                type = MaterialColorType.outlineColor;
             }
-            if (property == SHADE_COLOR_PROPERTY)
+            else if (property == SHADE_COLOR_PROPERTY)
             {
-                return MaterialColorType.shadeColor;
+                type = MaterialColorType.shadeColor;
             }
-            if (property == MATCAP_COLOR_PROPERTY)
+            else if (property == MATCAP_COLOR_PROPERTY)
             {
-                return MaterialColorType.matcapColor;
+                type = MaterialColorType.matcapColor;
+            }
+            else
+            {
+                type = default;
+                return false;
             }
 
-            throw new NotImplementedException();
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
# 概要
サポートされていないシェーダーが含まれているモデルのVRM10 Expression Assetを選択するとプレビューが表示されない問題を修正しました。

![image](https://user-images.githubusercontent.com/40651807/197958357-973829ee-807b-4af8-ab0d-808bd6775dbd.png)

# 詳細
## 再現方法
1. UniVRMのプロジェクトを開く
2. `Assets\VRM10_Samples\ModelSetup_SeedSan\Materials\mtoon\hair.mat`のシェーダーを`Sprites/Diffuse`に変更する
3. `Assets\VRM10_Samples\ModelSetup_SeedSan\Expressions\aa.asset`を選択する

## 発生する問題
* UniVRM10.PreviewMaterialItem.GetBindTypeでNotImplementedExceptionが発生する
* Scene上に__PREVIEW_SCENE_MANGER__が残る

<details>
<summary>エラー全文</summary>

```
NotImplementedException: The method or operation is not implemented.
UniVRM10.PreviewMaterialItem.GetBindType (System.String property) (at Assets/VRM10/Runtime/Components/Expression/PreviewMaterialItem.cs:115)
UniVRM10.PreviewMaterialUtil.CreateForPreview (UnityEngine.Material material) (at Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMaterialUtil.cs:27)
UniVRM10.PreviewSceneManager+<>c__DisplayClass3_0.<Initialize>b__0 (UnityEngine.Material src) (at Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs:100)
UniVRM10.PreviewMeshItem+<>c__DisplayClass29_0.<Create>b__1 (UnityEngine.Material x) (at Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMeshItem.cs:117)
System.Linq.Enumerable+SelectArrayIterator`2[TSource,TResult].ToArray () (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
System.Linq.Enumerable.ToArray[TSource] (System.Collections.Generic.IEnumerable`1[T] source) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
UniVRM10.PreviewMeshItem.Create (UnityEngine.Transform t, UnityEngine.Transform root, System.Func`2[T,TResult] getOrCreateMaterial) (at Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMeshItem.cs:117)
UniVRM10.PreviewSceneManager+<>c__DisplayClass3_0.<Initialize>b__1 (UnityEngine.Transform x) (at Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs:106)
System.Linq.Enumerable+SelectEnumerableIterator`2[TSource,TResult].MoveNext () (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
System.Linq.Enumerable+WhereEnumerableIterator`1[TSource].ToArray () (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
System.Linq.Enumerable.ToArray[TSource] (System.Collections.Generic.IEnumerable`1[T] source) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
UniVRM10.PreviewSceneManager.Initialize (UnityEngine.GameObject prefab) (at Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs:105)
UniVRM10.PreviewSceneManager.GetOrCreate (UnityEngine.GameObject prefab) (at Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs:48)
UniVRM10.ExpressionEditor.OnInspectorGUI () (at Assets/VRM10/Editor/Components/Expression/VRM10ExpressionEditor.cs:293)
UnityEditor.UIElements.InspectorElement+<>c__DisplayClass59_0.<CreateIMGUIInspectorFromEditor>b__0 () (at <a2e8177b4fa7415e9fa7912e7cd20e7d>:0)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&)
```
</details>

## 解決法
Expressionでの操作に対応しているプロパティ名・型であるかを確認し、非対応のものがあった場合はエラーを出すようにしました。
[PreviewSceneManager.cs](https://github.com/vrm-c/UniVRM/compare/master...mkc1370:feature/preview_unsupported_shader?expand=1#diff-1da7871ddfc125c89e71db05547d9a508645e40a0736b2fbcf25427528e82b62)で非対応のシェーダーに対しては次のような対応をします。
* Expressionで編集可能なマテリアルリストには追加しない（紛らわしいので）
* 複製されたマテリアルをプレビュー用に返す（nullを返すとプレビューがシェーダーエラーになってしまうため）

VRM化する過程でUniVRM非対応のシェーダーが設定されているマテリアルが含まれる状態は起こり得ます。
そのため、完全にプレビューを表示させないのではなく、対応していないというエラーが出るもののプレビューの表示はできるという対応にしました。
