### PR TITLE
Use static getter instead of preprocessors.

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/ExportDialogState.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/ExportDialogState.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
+using VRMShaders;
 
 namespace UniGLTF
 {
@@ -58,9 +59,10 @@ namespace UniGLTF
                 }
                 if (m_root.IsPrefab)
                 {
-#if VRM_DEVELOP
-                    Debug.Log($"PrefabUtility.UnloadPrefabContents({m_root.GameObject})");
-#endif
+                    if (Symbols.VRM_DEVELOP)
+                    {
+                        Debug.Log($"PrefabUtility.UnloadPrefabContents({m_root.GameObject})");
+                    }
                     PrefabUtility.UnloadPrefabContents(m_root.GameObject);
                 }
                 m_root = (value, isPrefab);

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterBase.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterBase.cs
@@ -57,9 +57,10 @@ namespace UniGLTF
         /// <param name="reverseAxis"></param>
         protected static void Import(ScriptedImporter scriptedImporter, AssetImportContext context, Axes reverseAxis, RenderPipelineTypes renderPipeline)
         {
-#if VRM_DEVELOP
-            Debug.Log("OnImportAsset to " + scriptedImporter.assetPath);
-#endif
+            if (Symbols.VRM_DEVELOP)
+            {
+                Debug.Log("OnImportAsset to " + scriptedImporter.assetPath);
+            }
 
             //
             // Import(create unity objects)

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/TextureExtractor.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/TextureExtractor.cs
@@ -92,9 +92,6 @@ namespace UniGLTF
                 {
                     // remap
                     var externalObject = targetPath.LoadAsset<Texture2D>();
-#if VRM_DEVELOP
-                    // Debug.Log($"remap: {targetPath} => {externalObject}");
-#endif
                     if (externalObject != null)
                     {
                         addRemap(key, externalObject);

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System.Linq;
+using VRMShaders;
 
 
 namespace UniGLTF.MeshUtility
@@ -53,11 +54,11 @@ namespace UniGLTF.MeshUtility
             {
                 var vertices = src.vertices;
                 var normals = src.normals;
-#if VRM_NORMALIZE_BLENDSHAPE_TANGENT
-                var tangents = src.tangents.Select(x => (Vector3)x).ToArray();
-#else
                 Vector3[] tangents = null;
-#endif
+                if (Symbols.VRM_NORMALIZE_BLENDSHAPE_TANGENT)
+                {
+                    tangents = src.tangents.Select(x => (Vector3)x).ToArray();
+                }
 
                 for (int i = 0; i < src.blendShapeCount; ++i)
                 {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContextExtensions.cs
@@ -22,9 +22,10 @@ namespace UniGLTF
                 throw new AggregateException(task.Exception);
             }
 
-#if VRM_DEVELOP
-            Debug.Log($"{self.Data.TargetPath}: {meassureTime.GetSpeedLog()}");
-#endif
+            if (Symbols.VRM_DEVELOP)
+            {
+                Debug.Log($"{self.Data.TargetPath}: {meassureTime.GetSpeedLog()}");
+            }
 
             return task.Result;
         }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfMaterialDescriptorGenerator.cs
@@ -16,9 +16,11 @@ namespace UniGLTF
             if (GltfUnlitMaterialImporter.TryCreateParam(data, i, out var param)) return param;
             if (GltfPbrMaterialImporter.TryCreateParam(data, i, out param)) return param;
             // fallback
-#if VRM_DEVELOP
-            Debug.LogWarning($"material: {i} out of range. fallback");
-#endif
+            if (Symbols.VRM_DEVELOP)
+            {
+                Debug.LogWarning($"material: {i} out of range. fallback");
+            }
+
             return new MaterialDescriptor(
                 GetMaterialName(i, null),
                 GltfPbrMaterialImporter.ShaderName, 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/GltfURPMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/GltfURPMaterialDescriptorGenerator.cs
@@ -17,9 +17,11 @@ namespace UniGLTF
             if (GltfUnlitMaterialImporter.TryCreateParam(data, i, out var param)) return param;
             if (GltfPbrUrpMaterialImporter.TryCreateParam(data, i, out param)) return param;
             // fallback
-#if VRM_DEVELOP
-            Debug.LogWarning($"material: {i} out of range. fallback");
-#endif
+            if (Symbols.VRM_DEVELOP)
+            {
+                Debug.LogWarning($"material: {i} out of range. fallback");
+            }
+
             return new MaterialDescriptor(
                 GetMaterialName(i, null),
                 GltfPbrMaterialImporter.ShaderName,

--- a/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorImporterContext.cs
@@ -118,10 +118,11 @@ namespace VRM
         {
             if (!string.IsNullOrEmpty(AssetDatabase.GetAssetPath(o)))
             {
-#if VRM_DEVELOP
-                // 来ない？
-                Debug.LogWarning($"{o} already exists. skip write");
-#endif
+                if (Symbols.VRM_DEVELOP)
+                {
+                    // 来ない？
+                    Debug.LogWarning($"{o} already exists. skip write");
+                }
                 return;
             }
 

--- a/Assets/VRM/Runtime/BlendShape/PreviewSceneManager.cs
+++ b/Assets/VRM/Runtime/BlendShape/PreviewSceneManager.cs
@@ -1,14 +1,9 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using System.Reflection;
 using System;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
+using VRMShaders;
 using UniGLTF;
-
 
 namespace VRM
 {
@@ -56,14 +51,17 @@ namespace VRM
             // HideFlags are special editor-only settings that let you have *secret* GameObjects in a scene, or to tell Unity not to save that temporary GameObject as part of the scene
             foreach (var x in go.transform.Traverse())
             {
-                x.gameObject.hideFlags = HideFlags.None
-                | HideFlags.DontSave
-                //| HideFlags.DontSaveInBuild
-#if VRM_DEVELOP
-#else
-                | HideFlags.HideAndDontSave
-#endif
-                ;
+                if (Symbols.VRM_DEVELOP)
+                {
+                    x.gameObject.hideFlags = HideFlags.None |
+                                             HideFlags.DontSave;
+                }
+                else
+                {
+                    x.gameObject.hideFlags = HideFlags.None |
+                                             HideFlags.DontSave |
+                                             HideFlags.HideAndDontSave;
+                }
             }
 
             return manager;

--- a/Assets/VRM/Runtime/IO/VRMURPMaterialDescriptorGenerator.cs
+++ b/Assets/VRM/Runtime/IO/VRMURPMaterialDescriptorGenerator.cs
@@ -22,9 +22,10 @@ namespace VRM
             // pbr "Standard" to "Universal Render Pipeline/Lit" 
             if (GltfPbrUrpMaterialImporter.TryCreateParam(data, i, out matDesc)) return matDesc;
             // fallback
-#if VRM_DEVELOP
-            Debug.LogWarning($"material: {i} out of range. fallback");
-#endif
+            if (Symbols.VRM_DEVELOP)
+            {
+                Debug.LogWarning($"material: {i} out of range. fallback");
+            }
             return new MaterialDescriptor(
                 GltfMaterialDescriptorGenerator.GetMaterialName(i, null),
                 GltfPbrMaterialImporter.ShaderName,

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
@@ -73,9 +73,10 @@ namespace UniVRM10
         /// <param name="doNormalize">normalize する</param>
         public static void Import(ScriptedImporter scriptedImporter, AssetImportContext context, bool doMigrate, RenderPipelineTypes renderPipeline)
         {
-#if VRM_DEVELOP
-            Debug.Log("OnImportAsset to " + scriptedImporter.assetPath);
-#endif
+            if (Symbols.VRM_DEVELOP)
+            {
+                Debug.Log("OnImportAsset to " + scriptedImporter.assetPath);
+            }
 
             // 1st parse as vrm1
             using (var data = new GlbFileParser(scriptedImporter.assetPath).Parse())

--- a/Assets/VRM10/Editor/Vrm10TopMenu.cs
+++ b/Assets/VRM10/Editor/Vrm10TopMenu.cs
@@ -7,19 +7,18 @@ namespace UniVRM10
         private const string UserMenuPrefix = VRMVersion.MENU;
         private const string DevelopmentMenuPrefix = VRMVersion.MENU + "/Development";
 
-        const string CONVERT_HUMANOID_KEY = VRMVersion.MENU + "/Export VRM-1.0";
         [MenuItem(UserMenuPrefix + "/Export VRM-1.0", priority = 1)]
-        static void OpenExportDialog() => VRM10ExportDialog.Open();
+        private static void OpenExportDialog() => VRM10ExportDialog.Open();
 
 #if VRM_DEVELOP        
         [MenuItem(UserMenuPrefix + "/VRM1 Window", false, 2)]
-        static void OpenWindow() => VRM10Window.Open();
+        private static void OpenWindow() => VRM10Window.Open();
 
         [MenuItem(DevelopmentMenuPrefix + "/Generate from JsonSchema")]
-        public static void Generate() => Vrm10SerializerGenerator.Run(false);
+        private static void Generate() => Vrm10SerializerGenerator.Run(false);
 
         [MenuItem(DevelopmentMenuPrefix + "/Generate from JsonSchema(debug)")]
-        public static void Parse() => Vrm10SerializerGenerator.Run(true);
+        private static void Parse() => Vrm10SerializerGenerator.Run(true);
 #endif
     }
 }

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using UnityEngine;
 using System;
+using VRMShaders;
 
 
 namespace UniVRM10
@@ -52,14 +53,17 @@ namespace UniVRM10
             // HideFlags are special editor-only settings that let you have *secret* GameObjects in a scene, or to tell Unity not to save that temporary GameObject as part of the scene
             foreach (var x in go.transform.Traverse())
             {
-                x.gameObject.hideFlags = HideFlags.None
-                | HideFlags.DontSave
-                //| HideFlags.DontSaveInBuild
-#if VRM_DEVELOP
-#else
-                | HideFlags.HideAndDontSave
-#endif
-                ;
+                if (Symbols.VRM_DEVELOP)
+                {
+                    x.gameObject.hideFlags = HideFlags.None |
+                                             HideFlags.DontSave;
+                }
+                else
+                {
+                    x.gameObject.hideFlags = HideFlags.None |
+                                             HideFlags.DontSave |
+                                             HideFlags.HideAndDontSave;
+                }
             }
 
             return manager;

--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MaterialDescriptorGenerator.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MaterialDescriptorGenerator.cs
@@ -17,9 +17,10 @@ namespace UniVRM10
             // pbr
             if (GltfPbrMaterialImporter.TryCreateParam(data, i, out matDesc)) return matDesc;
             // fallback
-#if VRM_DEVELOP
-            Debug.LogWarning($"material: {i} out of range. fallback");
-#endif
+            if (Symbols.VRM_DEVELOP)
+            {
+                Debug.LogWarning($"material: {i} out of range. fallback");
+            }
             return new MaterialDescriptor(
                 GltfMaterialDescriptorGenerator.GetMaterialName(i, null), GltfPbrMaterialImporter.ShaderName, 
                 null, 

--- a/Assets/VRM10/Runtime/Migration/Materials/Vrm0XMToonValue.cs
+++ b/Assets/VRM10/Runtime/Migration/Materials/Vrm0XMToonValue.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using UniGLTF;
 using UniJSON;
 using UnityEngine;
+using VRMShaders;
 using ColorSpace = VRMShaders.ColorSpace;
 
 namespace UniVRM10
@@ -84,9 +85,10 @@ namespace UniVRM10
                         break;
 
                     default:
-#if VRM_DEVELOP
-                        Debug.LogWarning($"vectorProperties: {kv.Key}: {kv.Value}");
-#endif
+                        if (Symbols.VRM_DEVELOP)
+                        {
+                            Debug.LogWarning($"vectorProperties: {kv.Key}: {kv.Value}");
+                        }
                         break;
                 }
             }
@@ -187,9 +189,10 @@ namespace UniVRM10
                         break;
 
                     default:
-#if VRM_DEVELOP
-                        Debug.LogWarning($"floatProperties: {kv.Key} is unknown");
-#endif
+                        if (Symbols.VRM_DEVELOP)
+                        {
+                            Debug.LogWarning($"floatProperties: {kv.Key} is unknown");
+                        }
                         break;
                 }
             }
@@ -217,9 +220,10 @@ namespace UniVRM10
                     // UV Animation
                     case "_UvAnimMaskTexture": map.UvAnimMaskTexture = index; break;
                     default:
-#if VRM_DEVELOP
-                        Debug.LogWarning($"textureProperties: {kv.Key} is unknown");
-#endif
+                        if (Symbols.VRM_DEVELOP)
+                        {
+                            Debug.LogWarning($"textureProperties: {kv.Key} is unknown");
+                        }
                         break;
                 }
             }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialFactory.cs
@@ -55,9 +55,6 @@ namespace VRMShaders
                 if (!x.UseExternal)
                 {
                     // 外部の '.asset' からロードしていない
-#if VRM_DEVELOP
-                    // Debug.Log($"Destroy {x.Asset}");
-#endif
                     UnityObjectDestroyer.DestroyRuntimeOrEditor(x.Asset);
                 }
             }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Util/Symbols.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Util/Symbols.cs
@@ -18,5 +18,17 @@ namespace VRMShaders
 #endif
             }
         }
+
+        public static bool VRM_NORMALIZE_BLENDSHAPE_TANGENT
+        {
+            get
+            {
+#if VRM_NORMALIZE_BLENDSHAPE_TANGENT
+                return true;
+#else
+                return false;
+#endif
+            }
+        }
     }
 }


### PR DESCRIPTION
プリプロセッサを使うことで IDE でのコード変更の追いづらさが高まってしまうので、使用をやめました。
これによる実行時の負荷増加は、保守性の低下と比べれば微々たるものだと考えます。
また IL2CPP を通せばコンパイル時に消える処理になっているといいなあ、というところです。