### PR TITLE
vrmc_materials_mtoon_render_pipelineにURPに関する知識を隔離する

### DIFF
--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_attribute.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_attribute.hlsl
@@ -25,19 +25,7 @@ struct Varyings
 #endif
     float3 viewDirWS : TEXCOORD4;
 
-#ifdef MTOON_URP
-    half4 fogFactorAndVertexLight   : TEXCOORD5; // x: fogFactor, yzw: vertex light
-    
-    #if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
-    float4 shadowCoord              : TEXCOORD6;
-    #endif
-
-    DECLARE_LIGHTMAP_OR_SH(lightmapUV, vertexSH, 7);
-
-#else
-    UNITY_FOG_COORDS(5)
-    UNITY_LIGHTING_COORDS(6,7)
-#endif
+    MTOON_FOG_AND_LIGHTING_COORDS(5, 6, 7)
     
     float4 pos : SV_POSITION; // UnityCG macro specified name. Accurately "positionCS"
     UNITY_VERTEX_INPUT_INSTANCE_ID

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_attribute.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_attribute.hlsl
@@ -1,12 +1,7 @@
 ﻿#ifndef VRMC_MATERIALS_MTOON_ATTRIBUTE_INCLUDED
 #define VRMC_MATERIALS_MTOON_ATTRIBUTE_INCLUDED
 
-#ifdef MTOON_URP
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-#else
-#include <UnityCG.cginc>
-#include <AutoLight.cginc>
-#endif
+#include "./vrmc_materials_mtoon_render_pipeline.hlsl"
 
 struct Attributes
 {

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_fragment.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_fragment.hlsl
@@ -1,12 +1,7 @@
 #ifndef VRMC_MATERIALS_MTOON_FORWARD_FRAGMENT_INCLUDED
 #define VRMC_MATERIALS_MTOON_FORWARD_FRAGMENT_INCLUDED
 
-#ifdef MTOON_URP
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-#else
-#include <UnityCG.cginc>
-#endif
-
+#include "./vrmc_materials_mtoon_render_pipeline.hlsl"
 #include "./vrmc_materials_mtoon_define.hlsl"
 #include "./vrmc_materials_mtoon_utility.hlsl"
 #include "./vrmc_materials_mtoon_input.hlsl"
@@ -31,11 +26,7 @@ half4 MToonFragment(const FragmentInput fragmentInput) : SV_Target
     const float2 uv = GetMToonGeometry_Uv(input.uv);
 
     // Get LitColor with Alpha
-    #ifdef MTOON_URP
-    const half4 litColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, uv) * _Color;
-    #else
-    const half4 litColor = UNITY_SAMPLE_TEX2D(_MainTex, uv) * _Color;
-    #endif
+    const half4 litColor = MTOON_SAMPLE_TEXTURE2D(_MainTex, uv) * _Color;
 
     // Alpha Test
     const half alpha = GetMToonGeometry_Alpha(litColor);

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_vertex.hlsl
@@ -42,23 +42,7 @@ Varyings MToonVertex(const Attributes v) // v is UnityCG macro specified name.
     output.tangentWS = half4(MToon_TransformObjectToWorldDir(v.tangentOS), tangentSign);
 #endif
 
-#ifdef MTOON_URP
-    OUTPUT_LIGHTMAP_UV(input.texcoord1, unity_LightmapST, output.lightmapUV);
-    OUTPUT_SH(output.normalWS.xyz, output.vertexSH);
-
-    half3 vertexLight = VertexLighting(output.positionWS, output.normalWS);
-    half fogFactor = ComputeFogFactor(output.pos.z);
-    output.fogFactorAndVertexLight = half4(fogFactor, vertexLight);
-    
-    #if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
-    VertexPositionInputs vertexInput = GetVertexPositionInputs(v.vertex.xyz);
-    output.shadowCoord = GetShadowCoord(vertexInput);
-    #endif
-
-#else
-    UNITY_TRANSFER_FOG(output, output.pos);
-    UNITY_TRANSFER_LIGHTING(output, v.texcoord1.xy);
-#endif
+    MTOON_TRANSFER_FOG_AND_LIGHTING(output, output.pos, v.texcoord1.xy, v.vertex.xyz);
 
     return output;
 }

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_vertex.hlsl
@@ -1,14 +1,7 @@
 #ifndef VRMC_MATERIALS_MTOON_FORWARD_VERTEX_INCLUDED
 #define VRMC_MATERIALS_MTOON_FORWARD_VERTEX_INCLUDED
 
-#ifdef MTOON_URP
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
-#else
-#include <UnityCG.cginc>
-#include <AutoLight.cginc>
-#endif
-
+#include "./vrmc_materials_mtoon_render_pipeline.hlsl"
 #include "./vrmc_materials_mtoon_define.hlsl"
 #include "./vrmc_materials_mtoon_utility.hlsl"
 #include "./vrmc_materials_mtoon_input.hlsl"
@@ -31,11 +24,7 @@ Varyings MToonVertex(const Attributes v) // v is UnityCG macro specified name.
         output.pos = position.positionCS;
         output.positionWS = position.positionWS.xyz;
 
