### PR TITLE
[sample] SimpleViewer を修復(BvhImporterContext の挙動変更に追随)

### DIFF
--- a/Assets/UniGLTF/Runtime/UniHumanoid/IO/BvhImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniHumanoid/IO/BvhImporterContext.cs
@@ -116,6 +116,8 @@ namespace UniHumanoid
             AvatarDescription = description;
             var animator = Root.AddComponent<Animator>();
             animator.avatar = Avatar;
+
+            Root.AddComponent<HumanPoseTransfer>();
         }
 
         static Transform BuildHierarchy(Transform parent, BvhNode node, float toMeter)

--- a/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
+++ b/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
@@ -225,7 +225,11 @@ namespace VRM.SimpleViewer
             var context = new UniHumanoid.BvhImporterContext();
             context.Parse(path, source);
             context.Load();
-            m_src = context.Root.GetOrAddComponent<HumanPoseTransfer>();
+            m_src = context.Root.GetComponent<HumanPoseTransfer>();
+            if (m_src == null)
+            {
+                throw new ArgumentNullException();
+            }
             m_loaded?.EnableBvh(m_src);
         }
 

--- a/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
+++ b/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
@@ -225,8 +225,7 @@ namespace VRM.SimpleViewer
             var context = new UniHumanoid.BvhImporterContext();
             context.Parse(path, source);
             context.Load();
-            m_src = context.Root.GetComponent<HumanPoseTransfer>();
-            m_src.GetComponent<Renderer>().enabled = false;
+            m_src = context.Root.GetOrAddComponent<HumanPoseTransfer>();
             m_loaded?.EnableBvh(m_src);
         }
 


### PR DESCRIPTION
vrm-1.0 のサンプルの都合で BvhImporterContext は BoxMan の自動作成とHumanPoseTransfer の自動作成を止めてた。
vrm-0.x のサンプルが動かなくなっていた。

* BoxMan を隠すコードを削除(renderer.enabled=false が不要になった)
* HumanPoseTransfer は自動作成を復活(使わなければ特に影響無い)
