### PR TITLE
Refactoring about Vrm10 LookAtRuntime

### DIFF
--- a/Assets/VRM10/Editor/EditorTool/VRM10LookAtEditorTool.cs
+++ b/Assets/VRM10/Editor/EditorTool/VRM10LookAtEditorTool.cs
@@ -86,7 +86,7 @@ namespace UniVRM10
 
             if (Application.isPlaying)
             {
-                OnSceneGUILookAt(root.Vrm.LookAt, root.Runtime.LookAt, root.LookAtTargetType, root.Gaze);
+                OnSceneGUILookAt(root.Vrm.LookAt, root.Runtime.LookAt, root.LookAtTargetType, root.LookAtTarget);
             }
             else
             {
@@ -125,22 +125,22 @@ namespace UniVRM10
 
         const float RADIUS = 0.5f;
 
-        static void OnSceneGUILookAt(VRM10ObjectLookAt lookAt, Vrm10RuntimeLookAt runtime, VRM10ObjectLookAt.LookAtTargetTypes lookAtTargetType, Transform gazeTarget)
+        static void OnSceneGUILookAt(VRM10ObjectLookAt lookAt, Vrm10RuntimeLookAt runtime, VRM10ObjectLookAt.LookAtTargetTypes lookAtTargetType, Transform lookAtTarget)
         {
-            if (lookAtTargetType == VRM10ObjectLookAt.LookAtTargetTypes.Auto && gazeTarget != null)
+            if (lookAtTargetType == VRM10ObjectLookAt.LookAtTargetTypes.SpecifiedTransform && lookAtTarget != null)
             {
                 {
                     EditorGUI.BeginChangeCheck();
-                    var newTargetPosition = Handles.PositionHandle(gazeTarget.position, Quaternion.identity);
+                    var newTargetPosition = Handles.PositionHandle(lookAtTarget.position, Quaternion.identity);
                     if (EditorGUI.EndChangeCheck())
                     {
-                        Undo.RecordObject(gazeTarget, "Change Look At Target Position");
-                        gazeTarget.position = newTargetPosition;
+                        Undo.RecordObject(lookAtTarget, "Change Look At Target Position");
+                        lookAtTarget.position = newTargetPosition;
                     }
                 }
 
                 Handles.color = new Color(1, 1, 1, 0.6f);
-                Handles.DrawDottedLine(runtime.EyeTransform.position, gazeTarget.position, 4.0f);
+                Handles.DrawDottedLine(runtime.EyeTransform.position, lookAtTarget.position, 4.0f);
             }
 
             var yaw = runtime.Yaw;

--- a/Assets/VRM10/Editor/EditorTool/VRM10LookAtEditorTool.cs
+++ b/Assets/VRM10/Editor/EditorTool/VRM10LookAtEditorTool.cs
@@ -69,18 +69,18 @@ namespace UniVRM10
             {
                 EditorGUI.BeginChangeCheck();
 
-                var worldOffset = head.localToWorldMatrix.MultiplyPoint(root.Vrm.LookAt.OffsetFromHead);
-                worldOffset = Handles.PositionHandle(worldOffset, head.rotation);
+                var eyeWorldPosition = head.localToWorldMatrix.MultiplyPoint(root.Vrm.LookAt.OffsetFromHead);
+                eyeWorldPosition = Handles.PositionHandle(eyeWorldPosition, head.rotation);
 
-                Handles.DrawDottedLine(head.position, worldOffset, 5);
+                Handles.DrawDottedLine(head.position, eyeWorldPosition, 5);
                 Handles.SphereHandleCap(0, head.position, Quaternion.identity, 0.02f, Event.current.type);
-                Handles.SphereHandleCap(0, worldOffset, Quaternion.identity, 0.02f, Event.current.type);
+                Handles.SphereHandleCap(0, eyeWorldPosition, Quaternion.identity, 0.02f, Event.current.type);
 
                 if (EditorGUI.EndChangeCheck())
                 {
                     Undo.RecordObject(root.Vrm, "LookAt.OffsetFromHead");
 
-                    root.Vrm.LookAt.OffsetFromHead = head.worldToLocalMatrix.MultiplyPoint(worldOffset);
+                    root.Vrm.LookAt.OffsetFromHead = head.worldToLocalMatrix.MultiplyPoint(eyeWorldPosition);
                 }
             }
 

--- a/Assets/VRM10/Editor/EditorTool/VRM10LookAtEditorTool.cs
+++ b/Assets/VRM10/Editor/EditorTool/VRM10LookAtEditorTool.cs
@@ -86,7 +86,7 @@ namespace UniVRM10
 
             if (Application.isPlaying)
             {
-                OnSceneGUILookAt(root.Vrm.LookAt, root.Runtime.LookAt, head, root.LookAtTargetType, root.Gaze);
+                OnSceneGUILookAt(root.Vrm.LookAt, root.Runtime.LookAt, root.LookAtTargetType, root.Gaze);
             }
             else
             {
@@ -125,28 +125,27 @@ namespace UniVRM10
 
         const float RADIUS = 0.5f;
 
-        static void OnSceneGUILookAt(VRM10ObjectLookAt lookAt, Vrm10RuntimeLookAt runtime, Transform head, VRM10ObjectLookAt.LookAtTargetTypes lookAtTargetType, Transform gaze)
+        static void OnSceneGUILookAt(VRM10ObjectLookAt lookAt, Vrm10RuntimeLookAt runtime, VRM10ObjectLookAt.LookAtTargetTypes lookAtTargetType, Transform gazeTarget)
         {
-            if (head == null) return;
-
-            if (gaze != null)
+            if (lookAtTargetType == VRM10ObjectLookAt.LookAtTargetTypes.Auto && gazeTarget != null)
             {
                 {
                     EditorGUI.BeginChangeCheck();
-                    var newTargetPosition = Handles.PositionHandle(gaze.position, Quaternion.identity);
+                    var newTargetPosition = Handles.PositionHandle(gazeTarget.position, Quaternion.identity);
                     if (EditorGUI.EndChangeCheck())
                     {
-                        Undo.RecordObject(gaze, "Change Look At Target Position");
-                        gaze.position = newTargetPosition;
+                        Undo.RecordObject(gazeTarget, "Change Look At Target Position");
+                        gazeTarget.position = newTargetPosition;
                     }
                 }
 
                 Handles.color = new Color(1, 1, 1, 0.6f);
-                Handles.DrawDottedLine(runtime.GetLookAtOrigin(head).position, gaze.position, 4.0f);
+                Handles.DrawDottedLine(runtime.EyeTransform.position, gazeTarget.position, 4.0f);
             }
 
-            var (yaw, pitch) = runtime.GetLookAtYawPitch(head, lookAtTargetType, gaze);
-            var lookAtOriginMatrix = runtime.GetLookAtOrigin(head).localToWorldMatrix;
+            var yaw = runtime.Yaw;
+            var pitch = runtime.Pitch;
+            var lookAtOriginMatrix = runtime.EyeTransform.localToWorldMatrix;
             Handles.matrix = lookAtOriginMatrix;
             var p = lookAt.OffsetFromHead;
             Handles.Label(Vector3.zero,

--- a/Assets/VRM10/Editor/EditorTool/VRM10LookAtEditorTool.cs
+++ b/Assets/VRM10/Editor/EditorTool/VRM10LookAtEditorTool.cs
@@ -140,12 +140,12 @@ namespace UniVRM10
                 }
 
                 Handles.color = new Color(1, 1, 1, 0.6f);
-                Handles.DrawDottedLine(runtime.EyeTransform.position, lookAtTarget.position, 4.0f);
+                Handles.DrawDottedLine(runtime.LookAtOriginTransform.position, lookAtTarget.position, 4.0f);
             }
 
             var yaw = runtime.Yaw;
             var pitch = runtime.Pitch;
-            var lookAtOriginMatrix = runtime.EyeTransform.localToWorldMatrix;
+            var lookAtOriginMatrix = runtime.LookAtOriginTransform.localToWorldMatrix;
             Handles.matrix = lookAtOriginMatrix;
             var p = lookAt.OffsetFromHead;
             Handles.Label(Vector3.zero,

--- a/Assets/VRM10/Runtime/AssemblyInfo.cs
+++ b/Assets/VRM10/Runtime/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+#if UNITY_EDITOR
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("VRM10.Tests")]
+#endif

--- a/Assets/VRM10/Runtime/AssemblyInfo.cs.meta
+++ b/Assets/VRM10/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0bb9ff90c68a3f4bb86b5fed930f30e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM10/Runtime/Components/Expression/LookAtEyeDirection.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/LookAtEyeDirection.cs
@@ -13,11 +13,13 @@
         public float LeftPitch { get; }
         
         /// <summary>
+        /// NOTE: 何故か使われていない
         /// Yaw of RightEye
         /// </summary>
         public float RightYaw { get; }
         
         /// <summary>
+        /// NOTE: 何故か使われていない
         /// Pitch of RightEye
         /// </summary>
         public float RightPitch { get; }

--- a/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectLookAt.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectLookAt.cs
@@ -10,13 +10,13 @@ namespace UniVRM10
         public enum LookAtTargetTypes
         {
             /// <summary>
-            /// Vrm10Instance に設定した Gaze Transform を見ます.
+            /// Vrm10Instance に設定した Transform を見ます.
             /// </summary>
-            Auto = 0,
+            SpecifiedTransform = 0,
             /// <summary>
             /// Vrm10RuntimeLookAt に設定した Yaw/Pitch 値に従います.
             /// </summary>
-            Manual = 1,
+            YawPitchValue = 1,
 
             [Obsolete] CalcYawPitchToGaze = 0,
             [Obsolete] SetYawPitch = 1,

--- a/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectLookAt.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectLookAt.cs
@@ -1,9 +1,6 @@
 using System;
 using UnityEngine;
 using UniGLTF.Extensions.VRMC_vrm;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 namespace UniVRM10
 {
@@ -12,8 +9,17 @@ namespace UniVRM10
     {
         public enum LookAtTargetTypes
         {
-            CalcYawPitchToGaze,
-            SetYawPitch,
+            /// <summary>
+            /// Vrm10Instance に設定した Gaze Transform を見ます.
+            /// </summary>
+            Auto = 0,
+            /// <summary>
+            /// Vrm10RuntimeLookAt に設定した Yaw/Pitch 値に従います.
+            /// </summary>
+            Manual = 1,
+
+            [Obsolete] CalcYawPitchToGaze = 0,
+            [Obsolete] SetYawPitch = 1,
         }
 
         [SerializeField]

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 
 namespace UniVRM10
@@ -43,11 +45,20 @@ namespace UniVRM10
         public bool DrawLookAtGizmo = true;
 
         /// <summay>
-        /// LookAtTargetTypes.CalcYawPitchToGaze時の注視点
+        /// The model looks at position of the Transform specified in this field.
+        /// That behaviour is available only when LookAtTargetType is SpecifiedTransform.
+        ///
+        /// モデルはここで指定した Transform の位置の方向に目を向けます。
+        /// LookAtTargetType を SpecifiedTransform に設定したときのみ有効です。
         /// </summary>
-        [SerializeField]
-        public Transform Gaze;
+        [SerializeField, FormerlySerializedAs("Gaze")]
+        public Transform LookAtTarget;
 
+        /// <summary>
+        /// Specify "LookAt" behaviour at runtime.
+        ///
+        /// 実行時の目の動かし方を指定します。
+        /// </summary>
         [SerializeField]
         public VRM10ObjectLookAt.LookAtTargetTypes LookAtTargetType;
 
@@ -157,6 +168,15 @@ namespace UniVRM10
             return true;
         }
 
+        #region Obsolete
 
+        [Obsolete]
+        public Transform Gaze
+        {
+            get => LookAtTarget;
+            set => LookAtTarget = value;
+        }
+
+        #endregion
     }
 }

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -110,15 +110,7 @@ namespace UniVRM10
 
             // cause new Vrm10Runtime.
             // init LookAt init rotation.
-            var runtime = Runtime;
-
-            if (LookAtTargetType == VRM10ObjectLookAt.LookAtTargetTypes.CalcYawPitchToGaze)
-            {
-                if (Gaze == null)
-                {
-                    LookAtTargetType = VRM10ObjectLookAt.LookAtTargetTypes.SetYawPitch;
-                }
-            }
+            var _ = Runtime;
         }
 
         private void Update()

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -191,7 +191,7 @@ namespace UniVRM10
             }
 
             // 3. Gaze control
-            LookAt.Process(m_target.LookAtTargetType, m_target.Gaze);
+            LookAt.Process(m_target.LookAtTargetType, m_target.LookAtTarget);
 
             // 4. Expression
             Expression.Process();

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -63,7 +63,7 @@ namespace UniVRM10
                 ControlRig = new Vrm10RuntimeControlRig(target.Humanoid, m_target.transform, controlRigInitialRotations);
             }
             Constraints = target.GetComponentsInChildren<IVrm10Constraint>();