-        #ifdef MTOON_URP
-        output.normalWS = TransformObjectToWorldNormal(-v.normalOS);
-        #else
-        output.normalWS = UnityObjectToWorldNormal(-v.normalOS);
-        #endif
+        output.normalWS = MToon_TransformObjectToWorldNormal(-v.normalOS);
     }
     else
     {
@@ -43,24 +32,14 @@ Varyings MToonVertex(const Attributes v) // v is UnityCG macro specified name.
         output.pos = position.positionCS;
         output.positionWS = position.positionWS.xyz;
 
-        #ifdef MTOON_URP
-        output.normalWS = TransformObjectToWorldNormal(v.normalOS);
-        #else
-        output.normalWS = UnityObjectToWorldNormal(v.normalOS);
-        #endif
+        output.normalWS = MToon_TransformObjectToWorldNormal(v.normalOS);
     }
 
     output.viewDirWS = MToon_GetWorldSpaceNormalizedViewDir(output.positionWS);
 
 #if defined(_NORMALMAP)
     const half tangentSign = v.tangentOS.w * unity_WorldTransformParams.w;
-
-    #ifdef MTOON_URP
-    output.tangentWS = half4(TransformObjectToWorldDir(v.tangentOS), tangentSign);
-    #else
-    output.tangentWS = half4(UnityObjectToWorldDir(v.tangentOS), tangentSign);
-    #endif
-
+    output.tangentWS = half4(MToon_TransformObjectToWorldDir(v.tangentOS), tangentSign);
 #endif
 
 #ifdef MTOON_URP

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_forward_vertex.hlsl
@@ -43,8 +43,6 @@ Varyings MToonVertex(const Attributes v) // v is UnityCG macro specified name.
 #endif
 
 #ifdef MTOON_URP
-    VertexPositionInputs vertexInput = GetVertexPositionInputs(v.vertex.xyz);
-
     OUTPUT_LIGHTMAP_UV(input.texcoord1, unity_LightmapST, output.lightmapUV);
     OUTPUT_SH(output.normalWS.xyz, output.vertexSH);
 
@@ -53,6 +51,7 @@ Varyings MToonVertex(const Attributes v) // v is UnityCG macro specified name.
     output.fogFactorAndVertexLight = half4(fogFactor, vertexLight);
     
     #if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
+    VertexPositionInputs vertexInput = GetVertexPositionInputs(v.vertex.xyz);
     output.shadowCoord = GetShadowCoord(vertexInput);
     #endif
 

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_normal.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_normal.hlsl
@@ -1,12 +1,7 @@
 ﻿#ifndef VRMC_MATERIALS_MTOON_GEOMETRY_NORMAL_INCLUDED
 #define VRMC_MATERIALS_MTOON_GEOMETRY_NORMAL_INCLUDED
 
-#ifdef MTOON_URP
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-#else
-#include <UnityCG.cginc>
-#endif
-
+#include "./vrmc_materials_mtoon_render_pipeline.hlsl"
 #include "./vrmc_materials_mtoon_define.hlsl"
 #include "./vrmc_materials_mtoon_utility.hlsl"
 #include "./vrmc_materials_mtoon_input.hlsl"
