### PR TITLE
fix: Fix vrmAssetPostprocessor

### DIFF
--- a/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -17,11 +17,13 @@ namespace VRM
         {
             foreach (string path in importedAssets)
             {
-                if (!UnityPath.FromUnityPath(path).IsFileExists) {
+                var unityPath = UnityPath.FromUnityPath(path);
+
+                if (!unityPath.IsFileExists) {
                     continue;
                 }
 
-                if (UnityPath.FromUnityPath(path).IsStreamingAsset)
+                if (unityPath.IsStreamingAsset)
                 {
                     Debug.LogFormat("Skip StreamingAssets: {0}", path);
                     continue;
@@ -32,7 +34,7 @@ namespace VRM
                 {
                     try
                     {
-                        ImportVrm(UnityPath.FromUnityPath(path));
+                        ImportVrm(unityPath);
                     }
                     catch (NotVrm0Exception)
                     {

--- a/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Assets/VRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -17,6 +17,10 @@ namespace VRM
         {
             foreach (string path in importedAssets)
             {
+                if (!UnityPath.FromUnityPath(path).IsFileExists) {
+                    continue;
+                }
+
                 if (UnityPath.FromUnityPath(path).IsStreamingAsset)
                 {
                     Debug.LogFormat("Skip StreamingAssets: {0}", path);


### PR DESCRIPTION
### Description

vrmAssetPostprocessorが誤ってディレクトリを処理してしまうことがあるのを修正しました。

名前が `.vrm` で終わるフォルダに反応して、以下のエラーが出ていました:

```
Exception: Exception of type 'System.Exception' was thrown.
VRM.vrmAssetPostprocessor.ImportVrm (UniGLTF.UnityPath vrmPath) (at Assets/VRM/VRM/Editor/Format/vrmAssetPostprocessor.cs:46)
VRM.vrmAssetPostprocessor.OnPostprocessAllAssets (System.String[] importedAssets, System.String[] deletedAssets, System.String[] movedAssets, System.String[] movedFromAssetPaths) (at Assets/VRM/VRM/Editor/Format/vrmAssetPostprocessor.cs:31)
```

具体的には、 `Packages/com.vrmc.vrm` に反応してエラーを起こしてしまう現象が発生していました。