-            LookAt = new Vrm10RuntimeLookAt(target.Vrm.LookAt, target.Humanoid, m_head, target.LookAtTargetType, target.Gaze);
+            LookAt = new Vrm10RuntimeLookAt(target.Vrm.LookAt, target.Humanoid, m_head);
             Expression = new Vrm10RuntimeExpression(target, LookAt, LookAt.EyeDirectionApplicable);
 
             var instance = target.GetComponent<RuntimeGltfInstance>();

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
@@ -40,22 +40,22 @@ namespace UniVRM10
             }
         }
 
-        internal void Process(VRM10ObjectLookAt.LookAtTargetTypes lookAtTargetType, Transform gazeTarget)
+        internal void Process(VRM10ObjectLookAt.LookAtTargetTypes lookAtTargetType, Transform lookAtTarget)
         {
             EyeTransform.localPosition = _eyeTransformLocalPosition;
             EyeTransform.localRotation = _eyeTransformLocalRotation;
 
             switch (lookAtTargetType)
             {
-                case VRM10ObjectLookAt.LookAtTargetTypes.Auto:
-                    // NOTE: 指定された Gaze Transform の位置を向くように Yaw/Pitch を計算して適用する
-                    if (gazeTarget != null)
+                case VRM10ObjectLookAt.LookAtTargetTypes.SpecifiedTransform:
+                    // NOTE: 指定された Transform の位置を向くように Yaw/Pitch を計算して適用する
+                    if (lookAtTarget != null)
                     {
-                        var value = CalculateYawPitchFromGazePosition(gazeTarget.position);
+                        var value = CalculateYawPitchFromLookAtPosition(lookAtTarget.position);
                         SetYawPitchManually(value.Yaw, value.Pitch);
                     }
                     break;
-                case VRM10ObjectLookAt.LookAtTargetTypes.Manual:
+                case VRM10ObjectLookAt.LookAtTargetTypes.YawPitchValue:
                     // NOTE: 直接 Set された Yaw/Pitch を使って計算する
                     break;
             }
@@ -64,7 +64,8 @@ namespace UniVRM10
         }
 
         /// <summary>
