### PR TITLE
Add limit break sliders to spring bone joint properties

### DIFF
--- a/Assets/VRM/Editor/SpringBone/VRMSpringBoneEditor.cs
+++ b/Assets/VRM/Editor/SpringBone/VRMSpringBoneEditor.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace VRM
 {
     [CustomEditor(typeof(VRMSpringBone))]
-    class VRM10SpringBoneJointEditor : Editor
+    class VRMSpringBoneEditor : Editor
     {
         private VRMSpringBone m_target;
 

--- a/Assets/VRM/Editor/SpringBone/VRMSpringBoneEditor.cs
+++ b/Assets/VRM/Editor/SpringBone/VRMSpringBoneEditor.cs
@@ -1,0 +1,121 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace VRM
+{
+    [CustomEditor(typeof(VRMSpringBone))]
+    class VRM10SpringBoneJointEditor : Editor
+    {
+        private VRMSpringBone m_target;
+
+        private SerializedProperty m_commentProp;
+        private SerializedProperty m_gizmoColorProp;
+        private SerializedProperty m_stiffnessForceProp;
+        private SerializedProperty m_gravityPowerProp;
+        private SerializedProperty m_gravityDirProp;
+        private SerializedProperty m_dragForceProp;
+        private SerializedProperty m_centerProp;
+        private SerializedProperty m_rootBonesProp;
+        private SerializedProperty m_hitRadiusProp;
+        private SerializedProperty m_colliderGroupsProp;
+        private SerializedProperty m_updateTypeProp;
+
+        void OnEnable()
+        {
+            if (target == null)
+            {
+                return;
+            }
+            m_target = (VRMSpringBone)target;
+
+            m_commentProp = serializedObject.FindProperty("m_comment");
+            m_gizmoColorProp = serializedObject.FindProperty("m_gizmoColor");
+            m_stiffnessForceProp = serializedObject.FindProperty("m_stiffnessForce");
+            m_gravityPowerProp = serializedObject.FindProperty("m_gravityPower");
+            m_gravityDirProp = serializedObject.FindProperty("m_gravityDir");
+            m_dragForceProp = serializedObject.FindProperty("m_dragForce");
+            m_centerProp = serializedObject.FindProperty("m_center");
+            m_rootBonesProp = serializedObject.FindProperty("RootBones");
+            m_hitRadiusProp = serializedObject.FindProperty("m_hitRadius");
+            m_colliderGroupsProp = serializedObject.FindProperty("ColliderGroups");
+            m_updateTypeProp = serializedObject.FindProperty("m_updateType");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.PropertyField(m_commentProp);
+            EditorGUILayout.PropertyField(m_gizmoColorProp);
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.LabelField("Settings", EditorStyles.boldLabel);
+
+            LimitBreakSlider(m_stiffnessForceProp, 0.0f, 4.0f, 0.0f, Mathf.Infinity);
+            LimitBreakSlider(m_gravityPowerProp, 0.0f, 2.0f, 0.0f, Mathf.Infinity);
+            EditorGUILayout.PropertyField(m_gravityDirProp);
+            EditorGUILayout.PropertyField(m_dragForceProp);
+            EditorGUILayout.PropertyField(m_centerProp);
+            EditorGUILayout.PropertyField(m_rootBonesProp);
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.LabelField("Collision", EditorStyles.boldLabel);
+
+            LimitBreakSlider(m_hitRadiusProp, 0.0f, 0.5f, 0.0f, Mathf.Infinity);
+            EditorGUILayout.PropertyField(m_colliderGroupsProp);
+            EditorGUILayout.PropertyField(m_updateTypeProp);
+
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        /// <summary>
+        /// スライダーと数値入力で限界値の違う、所謂「限界突破スライダー」を作成する
+        /// `EditorGUILayout.PropertyField` の代替として利用する
+        /// </summary>
+        private static void LimitBreakSlider(SerializedProperty property, float sliderLeft, float sliderRight, float numberLeft, float numberRight)
+        {
+            var label = new GUIContent(property.displayName);
+            var currentValue = property.floatValue;
+
+            var rect = EditorGUILayout.GetControlRect();
+
+            EditorGUI.BeginProperty(rect, label, property);
+
+            rect = EditorGUI.PrefixLabel(rect, label);
+
+            // slider
+            {
+                EditorGUI.BeginChangeCheck();
+
+                var sliderRect = rect;
+                sliderRect.width -= 55.0f;
+                rect.xMin += rect.width - 50.0f;
+
+                var clampedvalue = Mathf.Clamp(currentValue, sliderLeft, sliderRight);
+                var sliderValue = GUI.HorizontalSlider(sliderRect, clampedvalue, sliderLeft, sliderRight);
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    property.floatValue = sliderValue;
+                }
+            }
+
+            // number
+            {
+                EditorGUI.BeginChangeCheck();
+
+                var numberValue = Mathf.Clamp(EditorGUI.FloatField(rect, currentValue), numberLeft, numberRight);
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    property.floatValue = numberValue;
+                }
+            }
+
+            EditorGUI.EndProperty();
+        }
+    }
+}

--- a/Assets/VRM/Editor/SpringBone/VRMSpringBoneEditor.cs
+++ b/Assets/VRM/Editor/SpringBone/VRMSpringBoneEditor.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 namespace VRM
 {
     [CustomEditor(typeof(VRMSpringBone))]
+    [CanEditMultipleObjects]
     class VRMSpringBoneEditor : Editor
     {
         private VRMSpringBone m_target;

--- a/Assets/VRM/Editor/SpringBone/VRMSpringBoneEditor.cs
+++ b/Assets/VRM/Editor/SpringBone/VRMSpringBoneEditor.cs
@@ -29,17 +29,17 @@ namespace VRM
             }
             m_target = (VRMSpringBone)target;
 
-            m_commentProp = serializedObject.FindProperty("m_comment");
+            m_commentProp = serializedObject.FindProperty(nameof(VRMSpringBone.m_comment));
             m_gizmoColorProp = serializedObject.FindProperty("m_gizmoColor");
-            m_stiffnessForceProp = serializedObject.FindProperty("m_stiffnessForce");
-            m_gravityPowerProp = serializedObject.FindProperty("m_gravityPower");
-            m_gravityDirProp = serializedObject.FindProperty("m_gravityDir");
-            m_dragForceProp = serializedObject.FindProperty("m_dragForce");
-            m_centerProp = serializedObject.FindProperty("m_center");
-            m_rootBonesProp = serializedObject.FindProperty("RootBones");
-            m_hitRadiusProp = serializedObject.FindProperty("m_hitRadius");
-            m_colliderGroupsProp = serializedObject.FindProperty("ColliderGroups");
-            m_updateTypeProp = serializedObject.FindProperty("m_updateType");
+            m_stiffnessForceProp = serializedObject.FindProperty(nameof(VRMSpringBone.m_stiffnessForce));
+            m_gravityPowerProp = serializedObject.FindProperty(nameof(VRMSpringBone.m_gravityPower));
+            m_gravityDirProp = serializedObject.FindProperty(nameof(VRMSpringBone.m_gravityDir));
+            m_dragForceProp = serializedObject.FindProperty(nameof(VRMSpringBone.m_dragForce));
+            m_centerProp = serializedObject.FindProperty(nameof(VRMSpringBone.m_center));
+            m_rootBonesProp = serializedObject.FindProperty(nameof(VRMSpringBone.RootBones));
+            m_hitRadiusProp = serializedObject.FindProperty(nameof(VRMSpringBone.m_hitRadius));
+            m_colliderGroupsProp = serializedObject.FindProperty(nameof(VRMSpringBone.ColliderGroups));
+            m_updateTypeProp = serializedObject.FindProperty(nameof(VRMSpringBone.m_updateType));
         }
 
         public override void OnInspectorGUI()

--- a/Assets/VRM/Editor/SpringBone/VRMSpringBoneEditor.cs.meta
+++ b/Assets/VRM/Editor/SpringBone/VRMSpringBoneEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bcc37b2e1c446d4448718e89fcba946b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM/Runtime/SpringBone/VRMSpringBone.cs
+++ b/Assets/VRM/Runtime/SpringBone/VRMSpringBone.cs
@@ -19,11 +19,9 @@ namespace VRM
         [SerializeField] private Color m_gizmoColor = Color.yellow;
 
         [SerializeField]
-        [Range(0, 4)]
-        [Header("Settings")]
         public float m_stiffnessForce = 1.0f;
 
-        [SerializeField][Range(0, 2)] public float m_gravityPower;
+        [SerializeField] public float m_gravityPower;
 
         [SerializeField] public Vector3 m_gravityDir = new Vector3(0, -1.0f, 0);
 
@@ -35,8 +33,6 @@ namespace VRM
         Dictionary<Transform, Quaternion> m_initialLocalRotationMap;
 
         [SerializeField]
-        [Range(0, 0.5f)]
-        [Header("Collider")]
         public float m_hitRadius = 0.02f;
 
         [SerializeField]

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs
@@ -1,0 +1,98 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace UniVRM10
+{
+    [CustomEditor(typeof(VRM10SpringBoneJoint))]
+    class VRM10SpringBoneJointEditor : Editor
+    {
+        private VRM10SpringBoneJoint m_target;
+        private SerializedProperty m_stiffnessForceProp;
+        private SerializedProperty m_gravityPowerProp;
+        private SerializedProperty m_gravityDirProp;
+        private SerializedProperty m_dragForceProp;
+        private SerializedProperty m_jointRadiusProp;
+
+        void OnEnable()
+        {
+            if (target == null)
+            {
+                return;
+            }
+            m_target = (VRM10SpringBoneJoint)target;
+
+            m_stiffnessForceProp = serializedObject.FindProperty("m_stiffnessForce");
+            m_gravityPowerProp = serializedObject.FindProperty("m_gravityPower");
+            m_gravityDirProp = serializedObject.FindProperty("m_gravityDir");
+            m_dragForceProp = serializedObject.FindProperty("m_dragForce");
+            m_jointRadiusProp = serializedObject.FindProperty("m_jointRadius");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.LabelField("Settings", EditorStyles.boldLabel);
+
+            LimitBreakSlider(m_stiffnessForceProp, 0.0f, 4.0f, 0.0f, Mathf.Infinity);
+            LimitBreakSlider(m_gravityPowerProp, 0.0f, 2.0f, 0.0f, Mathf.Infinity);
+            EditorGUILayout.PropertyField(m_gravityDirProp);
+            EditorGUILayout.PropertyField(m_dragForceProp);
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.LabelField("Collision", EditorStyles.boldLabel);
+
+            LimitBreakSlider(m_jointRadiusProp, 0.0f, 0.5f, 0.0f, Mathf.Infinity);
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        /// <summary>
+        /// スライダーと数値入力で限界値の違う、所謂「限界突破スライダー」を作成する
+        /// `EditorGUILayout.PropertyField` の代替として利用する
+        /// </summary>
+        private static void LimitBreakSlider(SerializedProperty property, float sliderLeft, float sliderRight, float numberLeft, float numberRight)
+        {
+            var label = new GUIContent(property.displayName);
+            var currentValue = property.floatValue;
+
+            var rect = EditorGUILayout.GetControlRect();
+
+            EditorGUI.BeginProperty(rect, label, property);
+
+            rect = EditorGUI.PrefixLabel(rect, label);
+
+            // slider
+            {
+                EditorGUI.BeginChangeCheck();
+
+                var sliderRect = rect;
+                sliderRect.width -= 55.0f;
+                rect.xMin += rect.width - 50.0f;
+
+                var clampedvalue = Mathf.Clamp(currentValue, sliderLeft, sliderRight);
+                var sliderValue = GUI.HorizontalSlider(sliderRect, clampedvalue, sliderLeft, sliderRight);
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    property.floatValue = sliderValue;
+                }
+            }
+
+            // number
+            {
+                EditorGUI.BeginChangeCheck();
+
+                var numberValue = Mathf.Clamp(EditorGUI.FloatField(rect, currentValue), numberLeft, numberRight);
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    property.floatValue = numberValue;
+                }
+            }
+
+            EditorGUI.EndProperty();
+        }
+    }
+}

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs
@@ -21,11 +21,11 @@ namespace UniVRM10
             }
             m_target = (VRM10SpringBoneJoint)target;
 