@@ -20,19 +15,17 @@ inline float3 GetMToonGeometry_Normal(const Varyings input, const MTOON_FRONT_FA
 {
     const half3 normalWS = MTOON_IS_FRONT_VFACE(facing, input.normalWS, -input.normalWS);
 
-#if defined(_NORMALMAP)
-    
+    #if defined(_NORMALMAP)
+
     // Get Normal in WorldSpace from Normalmap if available
-    #ifdef MTOON_URP
-    const half3 normalTS = normalize(UnpackNormalScale(SAMPLE_TEXTURE2D(_BumpMap, sampler_MainTex, mtoonUv), _BumpScale));
-    #else
-    const half3 normalTS = normalize(UnpackNormalWithScale(UNITY_SAMPLE_TEX2D(_BumpMap, mtoonUv), _BumpScale));
-    #endif
-    
+    const half3 normalTS = normalize(MToon_UnpackNormalScale(MTOON_SAMPLE_TEXTURE2D(_BumpMap, mtoonUv), _BumpScale));
     return normalize(mul(normalTS, MToon_GetTangentToWorld(normalWS, input.tangentWS)));
-#else
+    
+    #else
+
     return GetMToonGeometry_NormalWithoutNormalMap(normalWS);
-#endif
+
+    #endif
 }
 
 #endif

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_uv.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_uv.hlsl
@@ -1,12 +1,7 @@
 ﻿#ifndef VRMC_MATERIALS_MTOON_GEOMETRY_UV_INCLUDED
 #define VRMC_MATERIALS_MTOON_GEOMETRY_UV_INCLUDED
 
-#ifdef MTOON_URP
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-#else
-#include <UnityCG.cginc>
-#endif
-
+#include "./vrmc_materials_mtoon_render_pipeline.hlsl"
 #include "./vrmc_materials_mtoon_define.hlsl"
 #include "./vrmc_materials_mtoon_utility.hlsl"
 #include "./vrmc_materials_mtoon_input.hlsl"
@@ -15,16 +10,9 @@ inline float GetMToonGeometry_Uv_Time(const float2 uvRaw)
 {
     if (MToon_IsParameterMapOn())
     {
-        #ifdef MTOON_URP
-        return SAMPLE_TEXTURE2D(_UvAnimMaskTex, sampler_UvAnimMaskTex, uvRaw);
-        #else
-        return UNITY_SAMPLE_TEX2D(_UvAnimMaskTex, uvRaw).b * _Time.y;
-        #endif
+        return MTOON_SAMPLE_TEXTURE2D(_UvAnimMaskTex, uvRaw).b * _Time.y;
     }
-    else
-    {
-        return _Time.y;
-    }
+    return _Time.y;
 }
 
 inline float2 GetMToonGeometry_Uv(const float2 geometryUv)

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_geometry_vertex.hlsl
@@ -1,13 +1,7 @@
 ﻿#ifndef VRMC_MATERIALS_MTOON_GEOMETRY_VERTEX_INCLUDED
 #define VRMC_MATERIALS_MTOON_GEOMETRY_VERTEX_INCLUDED
 
-#ifdef MTOON_URP
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-#else
-#include <UnityCG.cginc>
-#endif
-
+#include "./vrmc_materials_mtoon_render_pipeline.hlsl"
 #include "./vrmc_materials_mtoon_define.hlsl"
 #include "./vrmc_materials_mtoon_utility.hlsl"
 #include "./vrmc_materials_mtoon_input.hlsl"
@@ -55,25 +49,13 @@ inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const 
     if (MToon_IsOutlineModeWorldCoordinates())
     {
         const float3 positionWS = mul(unity_ObjectToWorld, float4(positionOS, 1)).xyz;
-        
-        #ifdef MTOON_URP
-        const half3 normalWS =  TransformObjectToWorldNormal(normalOS);
-        #else
-        const half3 normalWS = UnityObjectToWorldNormal(normalOS);
-        #endif
-
+        const half3 normalWS =  MToon_TransformObjectToWorldNormal(normalOS);
         const half outlineWidth = MToon_GetOutlineVertex_OutlineWidth(uv);
 
         VertexPositionInfo output;
         output.positionWS = float4(positionWS + normalWS * outlineWidth, 1);
-        
-        #ifdef MTOON_URP
-        output.positionCS = TransformWorldToHClip(output.positionWS.xyz);
-        #else
-        output.positionCS = UnityWorldToClipPos(output.positionWS);
-        #endif
+        output.positionCS = MToon_TransformWorldToHClip(output.positionWS.xyz);
 
-        
         return output;
     }
     else if (MToon_IsOutlineModeScreenCoordinates())
@@ -83,21 +65,9 @@ inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const 
 
         const float4 nearUpperRight = mul(unity_CameraInvProjection, float4(1, 1, UNITY_NEAR_CLIP_VALUE, _ProjectionParams.y));
         const half aspect = abs(nearUpperRight.y / nearUpperRight.x);
-
-        #ifdef MTOON_URP
-        const float4 positionCS = TransformObjectToHClip(positionOS);
-        #else
-        const float4 positionCS = UnityObjectToClipPos(positionOS);
-        #endif
-
+        const float4 positionCS = MToon_TransformObjectToHClip(positionOS);
         const half3 normalVS = MToon_GetObjectToViewNormal(normalOS);
-
-        #ifdef MTOON_URP
-        const half3 normalWS = TransformObjectToWorldNormal(normalOS.xyz);
-        const half3 normalCS = TransformWorldToHClipDir(normalWS.xyz);
-        #else
-        const half3 normalCS = TransformViewToProjection(normalVS.xyz);
-        #endif
+        const half3 normalCS = MToon_TransformViewToHClip(normalVS.xyz);
 
         half2 normalProjectedCS = normalize(normalCS.xy);
         const float clipSpaceHeight = 2.0f;
@@ -115,12 +85,7 @@ inline VertexPositionInfo MToon_GetOutlineVertex(const float3 positionOS, const 
     {
         VertexPositionInfo output;
         output.positionWS = mul(unity_ObjectToWorld, float4(positionOS * 0.001, 1));
-
-        #ifdef MTOON_URP
-        output.positionCS = TransformWorldToHClip(output.positionWS.xyz);
-        #else
-        output.positionCS = UnityWorldToClipPos(output.positionWS);
-        #endif
+        output.positionCS = MToon_TransformWorldToHClip(output.positionWS.xyz);
 
         return output;
     }
@@ -130,13 +95,7 @@ inline VertexPositionInfo MToon_GetVertex(const float3 positionOS)
 {
     VertexPositionInfo output;
     output.positionWS = mul(unity_ObjectToWorld, float4(positionOS, 1));
-
-    #ifdef MTOON_URP
-    output.positionCS = TransformWorldToHClip(output.positionWS.xyz);
-    #else
-    output.positionCS = UnityWorldToClipPos(output.positionWS);
-    #endif
-
+    output.positionCS = MToon_TransformWorldToHClip(output.positionWS.xyz);
 
     return output;
 }

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_input.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_input.hlsl
@@ -1,36 +1,19 @@
 ﻿#ifndef VRMC_MATERIALS_MTOON_INPUT_INCLUDED
 #define VRMC_MATERIALS_MTOON_INPUT_INCLUDED
 
-#ifdef MTOON_URP
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-#else
-#include <UnityShaderVariables.cginc>
-#endif
+#include "./vrmc_materials_mtoon_render_pipeline.hlsl"
 
 // Textures
-#ifdef MTOON_URP
-TEXTURE2D(_MainTex);                SAMPLER(sampler_MainTex);
-TEXTURE2D(_ShadeTex);               SAMPLER(sampler_ShadeTex);
-TEXTURE2D(_BumpMap);                SAMPLER(sampler_BumpMap);
-TEXTURE2D(_ShadingShiftTex);        SAMPLER(sampler_ShadingShiftTex);
-TEXTURE2D(_EmissionMap);            SAMPLER(sampler_EmissionMap);
-TEXTURE2D(_MatcapTex);              SAMPLER(sampler_MatcapTex);
-TEXTURE2D(_RimTex);                 SAMPLER(sampler_RimTex);
-TEXTURE2D(_OutlineWidthTex);        SAMPLER(sampler_OutlineWidthTex);
+MTOON_DECLARE_TEX2D(_MainTex);
+MTOON_DECLARE_TEX2D(_ShadeTex);
+MTOON_DECLARE_TEX2D(_BumpMap);
+MTOON_DECLARE_TEX2D(_ShadingShiftTex);
+MTOON_DECLARE_TEX2D(_EmissionMap);
+MTOON_DECLARE_TEX2D(_MatcapTex);
+MTOON_DECLARE_TEX2D(_RimTex);
+MTOON_DECLARE_TEX2D(_OutlineWidthTex);
 // NOTE: "tex2d() * _Time.y" returns mediump value if sampler is half precision in Android VR platform
-TEXTURE2D_FLOAT(_UvAnimMaskTex);    SAMPLER(sampler_UvAnimMaskTex);
-#else
-UNITY_DECLARE_TEX2D(_MainTex);
-UNITY_DECLARE_TEX2D(_ShadeTex);
-UNITY_DECLARE_TEX2D(_BumpMap);
-UNITY_DECLARE_TEX2D(_ShadingShiftTex);
-UNITY_DECLARE_TEX2D(_EmissionMap);
-UNITY_DECLARE_TEX2D(_MatcapTex);
-UNITY_DECLARE_TEX2D(_RimTex);
-UNITY_DECLARE_TEX2D(_OutlineWidthTex);
-// NOTE: "tex2d() * _Time.y" returns mediump value if sampler is half precision in Android VR platform
-UNITY_DECLARE_TEX2D_FLOAT(_UvAnimMaskTex);
-#endif
+MTOON_DECLARE_TEX2D_FLOAT(_UvAnimMaskTex);
 
 CBUFFER_START(UnityPerMaterial)
 // Vector

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_lighting_mtoon.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_lighting_mtoon.hlsl
@@ -1,12 +1,7 @@
 ﻿#ifndef VRMC_MATERIALS_MTOON_LIGHTING_MTOON_INCLUDED
 #define VRMC_MATERIALS_MTOON_LIGHTING_MTOON_INCLUDED
 
-#ifdef MTOON_URP
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-#else
-#include <UnityShaderVariables.cginc>
-#endif
-
+#include "./vrmc_materials_mtoon_render_pipeline.hlsl"
 #include "./vrmc_materials_mtoon_define.hlsl"
 #include "./vrmc_materials_mtoon_utility.hlsl"
 #include "./vrmc_materials_mtoon_input.hlsl"
@@ -25,16 +20,9 @@ inline half GetMToonLighting_Reflectance_ShadingShift(const MToonInput input)
 {
     if (MToon_IsParameterMapOn())
     {
-        #ifdef MTOON_URP
-        return SAMPLE_TEXTURE2D(_ShadingShiftTex, sampler_ShadingShiftTex, input.uv).r * _ShadingShiftTexScale + _ShadingShiftFactor;
-        #else
-        return UNITY_SAMPLE_TEX2D(_ShadingShiftTex, input.uv).r * _ShadingShiftTexScale + _ShadingShiftFactor;
-        #endif
+        return MTOON_SAMPLE_TEXTURE2D(_ShadingShiftTex, input.uv).r * _ShadingShiftTexScale + _ShadingShiftFactor;
     }
-    else
-    {
-        return _ShadingShiftFactor;
-    }
+    return _ShadingShiftFactor;
 }
 
 inline half GetMToonLighting_DotNL(const UnityLighting lighting, const MToonInput input)
@@ -87,11 +75,7 @@ inline half GetMToonLighting_Shadow(const UnityLighting lighting, const half dot
 
 inline half3 GetMToonLighting_DirectLighting(const UnityLighting unityLight, const MToonInput input, const half shade, const half shadow)
 {
-    #ifdef MTOON_URP
-    const half3 shadeColor = SAMPLE_TEXTURE2D(_ShadeTex, sampler_ShadeTex, input.uv).rgb * _ShadeColor.rgb;
-    #else
-    const half3 shadeColor = UNITY_SAMPLE_TEX2D(_ShadeTex, input.uv).rgb * _ShadeColor.rgb;
-    #endif
+    const half3 shadeColor = MTOON_SAMPLE_TEXTURE2D(_ShadeTex, input.uv).rgb * _ShadeColor.rgb;
     const half3 albedo = lerp(shadeColor, input.litColor, shade);
 
     return albedo * unityLight.directLightColor * shadow;
@@ -115,21 +99,11 @@ inline half3 GetMToonLighting_Emissive(const MToonInput input)
     {
         if (MToon_IsEmissiveMapOn())
         {
-            #ifdef MTOON_URP
-            return SAMPLE_TEXTURE2D(_EmissionMap, sampler_EmissionMap, input.uv).rgb * _EmissionColor.rgb;
-            #else
-            return UNITY_SAMPLE_TEX2D(_EmissionMap, input.uv).rgb * _EmissionColor.rgb;
-            #endif
+            return MTOON_SAMPLE_TEXTURE2D(_EmissionMap, input.uv).rgb * _EmissionColor.rgb;
         }
-        else
-        {
-            return _EmissionColor.rgb;
-        }
+        return _EmissionColor.rgb;
     }
-    else
-    {
-        return 0;
-    }
+    return 0;
 }
 
 inline half3 GetMToonLighting_Rim_Matcap(const MToonInput input)
@@ -142,16 +116,9 @@ inline half3 GetMToonLighting_Rim_Matcap(const MToonInput input)
         const half3 matcapUpAxisWS = normalize(cross(matcapRightAxisWS, input.viewDirWS));
         const half2 matcapUv = float2(dot(matcapRightAxisWS, input.normalWS), dot(matcapUpAxisWS, input.normalWS)) * 0.5 + 0.5;
         
-        #ifdef MTOON_URP
-        return _MatcapColor.rgb * SAMPLE_TEXTURE2D(_MatcapTex, sampler_MatcapTex, matcapUv).rgb;
-        #else
-        return _MatcapColor.rgb * UNITY_SAMPLE_TEX2D(_MatcapTex, matcapUv).rgb;
-        #endif
+        return _MatcapColor.rgb * MTOON_SAMPLE_TEXTURE2D(_MatcapTex, matcapUv).rgb;
     }
-    else
-    {
-        return _MatcapColor.rgb;
-    }
+    return _MatcapColor.rgb;
 }
 
 inline half3 GetMToonLighting_Rim(const UnityLighting unityLight, const MToonInput input, const half shadow)
@@ -174,16 +141,9 @@ inline half3 GetMToonLighting_Rim(const UnityLighting unityLight, const MToonInp
 
     if (MToon_IsRimMapOn())
     {
-        #ifdef MTOON_URP
-        return (matcapFactor + parametricRimFactor) * rimLightingFactor * SAMPLE_TEXTURE2D(_RimTex, sampler_RimTex, input.uv).rgb;
-        #else
-        return (matcapFactor + parametricRimFactor) * rimLightingFactor * UNITY_SAMPLE_TEX2D(_RimTex, input.uv).rgb;
-        #endif
+        return (matcapFactor + parametricRimFactor) * rimLightingFactor * MTOON_SAMPLE_TEXTURE2D(_RimTex, input.uv).rgb;
     }
-    else
-    {
-        return (matcapFactor + parametricRimFactor) * rimLightingFactor;
-    }
+    return (matcapFactor + parametricRimFactor) * rimLightingFactor;
 }
 
 half4 GetMToonLighting(const UnityLighting unityLight, const MToonInput input)
@@ -205,10 +165,7 @@ half4 GetMToonLighting(const UnityLighting unityLight, const MToonInput input)
         const half3 outlineCol = _OutlineColor.rgb * lerp(half3(1, 1, 1), baseCol, _OutlineLightingMix);
         return half4(outlineCol, input.alpha);
     }
