### PR TITLE
sampler の bvh load の修正

### DIFF
--- a/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerUI.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerUI.cs
@@ -220,7 +220,7 @@ namespace UniVRM10.VRM10Viewer
         private void LoadMotion(string source)
         {
             var context = new UniHumanoid.BvhImporterContext();
-            context.Parse("tmp.bvh", source);
+            context.Parse("tmp.bvh", File.ReadAllText(source));
             context.Load();
             m_src = context.Root.GetComponent<Animator>();
             m_ui.IsBvhEnabled = true;


### PR DESCRIPTION
bvh のファイルの中身を渡すべきところにファイル名を渡して、常にエラーになっていた。
