### PR TITLE
Fix shadow behaviour of MToon 1.0 when Single-Pass Stereo Rendering is enabled.

### DIFF
--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_fragment.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_fragment.hlsl
@@ -20,6 +20,7 @@ half4 MToonFragment(const FragmentInput fragmentInput) : SV_Target
     }
 
     const Varyings input = fragmentInput.varyings;
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
 
     // Get MToon UV (with UVAnimation)
     const float2 uv = GetMToonGeometry_Uv(input.uv);


### PR DESCRIPTION
MToon 1.0 シェーダの影を受ける描画が、Single-Pass Stereo Rendering のときにおかしな見た目になっている問題を修正しました。

必要なマクロの呼び出しが欠けていました。