### PR TITLE
Use `new ArraySegment<byte>(Array.Empty<byte>())` instead of `default(ArraySegment<byte>)`

### DIFF
--- a/Assets/VRM/Tests/VRMTextureEnumerateTests.cs
+++ b/Assets/VRM/Tests/VRMTextureEnumerateTests.cs
@@ -59,7 +59,7 @@ namespace VRM
                             },
                         }
                     },
-                    default
+                    new ArraySegment<byte>(Array.Empty<byte>())
                 ))
             {
                 var vrm = new glTF_VRM_extensions
@@ -122,7 +122,7 @@ namespace VRM
                         },
                     }
                 },
-                default
+                new ArraySegment<byte>(Array.Empty<byte>())
             ))
             {
                 var vrm = new glTF_VRM_extensions


### PR DESCRIPTION
`default(ArraySegment<byte>).ToArray()` throws `InvalidOperationException` since Unity 2021.
It fails `VRMTextureEnumerateTests`. Use `new ArraySegment<byte>(Array.Empty<byte>())` instead.

Confirmed to work with Unity 2020.3.34f1, 2021.3.13f1 and 2022.1.23f1.
    
fixes https://github.com/vrm-c/UniVRM/issues/1934