### PR TITLE
ArrayProperty name `Element 0` to `{Array.Name}[0]`

### DIFF
--- a/Assets/VRM10/Editor/Components/VRM10MetaPropertyValidator.cs
+++ b/Assets/VRM10/Editor/Components/VRM10MetaPropertyValidator.cs
@@ -1,4 +1,5 @@
 using UnityEditor;
+using UnityEngine;
 
 namespace UniVRM10
 {
@@ -33,6 +34,7 @@ namespace UniVRM10
 
                     var depth = m_prop.depth;
                     var iterator = m_prop.Copy();
+                    var arrayName = iterator.name;
                     for (var enterChildren = true; iterator.NextVisible(enterChildren); enterChildren = false)
                     {
                         if (iterator.depth < depth)
@@ -41,7 +43,17 @@ namespace UniVRM10
                         depth = iterator.depth;
 
                         // using (new EditorGUI.DisabledScope("m_Script" == iterator.propertyPath))
-                        EditorGUILayout.PropertyField(iterator, true);
+                        var match = System.Text.RegularExpressions.Regex.Match(iterator.propertyPath, "\\[(\\d+)\\]$");
+                        if (match != null && iterator.type == "string")
+                        {
+                            // ArrayItem
+                            // Debug.Log($"{match.Groups[1].Value}");
+                            iterator.stringValue = EditorGUILayout.TextField($"  {arrayName}[{match.Groups[1].Value}]", iterator.stringValue);
+                        }
+                        else
+                        {
+                            EditorGUILayout.PropertyField(iterator, true);
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
vrm-1.0 のエクスポートダイアログで Authors の Array 表示が分かりにくい件

fixed #1845
fixed #1880
fixed #1981

ちょっと改善

![Element0](https://user-images.githubusercontent.com/68057/223672681-ac61e8bc-e3b0-436e-b1aa-83b3950a819d.jpg)
