### PR TITLE
Windows以外でDetectInvalidCharactersテストが失敗する。テスト対象メソッドがもう使われていないのでテスト自体を削除

### DIFF
--- a/Assets/VRM/Tests/InvalidFileNameTest.cs
+++ b/Assets/VRM/Tests/InvalidFileNameTest.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using System.Linq;
-using System.IO;
 using UniGLTF;
 
 namespace VRM
@@ -29,20 +28,6 @@ namespace VRM
         public void DetectControlCharacters(string fileName, bool isIllegal)
         {
             var result = fileName.Any(x => char.IsControl(x));
-            Assert.AreEqual(result, isIllegal);
-        }
-
-        [Test]
-        [TestCase("VRM|Alicia?VRM", true)]
-        [TestCase("UniVRMUniVRM:UniVRM", true)]
-        [TestCase("VRMIsVRFileFormat", false)]
-        [TestCase("Alicia<Alicia>Alicia", true)]
-        [TestCase("UniVRMIsVRMImplementationInUnityPlatform", false)]
-        [TestCase("Avator*Avator/Avator", true)]
-        public void DetectInvalidCharacters(string fileName, bool isIllegal)
-        {
-            char[] invalidPathChars = Path.GetInvalidFileNameChars();
-            var result = fileName.Any(x => invalidPathChars.Contains(x));
             Assert.AreEqual(result, isIllegal);
         }
     }


### PR DESCRIPTION
macOS上のUnity 2020.3.34f1でDetectInvalidCharactersテストが失敗していました。テスト対象メソッドの Path.GetInvalidFileNameCharsの実装をUnityのレポジトリで確認したところ ( https://github.com/Unity-Technologies/mono/blob/2020.3.34f1/mcs/class/corlib/System.IO/Path.cs#L560-L571 ) Windows以外の環境では、必ずテストに失敗することがわかりました。

調査したところ、Path.GetInvalidFileNameChars自体がUniVRMとそのサブモジュールですでに使われていないことが判明したため テスト自体が不要になったと考え、削除しました。