### PR TITLE
Unity 2022.2以降のScriptedImporterEditor.ResetValues()のObsolete警告が出るのに対応

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/RemapScriptedImporterEditorBase.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/RemapScriptedImporterEditorBase.cs
@@ -44,9 +44,24 @@ namespace UniGLTF
             m_editMap.AddRange(value.Select(kv => new RemapEditorBase.SubAssetPair(kv.Key, kv.Value)));
         }
 
+#if UNITY_2022_2_OR_NEWER
         /// <summary>
         /// Revert
         /// </summary>
+        public override void DiscardChanges()
+        {
+            m_editMap.Clear();
+
+            base.DiscardChanges();
+        }
+#endif
+
+        /// <summary>
+        /// Revert
+        /// </summary>
+#if UNITY_2022_2_OR_NEWER
+        [System.Obsolete]
+#endif
         protected override void ResetValues()
         {
             m_editMap.Clear();


### PR DESCRIPTION
Unity 2022.2以降のバージョンでScriptedImporterEditor.ResetValues()がObsoleteになり、代わりにDiscardChanges()の利用が推奨されるようになりました。 UniGLTF.RemapScriptedImporterEditorBaseがResetValues()を利用しており、それにより、次のような警告を発生させていました。

```
Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/RemapScriptedImporterEditorBase.cs(50,33): warning CS0672: Member 'RemapScriptedImporterEditorBase.ResetValues()' overrides obsolete member 'AssetImporterEditor.ResetValues()'. Add the Obsolete attribute to 'RemapScriptedImporterEditorBase.ResetValues()'.
Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/RemapScriptedImporterEditorBase.cs(54,13): warning CS0618: 'AssetImporterEditor.ResetValues()' is obsolete: 'UnityUpgradeable () -> DiscardChanges'
```

オーバーライドされたResetValuesにもObsoleteを付与することで、警告が抑制されるようになりました。

また、移行先として推奨されているDiscardChanges()の実装も行いました。