### PR TITLE
springbone の import で throw しない

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -339,6 +339,7 @@ namespace UniGLTF
         {
             if (index < 0 || index >= Nodes.Count)
             {
+                Debug.LogWarning($"nodes[{index}] is not found !");
                 node = default;
                 return false;
             }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -335,6 +335,16 @@ namespace UniGLTF
         #region Imported
         protected GameObject Root;
         public List<Transform> Nodes = new List<Transform>();
+        public bool TryGetNode(int index, out Transform node)
+        {
+            if (index < 0 || index >= Nodes.Count)
+            {
+                node = default;
+                return false;
+            }
+            node = Nodes[index];
+            return true;
+        }
 
         public List<MeshWithMaterials> Meshes = new List<MeshWithMaterials>();
         #endregion

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -335,7 +335,7 @@ namespace UniGLTF
         #region Imported
         protected GameObject Root;
         public List<Transform> Nodes = new List<Transform>();
-        public bool TryGetNode(int index, out Transform node)
+        protected bool TryGetNode(int index, out Transform node)
         {
             if (index < 0 || index >= Nodes.Count)
             {

--- a/Assets/VRM/Editor/SpringBone/VRMSpringBoneUtilityEditor.cs
+++ b/Assets/VRM/Editor/SpringBone/VRMSpringBoneUtilityEditor.cs
@@ -93,10 +93,17 @@ namespace VRM
             var root = go.transform;
             var nodes = root.Traverse().Skip(1).ToList();
 
-            VRMSpringUtility.LoadSecondary(root, nodes, spring);
+            VRMSpringUtility.LoadSecondary(root, (int index, out Transform node) =>
+            {
+                if (index < 0 || index >= nodes.Count)
+                {
+                    node = default;
+                    return false;
+                }
+                node = nodes[index];
+                return true;
+            }, spring);
         }
-
         #endregion
-
     }
 }

--- a/Assets/VRM/Editor/SpringBone/VRMSpringBoneUtilityEditor.cs
+++ b/Assets/VRM/Editor/SpringBone/VRMSpringBoneUtilityEditor.cs
@@ -97,6 +97,7 @@ namespace VRM
             {
                 if (index < 0 || index >= nodes.Count)
                 {
+                    Debug.LogWarning($"nodes[{index}] is not found !");
                     node = default;
                     return false;
                 }

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -59,7 +59,7 @@ namespace VRM
 
             using (MeasureTime("VRM LoadSecondary"))
             {
-                VRMSpringUtility.LoadSecondary(Root.transform, Nodes,
+                VRMSpringUtility.LoadSecondary(Root.transform, TryGetNode,
                 VRM.secondaryAnimation);
             }
             await awaitCaller.NextFrame();

--- a/Assets/VRM/Runtime/SpringBone/VRMSpringUtility.cs
+++ b/Assets/VRM/Runtime/SpringBone/VRMSpringUtility.cs
@@ -62,7 +62,12 @@ namespace VRM
             }
         }
 
-        public static void LoadSecondary(Transform root, List<Transform> nodes,
+        /// <summary>
+        /// Node getter. If not found, Never throw, return false.
+        /// </summary>
+        public delegate bool TryGetNode(int index, out Transform transform);
+
+        public static void LoadSecondary(Transform root, TryGetNode tryGetNode,
             glTF_VRM_SecondaryAnimation secondaryAnimation)
         {
             var secondary = root.Find("secondary");
@@ -108,20 +113,27 @@ namespace VRM
                 }
             }
 
-            //var secondaryAnimation = context.VRM.extensions.VRM.secondaryAnimation;
             var colliders = new List<VRMSpringBoneColliderGroup>();
             foreach (var colliderGroup in secondaryAnimation.colliderGroups)
             {
-                var vrmGroup = nodes[colliderGroup.node].gameObject.AddComponent<VRMSpringBoneColliderGroup>();
-                vrmGroup.Colliders = colliderGroup.colliders.Select(x =>
+                if (tryGetNode(colliderGroup.node, out var node))
                 {
-                    return new VRMSpringBoneColliderGroup.SphereCollider
+                    var vrmGroup = node.gameObject.AddComponent<VRMSpringBoneColliderGroup>();
+                    vrmGroup.Colliders = colliderGroup.colliders.Select(x =>
                     {
-                        Offset = x.offset,
-                        Radius = x.radius
-                    };
-                }).ToArray();
-                colliders.Add(vrmGroup);
+                        return new VRMSpringBoneColliderGroup.SphereCollider
+                        {
+                            Offset = x.offset,
+                            Radius = x.radius
+                        };
+                    }).ToArray();
+                    colliders.Add(vrmGroup);
+                }
+                else
+                {
+                    Debug.LogError("Broken collider group");
+                    break;
+                }
             }
 
             if (secondaryAnimation.boneGroups.Count > 0)
@@ -129,9 +141,9 @@ namespace VRM
                 foreach (var boneGroup in secondaryAnimation.boneGroups)
                 {
                     var vrmBoneGroup = secondary.gameObject.AddComponent<VRMSpringBone>();
-                    if (boneGroup.center != -1)
+                    if (tryGetNode(boneGroup.center, out var node))
                     {
-                        vrmBoneGroup.m_center = nodes[boneGroup.center];
+                        vrmBoneGroup.m_center = node;
                     }
 
                     vrmBoneGroup.m_comment = boneGroup.comment;
@@ -147,14 +159,20 @@ namespace VRM
                         for (int i = 0; i < boneGroup.colliderGroups.Length; ++i)
                         {
                             var colliderGroup = boneGroup.colliderGroups[i];
-                            vrmBoneGroup.ColliderGroups[i] = colliders[colliderGroup];
+                            if (colliderGroup >= 0 && colliderGroup < colliders.Count)
+                            {
+                                vrmBoneGroup.ColliderGroups[i] = colliders[colliderGroup];
+                            }
                         }
                     }
 
                     var boneList = new List<Transform>();
                     foreach (var x in boneGroup.bones)
                     {
-                        boneList.Add(nodes[x]);
+                        if (tryGetNode(x, out var boneNode))
+                        {
+                            boneList.Add(boneNode);
+                        }
                     }
 
                     vrmBoneGroup.RootBones = boneList;

--- a/Assets/VRM/Runtime/SpringBone/VRMSpringUtility.cs
+++ b/Assets/VRM/Runtime/SpringBone/VRMSpringUtility.cs
@@ -21,13 +21,17 @@ namespace VRM
                 .Select(x => x.GetComponent<VRMSpringBoneColliderGroup>())
                 .Where(x => x != null))
             {
-                colliders.Add(vrmColliderGroup);
+                var index = nodes.IndexOf(vrmColliderGroup.transform);
+                if (index == -1)
+                {
+                    continue;
+                }
 
+                colliders.Add(vrmColliderGroup);
                 var colliderGroup = new glTF_VRM_SecondaryAnimationColliderGroup
                 {
-                    node = nodes.IndexOf(vrmColliderGroup.transform)
+                    node = index
                 };
-
                 colliderGroup.colliders = vrmColliderGroup.Colliders.Select(x =>
                 {
                     return new glTF_VRM_SecondaryAnimationCollider


### PR DESCRIPTION
fixed #2023

index の範囲違反を含む SpringBone を import したときに throw しない。
SpringBone の import は中途半端な状態になるが、VRM 全体としてはロードできるようになる。

export 時の index -1 チェックをひとつ追加。