### PR TITLE
Stop supporting to export legacy vrm shaders.

### DIFF
--- a/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Export/BuiltInVrmMaterialExporter.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Export/BuiltInVrmMaterialExporter.cs
@@ -10,33 +10,16 @@ namespace VRM
         public static readonly string[] SupportedShaderNames =
         {
             BuiltInVrmMToonMaterialExporter.TargetShaderName,
-            "VRM/UnlitTexture",
-            "VRM/UnlitTransparent",
-            "VRM/UnlitCutout",
-            "VRM/UnlitTransparentZWrite",
         };
 
         private readonly BuiltInGltfMaterialExporter _gltfExporter = new BuiltInGltfMaterialExporter();
 
         public glTFMaterial ExportMaterial(Material src, ITextureExporter textureExporter, GltfExportSettings settings)
         {
-            glTFMaterial dst = default;
             switch (src.shader.name)
             {
                 case BuiltInVrmMToonMaterialExporter.TargetShaderName:
-                    if (BuiltInVrmMToonMaterialExporter.TryExportMaterial(src, textureExporter, out dst)) return dst;
-                    break;
-                case "VRM/UnlitTexture":
-                    if (BuiltInGenericUnlitMaterialExporter.TryExportMaterial(src, glTFBlendMode.OPAQUE, textureExporter, out dst)) return dst;
-                    break;
-                case "VRM/UnlitTransparent":
-                    if (BuiltInGenericUnlitMaterialExporter.TryExportMaterial(src, glTFBlendMode.BLEND, textureExporter, out dst)) return dst;
-                    break;
-                case "VRM/UnlitCutout":
-                    if (BuiltInGenericUnlitMaterialExporter.TryExportMaterial(src, glTFBlendMode.MASK, textureExporter, out dst)) return dst;
-                    break;
-                case "VRM/UnlitTransparentZWrite":
-                    if (BuiltInGenericUnlitMaterialExporter.TryExportMaterial(src, glTFBlendMode.BLEND, textureExporter, out dst)) return dst;
+                    if (BuiltInVrmMToonMaterialExporter.TryExportMaterial(src, textureExporter, out var dst)) return dst;
                     break;
             }
 


### PR DESCRIPTION
https://github.com/vrm-c/UniVRM/pull/1004 で削除された Shader の Export がいまだ考慮されていたので、該当コードを削除。