### PR TITLE
Add a LookAtOrigin transform to ControlRig.

### DIFF
--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -63,7 +63,7 @@ namespace UniVRM10
                 ControlRig = new Vrm10RuntimeControlRig(target.Humanoid, m_target.transform, controlRigInitialRotations);
             }
             Constraints = target.GetComponentsInChildren<IVrm10Constraint>();
-            LookAt = new Vrm10RuntimeLookAt(target.Vrm.LookAt, target.Humanoid, m_head);
+            LookAt = new Vrm10RuntimeLookAt(target.Vrm.LookAt, target.Humanoid, ControlRig);
             Expression = new Vrm10RuntimeExpression(target, LookAt, LookAt.EyeDirectionApplicable);
 
             var instance = target.GetComponent<RuntimeGltfInstance>();

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeLookAt.cs
@@ -30,11 +30,13 @@ namespace UniVRM10
         /// </summary>
         public Transform LookAtOriginTransform { get; }
 
-        internal Vrm10RuntimeLookAt(VRM10ObjectLookAt lookAt, UniHumanoid.Humanoid humanoid, Transform head)
+        internal Vrm10RuntimeLookAt(VRM10ObjectLookAt lookAt, UniHumanoid.Humanoid humanoid, Vrm10RuntimeControlRig controlRig)
         {
             _lookAt = lookAt;
-            _head = head;
-            LookAtOriginTransform = InitializeEyePositionTransform(_head, _lookAt.OffsetFromHead);
+            LookAtOriginTransform = InitializeLookAtOriginTransform(
+                humanoid.Head,
+                controlRig != null ? controlRig.GetBoneTransform(HumanBodyBones.Head) : humanoid.Head,
+                _lookAt.OffsetFromHead);
             _lookAtOriginTransformLocalPosition = LookAtOriginTransform.localPosition;
             _lookAtOriginTransformLocalRotation = LookAtOriginTransform.localRotation;
 
@@ -92,17 +94,17 @@ namespace UniVRM10
             return (yaw, pitch);
         }
 
-        private static Transform InitializeEyePositionTransform(Transform head, Vector3 eyeOffsetValue)
+        private static Transform InitializeLookAtOriginTransform(Transform rawHead, Transform actualHead, Vector3 eyeOffsetValue)
         {
             if (!Application.isPlaying) return null;
 
             // NOTE: このメソッドを実行するとき、モデル全体は初期姿勢（T-Pose）でなければならない。
-            var eyePositionTransform = new GameObject("_eye_transform_").transform;
-            eyePositionTransform.SetParent(head);
-            eyePositionTransform.localPosition = eyeOffsetValue;
-            eyePositionTransform.rotation = Quaternion.identity;
+            var lookAtOrigin = new GameObject("_look_at_origin_").transform;
+            lookAtOrigin.SetParent(actualHead);
+            lookAtOrigin.position = rawHead.TransformPoint(eyeOffsetValue);
+            lookAtOrigin.rotation = Quaternion.identity;
 
-            return eyePositionTransform;
+            return lookAtOrigin;
         }
 
 #region Obsolete


### PR DESCRIPTION
https://github.com/vrm-c/UniVRM/pull/1984 で public にした目の位置を指定する `LookAtOrigin` Transform は VRHMD の視点位置紐づけに使われる。

この Transform が ControlRig ではなく生ボーンのヒエラルキーにあると以下の時に問題がある。
1. ControlRig を更新する
2. LookAtOrigin Transform を見てカメラ位置と紐づける
3. Vrm10Runtime.Process で ControlRig の姿勢を生ボーンに適用する

2 の時に正しい姿勢が得られない。
LookAtOrigin Transform はランタイムにアクセスされることだけを想定するので、ControlRig があるならそちらにぶら下がっていた方が好ましい。
