### PR TITLE
Refactor MaterialDesciptorGenerator

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -289,8 +289,8 @@ namespace UniGLTF
             {
                 // no material. work around.
                 // TODO: https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#default-material
-                var param = MaterialDescriptor.Default;
-                var material = await MaterialFactory.LoadAsync(param, TextureFactory.GetTextureAsync, awaitCaller);
+                var param = MaterialDescriptorGenerator.GetGltfDefault();
+                await MaterialFactory.LoadAsync(param, TextureFactory.GetTextureAsync, awaitCaller);
             }
             else
             {
@@ -298,7 +298,7 @@ namespace UniGLTF
                 {
                     await awaitCaller.NextFrameIfTimedOut();
                     var param = MaterialDescriptorGenerator.Get(Data, i);
-                    var material = await MaterialFactory.LoadAsync(param, TextureFactory.GetTextureAsync, awaitCaller);
+                    await MaterialFactory.LoadAsync(param, TextureFactory.GetTextureAsync, awaitCaller);
                 }
             }
         }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/BuiltInGltfMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/BuiltInGltfMaterialDescriptorGenerator.cs
@@ -31,5 +31,10 @@ namespace UniGLTF
                 new Dictionary<string, Vector4>(),
                 new Action<Material>[]{});
         }
+
+        public MaterialDescriptor GetGltfDefault()
+        {
+            return BuiltInGltfDefaultMaterialImporter.CreateParam();
+        }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfDefaultMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfDefaultMaterialImporter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using VRMShaders;
+
+namespace UniGLTF
+{
+    /// <summary>
+    /// Generate the descriptor of the glTF default material.
+    /// </summary>
+    public static class BuiltInGltfDefaultMaterialImporter
+    {
+        public static MaterialDescriptor CreateParam()
+        {
+            // FIXME
+            return new MaterialDescriptor(
+                "__default__",
+                "Standard",
+                default,
+                new Dictionary<string, TextureDescriptor>(),
+                new Dictionary<string, float>(),
+                new Dictionary<string, Color>(),
+                new Dictionary<string, Vector4>(),
+                new List<Action<Material>>()
+            );
+        }
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfDefaultMaterialImporter.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfDefaultMaterialImporter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: aa5431a3a9ee4f9caac398688c3a8973
+timeCreated: 1670224943

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/IMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/IMaterialDescriptorGenerator.cs
@@ -8,6 +8,14 @@ namespace UniGLTF
     /// </summary>
     public interface IMaterialDescriptorGenerator
     {
+        /// <summary>
+        /// Generate the MaterialDescriptor generated from the index i.
+        /// </summary>
         MaterialDescriptor Get(GltfData data, int i);
+
+        /// <summary>
+        /// Generate the MaterialDescriptor for the non-specified glTF material.
+        /// </summary>
+        MaterialDescriptor GetGltfDefault();
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfDefaultMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfDefaultMaterialImporter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using VRMShaders;
+
+namespace UniGLTF
+{
+    /// <summary>
+    /// Generate the descriptor of the glTF default material.
+    /// </summary>
+    public static class UrpGltfDefaultMaterialImporter
+    {
+        public static MaterialDescriptor CreateParam()
+        {
+            // FIXME
+            return new MaterialDescriptor(
+                "__default__",
+                UrpGltfPbrMaterialImporter.ShaderName,
+                default,
+                new Dictionary<string, TextureDescriptor>(),
+                new Dictionary<string, float>(),
+                new Dictionary<string, Color>(),
+                new Dictionary<string, Vector4>(),
+                new List<Action<Material>>()
+            );
+        }
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfDefaultMaterialImporter.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfDefaultMaterialImporter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 320b6d26ea014356b1c37e38425bf152
+timeCreated: 1670225169

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/UrpGltfMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/UrpGltfMaterialDescriptorGenerator.cs
@@ -32,5 +32,10 @@ namespace UniGLTF
                 new Dictionary<string, Vector4>(),
                 new Collection<Action<Material>>());
         }
+
+        public MaterialDescriptor GetGltfDefault()
+        {
+            return UrpGltfDefaultMaterialImporter.CreateParam();
+        }
     }
 }

--- a/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/BuiltInVrmMaterialDescriptorGenerator.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/BuiltInVrmMaterialDescriptorGenerator.cs
@@ -53,5 +53,10 @@ namespace VRM
                 new Dictionary<string, Vector4>(),
                 new Action<Material>[]{});
         }
