### PR TITLE
Consider thumbnail image's mimeType when loading the VRM 1.0 model.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/GltfTextureImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/GltfTextureImporter.cs
@@ -31,7 +31,7 @@ namespace UniGLTF
                 () =>
                 {
                     var imageBytes = data.GetBytesFromImage(imageIndex);
-                    return Task.FromResult<(byte[], string)?>((ToArray(imageBytes?.binary ?? default), null));
+                    return Task.FromResult<(byte[], string)?>((ToArray(imageBytes?.binary ?? default), imageBytes?.mimeType));
                 },
                 default, default, default, default, default);
             return (texDesc.SubAssetKey, texDesc);

--- a/Assets/VRM10/Runtime/IO/Texture/Vrm10TextureDescriptorGenerator.cs
+++ b/Assets/VRM10/Runtime/IO/Texture/Vrm10TextureDescriptorGenerator.cs
@@ -10,6 +10,8 @@ namespace UniVRM10
 {
     public sealed class Vrm10TextureDescriptorGenerator : ITextureDescriptorGenerator
     {
+        public const string UniqueThumbnailName = "thumbnail__VRM10";
+
         private readonly GltfData m_data;
         private TextureDescriptorSet _textureDescriptorSet;
 
@@ -69,8 +71,6 @@ namespace UniVRM10
             }
         }
 
-        public const string THUMBNAIL_NAME = "__VRM10_thumbnail__";
-
         /// <summary>
         /// VRM-1 の thumbnail テクスチャー。gltf.textures ではなく gltf.images の参照であることに注意(sampler等の設定が無い)
         /// </summary>
@@ -99,12 +99,7 @@ namespace UniVRM10
             // data.GLTF.textures は前処理によりユニーク性がある
             // unique な名前を振り出す
             var used = new HashSet<string>(data.GLTF.textures.Select(x => x.name));
-            var imageName = gltfImage.name;
-            if (string.IsNullOrEmpty(imageName))
-            {
-                imageName = THUMBNAIL_NAME;
-            }
-            var uniqueName = GlbLowLevelParser.FixNameUnique(used, imageName);
+            var uniqueName = GlbLowLevelParser.FixNameUnique(used, UniqueThumbnailName);
 
             value = GltfTextureImporter.CreateSrgbFromOnlyImage(data, imageIndex, uniqueName, gltfImage.uri);
             return true;

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Importer/UnityTextureDeserializer.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Importer/UnityTextureDeserializer.cs
@@ -17,8 +17,14 @@ namespace VRMShaders
                     break;
                 case "image/jpeg":
                     break;
+                case "":
+                    Debug.Log($"Texture image MIME type is empty.");
+                    break;
+                case null:
+                    Debug.Log($"Texture image MIME type is empty.");
+                    break;
                 default:
-                    Debug.LogWarning($"Texture image MIME type `{textureInfo.DataMimeType}` is not supported.");
+                    Debug.Log($"Texture image MIME type `{textureInfo.DataMimeType}` is not supported.");
                     break;
             }
 

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Importer/UnityTextureDeserializer.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Importer/UnityTextureDeserializer.cs
@@ -17,14 +17,15 @@ namespace VRMShaders
                     break;
                 case "image/jpeg":
                     break;
-                case "":
-                    Debug.Log($"Texture image MIME type is empty.");
-                    break;
-                case null:
-                    Debug.Log($"Texture image MIME type is empty.");
-                    break;
                 default:
-                    Debug.Log($"Texture image MIME type `{textureInfo.DataMimeType}` is not supported.");
+                    if (string.IsNullOrEmpty(textureInfo.DataMimeType))
+                    {
+                        Debug.Log($"Texture image MIME type is empty.");
+                    }
+                    else
+                    {
+                        Debug.Log($"Texture image MIME type `{textureInfo.DataMimeType}` is not supported.");
+                    }
                     break;
             }
 


### PR DESCRIPTION
VRM 1.0 モデルインポート時の挙動を修正。

- サムネイル画像の mimeType が `null` になっていたバグを修正。
- サムネイル画像の名前に対して強制的に `__UNIGLTF_DUPLICATED` suffix がついてしまっていた状態を解消。
  - Export 時に glTF texture を定義しているが、Import 時はこれを参照せず動的に glTF texture を生成するため名前が被る
- mimeType が予期しない値だった時のログを Warning から通常のレベルに変更。