### PR TITLE
[1.0] morph target の accessor に sparse を使うか否かのオプションを実装

### DIFF
--- a/Assets/VRM10/Editor/VRM10ExportSettings.cs
+++ b/Assets/VRM10/Editor/VRM10ExportSettings.cs
@@ -19,11 +19,14 @@ namespace UniVRM10
         [Tooltip("Remove blendShapeClip that preset is Unknown")]
         public bool ReduceBlendshapeClip = false;
 
+        [Tooltip("Use sparse accessor for morph target")]
+        public bool MorphTargetUseSparse = true;
+
         public GltfExportSettings MeshExportSettings => new GltfExportSettings
         {
-            UseSparseAccessorForMorphTarget = true,
+            UseSparseAccessorForMorphTarget = MorphTargetUseSparse,
             ExportOnlyBlendShapePosition = true,
-            DivideVertexBuffer = true,
+            DivideVertexBuffer = true,            
         };
 
         public GameObject Root { get; set; }

--- a/Assets/VRM10/Editor/VRM10ExportSettings.cs
+++ b/Assets/VRM10/Editor/VRM10ExportSettings.cs
@@ -10,13 +10,13 @@ namespace UniVRM10
         /// <summary>
         /// エクスポート時にBlendShapeClipから参照されないBlendShapeを削除する
         /// </summary>
-        [Tooltip("Remove blendshape that is not used from BlendShapeClip")]
+        [Tooltip("not implemented yet. Remove blendshape that is not used from BlendShapeClip")][ReadOnly]
         public bool ReduceBlendshape = false;
 
         /// <summary>
         /// skip if BlendShapeClip.Preset == Unknown
         /// </summary>
-        [Tooltip("Remove blendShapeClip that preset is Unknown")]
+        [Tooltip("not implemented yet. Remove blendShapeClip that preset is Unknown")][ReadOnly]
         public bool ReduceBlendshapeClip = false;
 
         [Tooltip("Use sparse accessor for morph target")]

--- a/Assets/VRM10/Editor/Vrm10ExportDialog.cs
+++ b/Assets/VRM10/Editor/Vrm10ExportDialog.cs
@@ -277,8 +277,11 @@ namespace UniVRM10
                     model.ConvertCoordinate(VrmLib.Coordinates.Vrm1, ignoreVrm: false);
 
                     // export vrm-1.0
-                    var exporter = new UniVRM10.Vrm10Exporter(new EditorTextureSerializer(), new GltfExportSettings());
-                    var option = new VrmLib.ExportArgs();
+                    var exporter = new UniVRM10.Vrm10Exporter(new EditorTextureSerializer(), m_settings.MeshExportSettings);
+                    var option = new VrmLib.ExportArgs
+                    {
+                        sparse = m_settings.MorphTargetUseSparse,                        
+                    };
                     exporter.Export(root, model, converter, option, Vrm ? Vrm.Meta : m_tmpObject.Meta);
 
                     var exportedBytes = exporter.Storage.ToGlbBytes();


### PR DESCRIPTION
fixed #1906

#1913

未実装だった `ReduceBlendshape`,  `ReduceBlendshapeClip` を封じました。
次のバージョンで実装予定です。