-        /// LookAtTargetTypes.Manual 時に考慮される Yaw/Pitch 値を設定する
+        /// Yaw/Pitch 値を直接設定します。
+        /// LookAtTargetTypes が SpecifiedTransform の場合、ここで設定しても値は上書きされます。
         /// </summary>
         /// <param name="yaw">Headボーンのforwardに対するyaw角(度)</param>
         /// <param name="pitch">Headボーンのforwardに対するpitch角(度)</param>
@@ -74,9 +75,9 @@ namespace UniVRM10
             Pitch = pitch;
         }
 
-        public (float Yaw, float Pitch) CalculateYawPitchFromGazePosition(Vector3 gazeWorldPosition)
+        public (float Yaw, float Pitch) CalculateYawPitchFromLookAtPosition(Vector3 lookAtWorldPosition)
         {
-            var localPosition = EyeTransform.worldToLocalMatrix.MultiplyPoint(gazeWorldPosition);
+            var localPosition = EyeTransform.worldToLocalMatrix.MultiplyPoint(lookAtWorldPosition);
             Matrix4x4.identity.CalcYawPitch(localPosition, out var yaw, out var pitch);
             return (yaw, pitch);
         }
@@ -115,9 +116,9 @@ namespace UniVRM10
         {
             switch (lookAtTargetType)
             {
-                case VRM10ObjectLookAt.LookAtTargetTypes.Auto:
-                    return CalculateYawPitchFromGazePosition(gaze.position);
-                case VRM10ObjectLookAt.LookAtTargetTypes.Manual:
+                case VRM10ObjectLookAt.LookAtTargetTypes.SpecifiedTransform:
+                    return CalculateYawPitchFromLookAtPosition(gaze.position);
+                case VRM10ObjectLookAt.LookAtTargetTypes.YawPitchValue:
                     return (Yaw, Pitch);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(lookAtTargetType), lookAtTargetType, null);

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
@@ -8,23 +8,35 @@ namespace UniVRM10
     {
         private readonly VRM10ObjectLookAt _lookAt;
         private readonly Transform _head;
-        private readonly Vector3 _eyeTransformLocalPosition;
-        private readonly Quaternion _eyeTransformLocalRotation;
+        private readonly Vector3 _lookAtOriginTransformLocalPosition;
+        private readonly Quaternion _lookAtOriginTransformLocalRotation;
 
         internal ILookAtEyeDirectionApplicable EyeDirectionApplicable { get; }
 
         public float Yaw { get; private set; }
         public float Pitch { get; private set; }
         public LookAtEyeDirection EyeDirection { get; private set; }
-        public Transform EyeTransform { get; }
+
+        /// <summary>
+        /// Transform that indicates the position center of eyes.
+        /// This only represents the position of center of eyes, not the viewing direction.
+        /// Local +Z axis represents forward vector of the head.
+        /// Local +Y axis represents up vector of the head.
+        ///
+        /// 目の位置を示す Transform。
+        /// 視線方向は反映されない。
+        /// ローカル +Z 軸が頭の正面方向を表す。
+        /// ローカル +Y 軸が頭の上方向を表す。
+        /// </summary>
+        public Transform LookAtOriginTransform { get; }
 
         internal Vrm10RuntimeLookAt(VRM10ObjectLookAt lookAt, UniHumanoid.Humanoid humanoid, Transform head)
         {
             _lookAt = lookAt;
             _head = head;
-            EyeTransform = InitializeEyePositionTransform(_head, _lookAt.OffsetFromHead);
-            _eyeTransformLocalPosition = EyeTransform.localPosition;
-            _eyeTransformLocalRotation = EyeTransform.localRotation;
+            LookAtOriginTransform = InitializeEyePositionTransform(_head, _lookAt.OffsetFromHead);
+            _lookAtOriginTransformLocalPosition = LookAtOriginTransform.localPosition;
+            _lookAtOriginTransformLocalRotation = LookAtOriginTransform.localRotation;
 
             var leftEyeBone = humanoid.GetBoneTransform(HumanBodyBones.LeftEye);
             var rightEyeBone = humanoid.GetBoneTransform(HumanBodyBones.RightEye);
@@ -40,8 +52,8 @@ namespace UniVRM10
 
         internal void Process(VRM10ObjectLookAt.LookAtTargetTypes lookAtTargetType, Transform lookAtTarget)
         {
-            EyeTransform.localPosition = _eyeTransformLocalPosition;
-            EyeTransform.localRotation = _eyeTransformLocalRotation;
+            LookAtOriginTransform.localPosition = _lookAtOriginTransformLocalPosition;
+            LookAtOriginTransform.localRotation = _lookAtOriginTransformLocalRotation;
 
             switch (lookAtTargetType)
             {
@@ -75,7 +87,7 @@ namespace UniVRM10
 
         public (float Yaw, float Pitch) CalculateYawPitchFromLookAtPosition(Vector3 lookAtWorldPosition)
         {
-            var localPosition = EyeTransform.worldToLocalMatrix.MultiplyPoint(lookAtWorldPosition);
+            var localPosition = LookAtOriginTransform.worldToLocalMatrix.MultiplyPoint(lookAtWorldPosition);
             Matrix4x4.identity.CalcYawPitch(localPosition, out var yaw, out var pitch);
             return (yaw, pitch);
         }
@@ -97,7 +109,7 @@ namespace UniVRM10
         [Obsolete]
         public Transform GetLookAtOrigin(Transform head)
         {
-            return EyeTransform;
+            return LookAtOriginTransform;
         }
 
         [Obsolete]

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
@@ -11,13 +11,11 @@ namespace UniVRM10
         private readonly Vector3 _eyeTransformLocalPosition;
         private readonly Quaternion _eyeTransformLocalRotation;
 
-        public float Yaw { get; private set; }
-        public float Pitch { get; private set; }
-
         internal ILookAtEyeDirectionApplicable EyeDirectionApplicable { get; }
 
+        public float Yaw { get; private set; }
+        public float Pitch { get; private set; }
         public LookAtEyeDirection EyeDirection { get; private set; }
-
         public Transform EyeTransform { get; }
 
         internal Vrm10RuntimeLookAt(VRM10ObjectLookAt lookAt, UniHumanoid.Humanoid humanoid, Transform head)

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
@@ -74,7 +74,7 @@ namespace UniVRM10
             Pitch = pitch;
         }
 
-        private (float Yaw, float Pitch) CalculateYawPitchFromGazePosition(Vector3 gazeWorldPosition)
+        public (float Yaw, float Pitch) CalculateYawPitchFromGazePosition(Vector3 gazeWorldPosition)
         {
             var localPosition = EyeTransform.worldToLocalMatrix.MultiplyPoint(gazeWorldPosition);
             Matrix4x4.identity.CalcYawPitch(localPosition, out var yaw, out var pitch);

--- a/Assets/VRM10_Samples/VRM10Viewer/VRM10Loaded.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/VRM10Loaded.cs
@@ -69,7 +69,7 @@ namespace UniVRM10.VRM10Viewer
                     m_blink = instance.gameObject.AddComponent<VRM10Blinker>();
                     m_autoExpression = instance.gameObject.AddComponent<VRM10AutoExpression>();
 
-                    m_controller.LookAtTargetType = VRM10ObjectLookAt.LookAtTargetTypes.CalcYawPitchToGaze;
+                    m_controller.LookAtTargetType = VRM10ObjectLookAt.LookAtTargetTypes.Auto;
                     m_controller.Gaze = lookAtTarget;
                 }
             }

--- a/Assets/VRM10_Samples/VRM10Viewer/VRM10Loaded.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/VRM10Loaded.cs
@@ -69,8 +69,8 @@ namespace UniVRM10.VRM10Viewer
                     m_blink = instance.gameObject.AddComponent<VRM10Blinker>();
                     m_autoExpression = instance.gameObject.AddComponent<VRM10AutoExpression>();
 
-                    m_controller.LookAtTargetType = VRM10ObjectLookAt.LookAtTargetTypes.Auto;
-                    m_controller.Gaze = lookAtTarget;
+                    m_controller.LookAtTargetType = VRM10ObjectLookAt.LookAtTargetTypes.SpecifiedTransform;
+                    m_controller.LookAtTarget = lookAtTarget;
                 }
             }
 


### PR DESCRIPTION
`Vrm10RuntimeLookAt` の実装が、API・ロジックともに非常に分かりづらかったためリファクタリングしました。
元の public 関数は Obsolete として残しています。