### PR TITLE
Specify a Shader instead of a string in MaterialDescriptor.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/BuiltInGltfMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/BuiltInGltfMaterialDescriptorGenerator.cs
@@ -23,7 +23,7 @@ namespace UniGLTF
 
             return new MaterialDescriptor(
                 GltfMaterialImportUtils.ImportMaterialName(i, null),
-                BuiltInGltfPbrMaterialImporter.ShaderName,
+                BuiltInGltfPbrMaterialImporter.Shader,
                 null,
                 new Dictionary<string, TextureDescriptor>(),
                 new Dictionary<string, float>(),

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfDefaultMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfDefaultMaterialImporter.cs
@@ -15,7 +15,7 @@ namespace UniGLTF
             // FIXME
             return new MaterialDescriptor(
                 "__default__",
-                "Standard",
+                BuiltInGltfPbrMaterialImporter.Shader,
                 default,
                 new Dictionary<string, TextureDescriptor>(),
                 new Dictionary<string, float>(),

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfPbrMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfPbrMaterialImporter.cs
@@ -45,7 +45,7 @@ namespace UniGLTF
         private static readonly int DstBlend = Shader.PropertyToID("_DstBlend");
         private static readonly int ZWrite = Shader.PropertyToID("_ZWrite");
         private static readonly int Cutoff = Shader.PropertyToID("_Cutoff");
-        public const string ShaderName = "Standard";
+        public static Shader Shader => Shader.Find("Standard");
 
         private enum BlendMode
         {
@@ -205,7 +205,7 @@ namespace UniGLTF
 
             matDesc = new MaterialDescriptor(
                 GltfMaterialImportUtils.ImportMaterialName(i, src),
-                ShaderName,
+                Shader,
                 null,
                 textureSlots,
                 floatValues,

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfUnlitMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfUnlitMaterialImporter.cs
@@ -11,6 +11,8 @@ namespace UniGLTF
     {
         private static readonly int Cutoff = Shader.PropertyToID("_Cutoff");
 
+        public static Shader Shader => Shader.Find(UniUnlitUtil.ShaderName);
+
         public static bool TryCreateParam(GltfData data, int i, out MaterialDescriptor matDesc)
         {
             if (i < 0 || i >= data.GLTF.materials.Count)
@@ -48,7 +50,7 @@ namespace UniGLTF
 
             matDesc = new MaterialDescriptor(
                 GltfMaterialImportUtils.ImportMaterialName(i, src),
-                UniUnlitUtil.ShaderName,
+                Shader,
                 null,
                 textureSlots,
                 new Dictionary<string, float>(),

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfDefaultMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfDefaultMaterialImporter.cs
@@ -15,7 +15,7 @@ namespace UniGLTF
             // FIXME
             return new MaterialDescriptor(
                 "__default__",
-                UrpGltfPbrMaterialImporter.ShaderName,
+                UrpGltfPbrMaterialImporter.Shader,
                 default,
                 new Dictionary<string, TextureDescriptor>(),
                 new Dictionary<string, float>(),

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfPbrMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfPbrMaterialImporter.cs
@@ -13,11 +13,14 @@ namespace UniGLTF
     /// </summary>
     public static class UrpGltfPbrMaterialImporter
     {
+        public const string ShaderName = "Universal Render Pipeline/Lit";
+
         private static readonly int SrcBlend = Shader.PropertyToID("_SrcBlend");
         private static readonly int DstBlend = Shader.PropertyToID("_DstBlend");
         private static readonly int ZWrite = Shader.PropertyToID("_ZWrite");
         private static readonly int Cutoff = Shader.PropertyToID("_Cutoff");
-        public const string ShaderName = "Universal Render Pipeline/Lit";
+
+        public static Shader Shader => Shader.Find(ShaderName);
 
         private enum BlendMode
         {
@@ -182,7 +185,7 @@ namespace UniGLTF
 
             matDesc = new MaterialDescriptor(
                 GltfMaterialImportUtils.ImportMaterialName(i, src),
-                ShaderName,
+                Shader,
                 null,
                 textureSlots,
                 floatValues,

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/UrpGltfMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/UrpGltfMaterialDescriptorGenerator.cs
@@ -24,7 +24,7 @@ namespace UniGLTF
 
             return new MaterialDescriptor(
                 GltfMaterialImportUtils.ImportMaterialName(i, null),
-                BuiltInGltfPbrMaterialImporter.ShaderName,
+                UrpGltfPbrMaterialImporter.Shader,
                 null,
                 new Dictionary<string, TextureDescriptor>(),
                 new Dictionary<string, float>(),

--- a/Assets/UniGLTF/Tests/UniGLTF/GltfLoadTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/GltfLoadTests.cs
@@ -227,7 +227,7 @@ namespace UniGLTF
                 using (var data = new AutoGltfFileParser(path).Parse())
                 {
                     var matDesc = new BuiltInGltfMaterialDescriptorGenerator().Get(data, 0);
-                    Assert.AreEqual("Standard", matDesc.ShaderName);
+                    Assert.AreEqual("Standard", matDesc.Shader.name);
                     Assert.AreEqual(5, matDesc.TextureSlots.Count);
                     var (key, value) = matDesc.EnumerateSubAssetKeyValue().First();
                     Assert.AreEqual(new SubAssetKey(typeof(Texture2D), "texture_0"), key);

--- a/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/BuiltInVrmMaterialDescriptorGenerator.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/BuiltInVrmMaterialDescriptorGenerator.cs
@@ -45,7 +45,7 @@ namespace VRM
             Debug.LogWarning($"fallback");
             return new MaterialDescriptor(
                 GltfMaterialImportUtils.ImportMaterialName(i, null),
-                BuiltInGltfPbrMaterialImporter.ShaderName,
+                BuiltInGltfPbrMaterialImporter.Shader,
                 null,
                 new Dictionary<string, TextureDescriptor>(),
                 new Dictionary<string, float>(),

--- a/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInVrmMToonMaterialImporter.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInVrmMToonMaterialImporter.cs
@@ -67,6 +67,7 @@ namespace VRM
             {
                 shaderName = FallbackShaders[shaderName];
             }
+            var shader = Shader.Find(shaderName);
 
             var textureSlots = new Dictionary<string, TextureDescriptor>();
             var floatValues = new Dictionary<string, float>();
@@ -75,7 +76,7 @@ namespace VRM
             var actions = new List<Action<Material>>();
             matDesc = new MaterialDescriptor(
                 name,
-                shaderName,
+                shader,
                 vrmMaterial.renderQueue,
                 textureSlots,
                 floatValues,

--- a/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInVrmMToonMaterialImporter.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInVrmMToonMaterialImporter.cs
@@ -12,7 +12,7 @@ namespace VRM
         /// <summary>
         /// 過去バージョンに含まれていたが、廃止・統合された Shader のフォールバック情報
         /// </summary>
-        public static Dictionary<string, string> FallbackShaders = new Dictionary<string, string>
+        public static readonly Dictionary<string, string> FallbackShaders = new Dictionary<string, string>
         {
             {"VRM/UnlitTexture", "Unlit/Texture"},
             {"VRM/UnlitTransparent", "Unlit/Transparent"},

--- a/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInVrmUnlitTransparentZWriteMaterialImporter.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInVrmUnlitTransparentZWriteMaterialImporter.cs
@@ -158,7 +158,10 @@ namespace VRM
                 unityMaterial.renderQueue = vrmMaterial.renderQueue;
             });
 
-            matDesc = new MaterialDescriptor(name, Utils.ShaderName, null,
+            matDesc = new MaterialDescriptor(
+                name,
+                Shader.Find(Utils.ShaderName),
+                null,
                 textureSlots,
                 floatValues,
                 colors,

--- a/Assets/VRM/Runtime/IO/MaterialIO/URP/Import/UrpVrmMaterialDescriptorGenerator.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/URP/Import/UrpVrmMaterialDescriptorGenerator.cs
@@ -29,7 +29,7 @@ namespace VRM
             }
             return new MaterialDescriptor(
                 GltfMaterialImportUtils.ImportMaterialName(i, null),
-                BuiltInGltfPbrMaterialImporter.ShaderName,
+                UrpGltfPbrMaterialImporter.Shader,
                 null,
                 new Dictionary<string, TextureDescriptor>(),
                 new Dictionary<string, float>(),

--- a/Assets/VRM/Tests/MToonTest.cs
+++ b/Assets/VRM/Tests/MToonTest.cs
@@ -72,7 +72,7 @@ namespace VRM
             {
                 var vrmImporter = new VRMImporterContext(new VRMData(data), null);
                 var materialParam = new BuiltInVrmMaterialDescriptorGenerator(vrmImporter.VRM).Get(data, 0);
-                Assert.AreEqual("VRM/MToon", materialParam.ShaderName);
+                Assert.AreEqual("VRM/MToon", materialParam.Shader.name);
                 Assert.AreEqual("Alicia_body", materialParam.TextureSlots["_MainTex"].UnityObjectName);
 
                 var (key, value) = materialParam.EnumerateSubAssetKeyValue().First();

--- a/Assets/VRM10/Runtime/IO/Material/BuiltInRP/Import/BuiltInVrm10MaterialDescriptorGenerator.cs
+++ b/Assets/VRM10/Runtime/IO/Material/BuiltInRP/Import/BuiltInVrm10MaterialDescriptorGenerator.cs
@@ -16,13 +16,15 @@ namespace UniVRM10
             if (BuiltInGltfUnlitMaterialImporter.TryCreateParam(data, i, out matDesc)) return matDesc;
             // pbr
             if (BuiltInGltfPbrMaterialImporter.TryCreateParam(data, i, out matDesc)) return matDesc;
+
             // fallback
             if (Symbols.VRM_DEVELOP)
             {
                 Debug.LogWarning($"material: {i} out of range. fallback");
             }
             return new MaterialDescriptor(
-                GltfMaterialImportUtils.ImportMaterialName(i, null), BuiltInGltfPbrMaterialImporter.ShaderName,
+                GltfMaterialImportUtils.ImportMaterialName(i, null),
+                BuiltInGltfPbrMaterialImporter.Shader,
                 null, 
                 new Dictionary<string, TextureDescriptor>(),
                 new Dictionary<string, float>(),

--- a/Assets/VRM10/Runtime/IO/Material/BuiltInRP/Import/Materials/BuiltInVrm10MToonMaterialImporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/BuiltInRP/Import/Materials/BuiltInVrm10MToonMaterialImporter.cs
@@ -33,7 +33,7 @@ namespace UniVRM10
             // use material.name, because material name may renamed in GltfParser.
             matDesc = new MaterialDescriptor(
                 m.name,
-                MToon10Meta.UnityShaderName,
+                Shader.Find(MToon10Meta.UnityShaderName),
                 null,
                 Vrm10MToonTextureImporter.EnumerateAllTextures(data, m, mtoon).ToDictionary(tuple => tuple.key, tuple => tuple.Item2.Item2),
                 TryGetAllFloats(m, mtoon).ToDictionary(tuple => tuple.key, tuple => tuple.value),

--- a/Assets/VRM10/Runtime/IO/Material/URP/Import/UrpVrm10MaterialDescriptorGenerator.cs
+++ b/Assets/VRM10/Runtime/IO/Material/URP/Import/UrpVrm10MaterialDescriptorGenerator.cs
@@ -14,11 +14,12 @@ namespace UniVRM10
             if (BuiltInGltfUnlitMaterialImporter.TryCreateParam(data, i, out MaterialDescriptor matDesc)) return matDesc;
             // pbr
             if (UrpGltfPbrMaterialImporter.TryCreateParam(data, i, out matDesc)) return matDesc;
+
             // fallback
             Debug.LogWarning($"material: {i} out of range. fallback");
             return new MaterialDescriptor(
                 GltfMaterialImportUtils.ImportMaterialName(i, null),
-                BuiltInGltfPbrMaterialImporter.ShaderName,
+                UrpGltfPbrMaterialImporter.Shader,
                 null,
                 new Dictionary<string, TextureDescriptor>(),
                 new Dictionary<string, float>(),

--- a/Assets/VRM10/Tests/MaterialImportTests.cs
+++ b/Assets/VRM10/Tests/MaterialImportTests.cs
@@ -27,7 +27,7 @@ namespace UniVRM10
 
                 var matDesc = new BuiltInVrm10MaterialDescriptorGenerator().Get(data, 0);
                 Assert.AreEqual("Alicia_body", matDesc.Name);
-                Assert.AreEqual("VRM10/MToon10", matDesc.ShaderName);
+                Assert.AreEqual("VRM10/MToon10", matDesc.Shader.name);
                 Assert.AreEqual("Alicia_body", matDesc.TextureSlots["_MainTex"].UnityObjectName);
                 Assert.AreEqual("Alicia_body", matDesc.TextureSlots["_ShadeTex"].UnityObjectName);
 

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialDescriptor.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialDescriptor.cs
@@ -7,7 +7,7 @@ namespace VRMShaders
     public sealed class MaterialDescriptor
     {
         public readonly string Name;
-        public readonly string ShaderName;
+        public readonly Shader Shader;
         public readonly int? RenderQueue;
         public readonly IReadOnlyDictionary<string, TextureDescriptor> TextureSlots;
         public readonly IReadOnlyDictionary<string, float> FloatValues;
@@ -19,7 +19,7 @@ namespace VRMShaders
 
         public MaterialDescriptor(
             string name,
-            string shaderName,
+            Shader shader,
             int? renderQueue,
             IReadOnlyDictionary<string, TextureDescriptor> textureSlots,
             IReadOnlyDictionary<string, float> floatValues,
@@ -28,7 +28,7 @@ namespace VRMShaders
             IReadOnlyList<Action<Material>> actions)
         {
             Name = name;
-            ShaderName = shaderName;
+            Shader = shader;
             RenderQueue = renderQueue;
             TextureSlots = textureSlots;
             FloatValues = floatValues;

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Material/Importer/MaterialFactory.cs
@@ -101,19 +101,12 @@ namespace VRMShaders
                 getTexture = (x, y) => Task.FromResult<Texture>(null);
             }
 
-            var shaderName = matDesc.ShaderName;
-            if (String.IsNullOrEmpty(shaderName))
+            if (matDesc.Shader == null)
             {
-                throw new Exception("no shader name");
+                throw new ArgumentNullException(nameof(matDesc.Shader));
             }
 
-            var shader = Shader.Find(shaderName);
-            if (shader == null)
-            {
-                throw new Exception($"shader: {shaderName} not found");
-            }
-
-            material = new Material(shader);
+            material = new Material(matDesc.Shader);
             material.name = matDesc.SubAssetKey.Name;
 
             foreach (var kv in matDesc.TextureSlots)


### PR DESCRIPTION
アプリケーションによっては Shader を暗黙的な `Shader.Find()` ではなく、アプリケーション側で明示的なアセットバンドルなどに含めて提供したい場合があります。
そうしたときに、既存の `MaterialDescriptor` の構造ではそれができません。

本 PR では `MaterialDescriptor` が保持するシェーダ情報を `string` から `Shader` に変えることで
上記の例のような場合を `IMaterialDescriptorGenerator` で実装可能にするよう柔軟性を持たせます。