### PR TITLE
Migrate baseColorFactor of older VRM files

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfPbrMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfPbrMaterialImporter.cs
@@ -82,12 +82,10 @@ namespace UniGLTF
                     }
                 }
 
-                if (src.pbrMetallicRoughness.baseColorFactor != null &&
-                    src.pbrMetallicRoughness.baseColorFactor.Length == 4)
+                var baseColorFactor = GltfMaterialImportUtils.ImportLinearBaseColorFactor(data, src);
+                if (baseColorFactor.HasValue)
                 {
-                    colors.Add("_Color",
-                        src.pbrMetallicRoughness.baseColorFactor.ToColor4(ColorSpace.Linear, ColorSpace.sRGB)
-                    );
+                    colors.Add("_Color", baseColorFactor.Value.gamma);
                 }
 
                 if (src.pbrMetallicRoughness.baseColorTexture != null &&

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfPbrMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfPbrMaterialImporter.cs
@@ -139,7 +139,7 @@ namespace UniGLTF
                     material.globalIlluminationFlags &= ~MaterialGlobalIlluminationFlags.EmissiveIsBlack;
                 });
 
-                var emissiveFactor = GltfMaterialImportUtils.ImportLinearEmissiveFactorFromMaterial(data, src);
+                var emissiveFactor = GltfMaterialImportUtils.ImportLinearEmissiveFactor(data, src);
                 if (emissiveFactor.HasValue)
                 {
                     // NOTE: Built-in RP Standard shader's emission color is in gamma color space.

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfUnlitMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfUnlitMaterialImporter.cs
@@ -26,18 +26,15 @@ namespace UniGLTF
                 return false;
             }
 
+            var colors = new Dictionary<string, Color>();
             var textureSlots = new Dictionary<string, TextureDescriptor>();
-            var colors =
-                src.pbrMetallicRoughness.baseColorFactor != null &&
-                src.pbrMetallicRoughness.baseColorFactor.Length == 4
-                    ? new Dictionary<string, Color>
-                    {
-                        {
-                            "_Color",
-                            src.pbrMetallicRoughness.baseColorFactor.ToColor4(ColorSpace.Linear, ColorSpace.sRGB)
-                        }
-                    }
-                    : new Dictionary<string, Color>();
+
+            // color
+            var baseColorFactor = GltfMaterialImportUtils.ImportLinearBaseColorFactor(data, src);
+            if (baseColorFactor.HasValue)
+            {
+                colors.Add("_Color", baseColorFactor.Value.gamma);
+            }
 
             // texture
             if (src.pbrMetallicRoughness.baseColorTexture != null)

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfMaterialImportUtils.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfMaterialImportUtils.cs
@@ -30,7 +30,7 @@ namespace UniGLTF
             }
         }
 
-        public static Color? ImportLinearEmissiveFactorFromMaterial(GltfData data, glTFMaterial src)
+        public static Color? ImportLinearEmissiveFactor(GltfData data, glTFMaterial src)
         {
             if (src.emissiveFactor == null || src.emissiveFactor.Length != 3) return null;
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfMaterialImportUtils.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/GltfMaterialImportUtils.cs
@@ -14,6 +14,22 @@ namespace UniGLTF
             return $"material_{index:00}";
         }
 
+        public static Color? ImportLinearBaseColorFactor(GltfData data, glTFMaterial src)
+        {
+            if (src.pbrMetallicRoughness == null) return null;
+            var baseColorFactor = src.pbrMetallicRoughness.baseColorFactor;
+            if (baseColorFactor == null || baseColorFactor.Length != 4) return null;
+
+            if (data.MigrationFlags.IsBaseColorFactorGamma)
+            {
+                return baseColorFactor.ToColor4(ColorSpace.sRGB, ColorSpace.Linear);
+            }
+            else
+            {
+                return baseColorFactor.ToColor4(ColorSpace.Linear, ColorSpace.Linear);
+            }
+        }
+
         public static Color? ImportLinearEmissiveFactorFromMaterial(GltfData data, glTFMaterial src)
         {
             if (src.emissiveFactor == null || src.emissiveFactor.Length != 3) return null;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfPbrMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfPbrMaterialImporter.cs
@@ -117,7 +117,7 @@ namespace UniGLTF
                     material.globalIlluminationFlags &= ~MaterialGlobalIlluminationFlags.EmissiveIsBlack;
                 });
 
-                var emissiveFactor = GltfMaterialImportUtils.ImportLinearEmissiveFactorFromMaterial(data, src);
+                var emissiveFactor = GltfMaterialImportUtils.ImportLinearEmissiveFactor(data, src);
                 if (emissiveFactor.HasValue)
                 {
                     colors.Add("_EmissionColor", emissiveFactor.Value);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MigrationFlags.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MigrationFlags.cs
@@ -3,12 +3,20 @@
     public sealed class MigrationFlags
     {
         /// <summary>
+        /// Before UniGLTF v0.54.0, Built-in RP Standard shader and Unlit shaders' albedo color is exported in gamma color space.
+        /// https://github.com/vrm-c/UniVRM/pull/339
+        /// </summary>
+        public bool IsBaseColorFactorGamma { get; set; }
+
+        /// <summary>
         /// Before UniGLTF v0.69, roughness value in the texture was invalid squared value.
+        /// https://github.com/vrm-c/UniVRM/pull/780
         /// </summary>
         public bool IsRoughnessTextureValueSquared { get; set; } = false;
 
         /// <summary>
         /// Before UniGLTF v0.107.0, Built-in RP Standard shader's emission color is exported in gamma color space.
+        /// https://github.com/vrm-c/UniVRM/pull/1909
         /// </summary>
         public bool IsEmissiveFactorGamma { get; set; } = false;
     }

--- a/Assets/VRM/Runtime/IO/VRMData.cs
+++ b/Assets/VRM/Runtime/IO/VRMData.cs
@@ -24,6 +24,17 @@ namespace VRM
         {
             if (!VRMVersion.ParseVersion(exportedVrmVersionString, out var exportedVrmVersion)) return;
 
+            migrationFlags.IsBaseColorFactorGamma = VRMVersion.IsNewer(
+                new VRMVersion.Version
+                {
+                    Major = 0,
+                    Minor = 54,
+                    Patch = 0,
+                    Pre = "",
+                },
+                exportedVrmVersion
+            );
+
             migrationFlags.IsRoughnessTextureValueSquared = VRMVersion.IsNewer(
                 new VRMVersion.Version
                 {


### PR DESCRIPTION
UniVRM 0.54 未満の古い VRM ファイルに対する、Standard Material のマイグレーションフラグを追加しました。

この PR で修正されたものです。
https://github.com/vrm-c/UniVRM/pull/339