-            m_stiffnessForceProp = serializedObject.FindProperty("m_stiffnessForce");
-            m_gravityPowerProp = serializedObject.FindProperty("m_gravityPower");
-            m_gravityDirProp = serializedObject.FindProperty("m_gravityDir");
-            m_dragForceProp = serializedObject.FindProperty("m_dragForce");
-            m_jointRadiusProp = serializedObject.FindProperty("m_jointRadius");
+            m_stiffnessForceProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_stiffnessForce));
+            m_gravityPowerProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_gravityPower));
+            m_gravityDirProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_gravityDir));
+            m_dragForceProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_dragForce));
+            m_jointRadiusProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_jointRadius));
         }
 
         public override void OnInspectorGUI()

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 namespace UniVRM10
 {
     [CustomEditor(typeof(VRM10SpringBoneJoint))]
+    [CanEditMultipleObjects]
     class VRM10SpringBoneJointEditor : Editor
     {
         private VRM10SpringBoneJoint m_target;

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs.meta
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb6829ce1ea93194fbd08e175456a797
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneJoint.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneJoint.cs
@@ -11,10 +11,10 @@ namespace UniVRM10
     [DisallowMultipleComponent]
     public class VRM10SpringBoneJoint : MonoBehaviour
     {
-        [SerializeField, Range(0, 4), Header("Settings")]
+        [SerializeField]
         public float m_stiffnessForce = 1.0f;
 
-        [SerializeField, Range(0, 2)]
+        [SerializeField]
         public float m_gravityPower = 0;
 
         [SerializeField]
@@ -23,7 +23,7 @@ namespace UniVRM10
         [SerializeField, Range(0, 1)]
         public float m_dragForce = 0.4f;
 
-        [SerializeField, Range(0, 0.5f), Header("Collision")]
+        [SerializeField]
         public float m_jointRadius = 0.02f;
 
         void AddJointRecursive(Transform t, VRM10SpringBoneJoint src)


### PR DESCRIPTION
### Description

SpringBoneの各パラメータ（stiffness, gravityPower, jointRadius）に対して、スライダーの範囲は従来のまま、数値入力の際にスライダーの範囲を超えて入力できるように変更しました。
VRM0・VRM1の双方に変更を適用しました。

### Points need review

Editor拡張というものをいじる機会があまりなく、これで問題がないか不安です。

- [ ] 動作に問題はないでしょうか？
    - Undo・Redoができること・変更を加えたプロパティの表示が変わること・プロパティ名を右クリックして値のコピーができることは確認しております。
- [ ] 実装は適切でしょうか？