-    else
-    {
-        return half4(baseCol, input.alpha);
-    }
+    return half4(baseCol, input.alpha);
 }
 
 #ifdef MTOON_URP

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_lighting_unity.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_lighting_unity.hlsl
@@ -17,30 +17,7 @@ struct UnityLighting
 
 UnityLighting GetUnityLighting(const Varyings input, const half3 normalWS)
 {
-#ifdef MTOON_URP
-    #if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
-    float4 shadowCoord = input.shadowCoord;
-    #elif defined(MAIN_LIGHT_CALCULATE_SHADOWS)
-    float4 shadowCoord = TransformWorldToShadowCoord(input.positionWS);
-    #else
-    float4 shadowCoord = float4(0, 0, 0, 0);
-    #endif
-    
-    half4 shadowMask = SAMPLE_SHADOWMASK(input.lightmapUV);
-    Light mainLight = GetMainLight(shadowCoord, input.positionWS, shadowMask);
-    
-    const half3 lightDir = mainLight.direction;
-    const half3 lightColor = mainLight.color.rgb;
-
-    float atten = mainLight.shadowAttenuation;
-
-#else
-    UNITY_LIGHT_ATTENUATION(atten, input, input.positionWS);
-
-    const half3 lightDir = normalize(UnityWorldSpaceLightDir(input.positionWS));
-    const half3 lightColor = _LightColor0.rgb;
-
-#endif
+    MTOON_LIGHT_DESCRIPTION(input, atten, lightDir, lightColor);
 
     if (MToon_IsForwardBasePass())
     {
@@ -57,16 +34,13 @@ UnityLighting GetUnityLighting(const Varyings input, const half3 normalWS)
         output.directLightAttenuation = atten;
         return output;
     }
-    else
-    {
-        UnityLighting output;
-        output.indirectLight = 0;
-        output.indirectLightEqualized = 0;
-        output.directLightColor = lightColor;
-        output.directLightDirection = lightDir;
-        output.directLightAttenuation = atten;
-        return output;
-    }
+    UnityLighting output;
+    output.indirectLight = 0;
+    output.indirectLightEqualized = 0;
+    output.directLightColor = lightColor;
+    output.directLightDirection = lightDir;
+    output.directLightAttenuation = atten;
+    return output;
 }
 
 #ifdef MTOON_URP

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_lighting_unity.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_lighting_unity.hlsl
@@ -22,13 +22,8 @@ UnityLighting GetUnityLighting(const Varyings input, const half3 normalWS)
     if (MToon_IsForwardBasePass())
     {
         UnityLighting output;
-#ifdef MTOON_URP
-        output.indirectLight = SampleSH(normalWS);
-        output.indirectLightEqualized = (SampleSH(half3(0, 1, 0)) + SampleSH(half3(0, -1, 0))) * 0.5;
-#else
-        output.indirectLight = ShadeSH9(half4(normalWS, 1));
-        output.indirectLightEqualized = (ShadeSH9(half4(0, 1, 0, 1)) + ShadeSH9(half4(0, -1, 0, 1))) * 0.5;
-#endif
+        output.indirectLight = MToon_SampleSH(half3(normalWS));
+        output.indirectLightEqualized = (MToon_SampleSH(half3(0, 1, 0)) + MToon_SampleSH(half3(0, -1, 0))) * 0.5;
         output.directLightColor = lightColor;
         output.directLightDirection = lightDir;
         output.directLightAttenuation = atten;

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_lighting_unity.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_lighting_unity.hlsl
@@ -1,15 +1,7 @@
 ﻿#ifndef VRMC_MATERIALS_MTOON_LIGHTING_UNITY_INCLUDED
 #define VRMC_MATERIALS_MTOON_LIGHTING_UNITY_INCLUDED
 
-#ifdef MTOON_URP
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
-#else
-#include <UnityCG.cginc>
-#include <AutoLight.cginc>
-#include <Lighting.cginc>
-#endif
-
+#include "./vrmc_materials_mtoon_render_pipeline.hlsl"
 #include "./vrmc_materials_mtoon_define.hlsl"
 #include "./vrmc_materials_mtoon_input.hlsl"
 #include "./vrmc_materials_mtoon_attribute.hlsl"

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
@@ -1,0 +1,79 @@
+﻿#ifndef VRMC_MATERIALS_MTOON_RENDER_PIPELINE_INCLUDED
+#define VRMC_MATERIALS_MTOON_RENDER_PIPELINE_INCLUDED
+
+#ifdef MTOON_URP
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+#else
+#include <UnityCG.cginc>
+#include <AutoLight.cginc>
+#include <Lighting.cginc>
+#include <UnityShaderVariables.cginc>
+#endif
+
+#ifdef MTOON_URP
+#define MTOON_DECLARE_TEX2D(tex) TEXTURE2D_FLOAT(tex); SAMPLER(sampler##tex);
+#define MTOON_DECLARE_TEX2D_FLOAT(tex) TEXTURE2D(tex); SAMPLER(sampler##tex);
+#define MTOON_SAMPLE_TEXTURE2D(tex, uv) SAMPLE_TEXTURE2D(tex, sampler##tex, uv)
+#else
+#define MTOON_DECLARE_TEX2D(tex) UNITY_DECLARE_TEX2D(tex)
+#define MTOON_DECLARE_TEX2D_FLOAT(tex) UNITY_DECLARE_TEX2D_FLOAT(tex);
+#define MTOON_SAMPLE_TEXTURE2D(tex, uv) UNITY_SAMPLE_TEX2D(tex, uv)
+#endif
+
+inline float3 MToon_TransformObjectToWorldNormal(float3 normalOS)
+{
+    #ifdef MTOON_URP
+    return TransformObjectToWorldNormal(normalOS);
+    #else
+    return UnityObjectToWorldNormal(normalOS);
+    #endif
+}
+
+inline float4 MToon_TransformWorldToHClip(float3 positionWS)
+{
+    #ifdef MTOON_URP
+    return TransformWorldToHClip(positionWS);
+    #else
+    return UnityWorldToClipPos(positionWS);
+    #endif
+}
+
+inline float4 MToon_TransformObjectToHClip(float3 positionOS)
+{
+    #ifdef MTOON_URP
+    return TransformObjectToHClip(positionOS);
+    #else
+    return UnityObjectToClipPos(positionOS);
+    #endif
+}
+
+inline float3 MToon_TransformViewToHClip(float3 positionVS)
+{
+    #ifdef MTOON_URP
+    return mul((float3x3)GetViewToHClipMatrix(), positionVS);
+    #else
+    return TransformViewToProjection(positionVS);
+    #endif
+}
+
+inline float3 MToon_UnpackNormalScale(float4 packedNormal, float bumpScale)
+{
+    #ifdef MTOON_URP
+    return UnpackNormalScale(packedNormal, bumpScale);
+    #else
+    return UnpackNormalWithScale(packedNormal, bumpScale);
+    #endif
+}
+
+inline float3 MToon_TransformObjectToWorldDir(float3 dirOS)
+{
+    #ifdef MTOON_URP
+    return TransformObjectToWorldDir(dirOS);
+    #else
+    return UnityObjectToWorldDir(dirOS);
+    #endif
+}
+
+#endif

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
@@ -59,12 +59,18 @@
 #define MTOON_SHADOW_COORD float4(0, 0, 0, 0)
 #endif
 
+#if defined(SHADOWS_SHADOWMASK) && defined(LIGHTMAP_ON)
+#define MTOON_SAMPLE_SHADOWMASK(uv) SAMPLE_TEXTURE2D_LIGHTMAP(SHADOWMASK_NAME, SHADOWMASK_SAMPLER_NAME, uv SHADOWMASK_SAMPLE_EXTRA_ARGS)
+#elif !defined (LIGHTMAP_ON)
+#define MTOON_SAMPLE_SHADOWMASK(uv) unity_ProbesOcclusion
+#else
+#define MTOON_SAMPLE_SHADOWMASK(uv) half4(1, 1, 1, 1)
+#endif
+
 #define MTOON_LIGHT_DESCRIPTION(input, atten, lightDir, lightColor) \
-    half4 shadowMask = SAMPLE_SHADOWMASK(input.lightmapUV); \
-    Light mainLight = GetMainLight(MTOON_SHADOW_COORD, input.positionWS, shadowMask); \
-    const half3 lightDir = mainLight.direction; \
-    const half3 lightColor = mainLight.color.rgb; \
-    const float atten = mainLight.shadowAttenuation;
+    const half3 lightDir = _MainLightPosition.xyz; \
+    const half3 lightColor = _MainLightColor.rgb; \
+    const float atten = MainLightShadow(MTOON_SHADOW_COORD, input.positionWS, MTOON_SAMPLE_SHADOWMASK(input.lightmapUV), _MainLightOcclusionProbes);
 
 #else
 

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
@@ -81,6 +81,28 @@
 
 #endif
 
+// Transfer fog and lighting
+#ifdef MTOON_URP
+
+#if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
+#define MTOON_TRANSFER_FOG_AND_LIGHTING(o, outpos, coord, vertex) \
+    OUTPUT_LIGHTMAP_UV(coord.xy, unity_LightmapST, output.lightmapUV); \
+    OUTPUT_SH(output.normalWS.xyz, output.vertexSH); \
+    output.fogFactorAndVertexLight = half4(ComputeFogFactor(outpos.z), VertexLighting(output.positionWS, output.normalWS)); \
+    output.shadowCoord = GetShadowCoord(GetVertexPositionInputs(vertex.xyz)); 
+#else
+#define MTOON_TRANSFER_FOG_AND_LIGHTING(o, outpos, coord, vertex) \
+    OUTPUT_LIGHTMAP_UV(coord.xy, unity_LightmapST, output.lightmapUV); \
+    OUTPUT_SH(output.normalWS.xyz, output.vertexSH); \
+    output.fogFactorAndVertexLight = half4(ComputeFogFactor(outpos.z), VertexLighting(output.positionWS, output.normalWS));
+#endif
+
+#else
+#define MTOON_TRANSFER_FOG_AND_LIGHTING(o, outpos, coord, vertex) \
+    UNITY_TRANSFER_FOG(o, outpos); \
+    UNITY_TRANSFER_LIGHTING(o, coord.xy);
+#endif
+
 // SampleSH
 inline half3 MToon_SampleSH(half3 normalWS)
 {

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
@@ -75,6 +75,16 @@
 
 #endif
 
+// SampleSH
+inline half3 MToon_SampleSH(half3 normalWS)
+{
+    #ifdef MTOON_URP
+    return SampleSH(normalWS);
+    #else
+    return ShadeSH9(half4(normalWS, 1));
+    #endif
+}
+
 // Transform
 inline float3 MToon_TransformObjectToWorldNormal(float3 normalOS)
 {

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
@@ -48,6 +48,33 @@
     UNITY_LIGHTING_COORDS(6,7)
 #endif
 
+// Light
+#ifdef MTOON_URP
+
+#if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
+#define MTOON_SHADOW_COORD input.shadowCoord
+#elif defined(MAIN_LIGHT_CALCULATE_SHADOWS)
+#define MTOON_SHADOW_COORD TransformWorldToShadowCoord(input.positionWS)
+#else
+#define MTOON_SHADOW_COORD float4(0, 0, 0, 0)
+#endif
+
+#define MTOON_LIGHT_DESCRIPTION(input, atten, lightDir, lightColor) \
+    half4 shadowMask = SAMPLE_SHADOWMASK(input.lightmapUV); \
+    Light mainLight = GetMainLight(MTOON_SHADOW_COORD, input.positionWS, shadowMask); \
+    const half3 lightDir = mainLight.direction; \
+    const half3 lightColor = mainLight.color.rgb; \
+    const float atten = mainLight.shadowAttenuation;
+
+#else
+
+#define MTOON_LIGHT_DESCRIPTION(input, atten, lightDir, lightColor) \
+    UNITY_LIGHT_ATTENUATION(atten, input, input.positionWS); \
+    const half3 lightDir = normalize(UnityWorldSpaceLightDir(input.positionWS)); \
+    const half3 lightColor = _LightColor0.rgb;
+
+#endif
+
 // Transform
 inline float3 MToon_TransformObjectToWorldNormal(float3 normalOS)
 {

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl
@@ -1,6 +1,7 @@
 ﻿#ifndef VRMC_MATERIALS_MTOON_RENDER_PIPELINE_INCLUDED
 #define VRMC_MATERIALS_MTOON_RENDER_PIPELINE_INCLUDED
 
+// Include
 #ifdef MTOON_URP
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
@@ -12,6 +13,7 @@
 #include <UnityShaderVariables.cginc>
 #endif
 
+// Texture
 #ifdef MTOON_URP
 #define MTOON_DECLARE_TEX2D(tex) TEXTURE2D_FLOAT(tex); SAMPLER(sampler##tex);
 #define MTOON_DECLARE_TEX2D_FLOAT(tex) TEXTURE2D(tex); SAMPLER(sampler##tex);
@@ -22,6 +24,31 @@
 #define MTOON_SAMPLE_TEXTURE2D(tex, uv) UNITY_SAMPLE_TEX2D(tex, uv)
 #endif
 
+// Fog and lighting
+#ifdef MTOON_URP
+
+#ifdef REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR
+
+#define MTOON_FOG_AND_LIGHTING_COORDS(idx1, idx2, idx3) \
+    half4 fogFactorAndVertexLight : TEXCOORD##idx1; \
+    float4 shadowCoord              : TEXCOORD##idx2; \
+    DECLARE_LIGHTMAP_OR_SH(lightmapUV, vertexSH, idx3);
+
+#else
+
+#define MTOON_FOG_AND_LIGHTING_COORDS(idx1, idx2, idx3) \
+    half4 fogFactorAndVertexLight : TEXCOORD##idx1; \
+    DECLARE_LIGHTMAP_OR_SH(lightmapUV, vertexSH, idx);
+
+#endif
+
+#else
+#define MTOON_FOG_AND_LIGHTING_COORDS(idx1, idx2, idx3) \
+    UNITY_FOG_COORDS(5) \
+    UNITY_LIGHTING_COORDS(6,7)
+#endif
+
+// Transform
 inline float3 MToon_TransformObjectToWorldNormal(float3 normalOS)
 {
     #ifdef MTOON_URP

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_render_pipeline.hlsl.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4c9e0c12587dbb5488a3e07dfc9430d3
+timeCreated: 1622632833

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_shadowcaster_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_shadowcaster_vertex.hlsl
@@ -18,7 +18,7 @@ VertexPositionInfo MToon_GetShadowCasterVertex(const float3 positionOS, const fl
 {
     VertexPositionInfo output;
     output.positionWS = mul(unity_ObjectToWorld, float4(positionOS, 1));
-    float4 positionCS = TransformWorldToHClip(ApplyShadowBias(output.positionWS, normalWS, _LightDirection));
+    float4 positionCS = TransformWorldToHClip(ApplyShadowBias(output.positionWS.xyz, normalWS, _LightDirection));
 
     #if UNITY_REVERSED_Z
     positionCS.z = min(positionCS.z, positionCS.w * UNITY_NEAR_CLIP_VALUE);


### PR DESCRIPTION
[vrmc_materials_mtoon_render_pipeline.hlsl](https://github.com/vrm-c/UniVRM/pull/2062/files#diff-2579bae94c095767625f2ec972533b8b0f264d615c2693323f06e0f390b70753) を切り出し、そこ以外の各種ロジックからURPに関する知識を隔離しました。

このPRでやらないこと
- AdditionalLightingのロジックの修正
    - これは対応コストの高さが予測されるため、後回しにする