+
+        public MaterialDescriptor GetGltfDefault()
+        {
+            return BuiltInGltfDefaultMaterialImporter.CreateParam();
+        }
     }
 }

--- a/Assets/VRM/Runtime/IO/MaterialIO/URP/Import/UrpVrmMaterialDescriptorGenerator.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/URP/Import/UrpVrmMaterialDescriptorGenerator.cs
@@ -37,5 +37,10 @@ namespace VRM
                 new Dictionary<string, Vector4>(),
                 new Action<Material>[]{});
         }
+
+        public MaterialDescriptor GetGltfDefault()
+        {
+            return UrpGltfDefaultMaterialImporter.CreateParam();
+        }
     }
 }

--- a/Assets/VRM10/Runtime/IO/Material/BuiltInRP/Import/BuiltInVrm10MaterialDescriptorGenerator.cs
+++ b/Assets/VRM10/Runtime/IO/Material/BuiltInRP/Import/BuiltInVrm10MaterialDescriptorGenerator.cs
@@ -31,5 +31,9 @@ namespace UniVRM10
                 new Action<Material>[]{});
         }
 
+        public MaterialDescriptor GetGltfDefault()
+        {
+            return BuiltInGltfDefaultMaterialImporter.CreateParam();
+        }
     }
 }

--- a/Assets/VRM10/Runtime/IO/Material/URP/Import/UrpVrm10MaterialDescriptorGenerator.cs
+++ b/Assets/VRM10/Runtime/IO/Material/URP/Import/UrpVrm10MaterialDescriptorGenerator.cs
@@ -27,5 +27,9 @@ namespace UniVRM10
                 new Action<Material>[]{});
         }
 
+        public MaterialDescriptor GetGltfDefault()
+        {
+            return UrpGltfDefaultMaterialImporter.CreateParam();
+        }
     }
 }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialDescriptor.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialDescriptor.cs
@@ -17,13 +17,6 @@ namespace VRMShaders
 
         public SubAssetKey SubAssetKey => new SubAssetKey(SubAssetKey.MaterialType, Name);
 
-        public static readonly MaterialDescriptor Default = new MaterialDescriptor("__default__", "Standard", default,
-            new Dictionary<string, TextureDescriptor>(),
-            new Dictionary<string, float>(),
-            new Dictionary<string, Color>(),
-            new Dictionary<string, Vector4>(),
-            new List<Action<Material>>());
-
         public MaterialDescriptor(
             string name,
             string shaderName,

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialDescriptor.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialDescriptor.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace VRMShaders
 {
-    public readonly struct MaterialDescriptor : IEquatable<MaterialDescriptor>
+    public sealed class MaterialDescriptor
     {
         public readonly string Name;
         public readonly string ShaderName;
@@ -42,32 +42,6 @@ namespace VRMShaders
             Colors = colors;
             Vectors = vectors;
             Actions = actions;
-        }
-
-        public bool Equals(MaterialDescriptor other)
-        {
-            return Name == other.Name && ShaderName == other.ShaderName && RenderQueue == other.RenderQueue && Equals(TextureSlots, other.TextureSlots) && Equals(FloatValues, other.FloatValues) && Equals(Colors, other.Colors) && Equals(Vectors, other.Vectors) && Equals(Actions, other.Actions);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is MaterialDescriptor other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = (Name != null ? Name.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (ShaderName != null ? ShaderName.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ RenderQueue.GetHashCode();
-                hashCode = (hashCode * 397) ^ (TextureSlots != null ? TextureSlots.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (FloatValues != null ? FloatValues.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (Colors != null ? Colors.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (Vectors != null ? Vectors.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (Actions != null ? Actions.GetHashCode() : 0);
-                return hashCode;
-            }
         }
     }
 }


### PR DESCRIPTION
MaterialDescriptor には `string shaderName` ではなく `Shader shader` を持たせたい。
そのためにまず、MaterialDescriptor をリファクタして、ImporterContext から RenderPipeline の具体的な知識を剥がす。