### PR TITLE
MToon10のURP向けシェーダの不具合やパス不備の修正

### DIFF
--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthnormals_fragment.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthnormals_fragment.hlsl
@@ -1,0 +1,38 @@
+#ifndef VRMC_MATERIALS_MTOON_DEPTHNORMALS_FRAGMENT_INCLUDED
+#define VRMC_MATERIALS_MTOON_DEPTHNORMALS_FRAGMENT_INCLUDED
+
+#ifdef MTOON_URP
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+#include "./vrmc_materials_mtoon_define.hlsl"
+#include "./vrmc_materials_mtoon_utility.hlsl"
+#include "./vrmc_materials_mtoon_input.hlsl"
+#include "./vrmc_materials_mtoon_attribute.hlsl"
+#include "./vrmc_materials_mtoon_geometry_uv.hlsl"
+#include "./vrmc_materials_mtoon_geometry_alpha.hlsl"
+#include "./vrmc_materials_mtoon_geometry_normal.hlsl"
+#include "./vrmc_materials_mtoon_lighting_unity.hlsl"
+#include "./vrmc_materials_mtoon_lighting_mtoon.hlsl"
+
+half4 MToonDepthNormalsFragment(const FragmentInput fragmentInput) : SV_Target
+{
+    const Varyings input = fragmentInput.varyings;
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+    // Get MToon UV (with UVAnimation)
+    const float2 uv = GetMToonGeometry_Uv(input.uv);
+
+    // Get LitColor with Alpha
+    const half4 litColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, uv) * _Color;
+    GetMToonGeometry_Alpha(litColor);
+
+    // Get Normal
+    float3 normalWS = GetMToonGeometry_Normal(input, fragmentInput.facing, uv);
+    normalWS = NormalizeNormalPerPixel(normalWS);
+
+    return half4(normalWS, 0.0);
+}
+
+#endif
+
+#endif

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthnormals_fragment.hlsl.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthnormals_fragment.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 93f88dc204e783a4aaabfc17a087bce8
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthnormals_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthnormals_vertex.hlsl
@@ -1,0 +1,43 @@
+#ifndef VRMC_MATERIALS_MTOON_DEPTHNORMALS_VERTEX_INCLUDED
+#define VRMC_MATERIALS_MTOON_DEPTHNORMALS_VERTEX_INCLUDED
+
+#ifdef MTOON_URP
+
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+#include "./vrmc_materials_mtoon_define.hlsl"
+#include "./vrmc_materials_mtoon_utility.hlsl"
+#include "./vrmc_materials_mtoon_input.hlsl"
+#include "./vrmc_materials_mtoon_attribute.hlsl"
+#include "./vrmc_materials_mtoon_geometry_vertex.hlsl"
+
+Varyings MToonDepthNormalsVertex(const Attributes v)
+{
+    Varyings output = (Varyings)0;
+
+    UNITY_SETUP_INSTANCE_ID(v);
+    UNITY_TRANSFER_INSTANCE_ID(v, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+#if defined(_NORMALMAP)
+    VertexNormalInputs normalInput = GetVertexNormalInputs(v.normalOS, v.tangentOS);
+    float3 normalWS = normalInput.normalWS;
+    float sign = v.tangentOS.w * float(GetOddNegativeScale());
+    half4 tangentWS = half4(normalInput.tangentWS.xyz, sign);
+#else
+    float3 normalWS = TransformObjectToWorldNormal(v.normalOS);
+#endif
+
+    output.pos = TransformObjectToHClip(v.vertex.xyz);
+    output.normalWS = normalWS;
+#if defined(_NORMALMAP)
+    output.tangentWS = tangentWS;
+#endif
+    output.uv = v.texcoord0;
+
+    return output;
+}
+
+#endif
+
+#endif

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthnormals_vertex.hlsl.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthnormals_vertex.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b69080781a3778e499a6ae99adb82053
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthonly_fragment.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthonly_fragment.hlsl
@@ -1,0 +1,34 @@
+#ifndef VRMC_MATERIALS_MTOON_DEPTHONLY_FRAGMENT_INCLUDED
+#define VRMC_MATERIALS_MTOON_DEPTHONLY_FRAGMENT_INCLUDED
+
+#ifdef MTOON_URP
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+#include "./vrmc_materials_mtoon_define.hlsl"
+#include "./vrmc_materials_mtoon_utility.hlsl"
+#include "./vrmc_materials_mtoon_input.hlsl"
+#include "./vrmc_materials_mtoon_attribute.hlsl"
+#include "./vrmc_materials_mtoon_geometry_uv.hlsl"
+#include "./vrmc_materials_mtoon_geometry_alpha.hlsl"
+#include "./vrmc_materials_mtoon_geometry_normal.hlsl"
+#include "./vrmc_materials_mtoon_lighting_unity.hlsl"
+#include "./vrmc_materials_mtoon_lighting_mtoon.hlsl"
+
+half4 MToonDepthOnlyFragment(const FragmentInput fragmentInput) : SV_Target
+{
+    const Varyings input = fragmentInput.varyings;
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+    // Get MToon UV (with UVAnimation)
+    const float2 uv = GetMToonGeometry_Uv(input.uv);
+
+    // Get LitColor with Alpha
+    const half4 litColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, uv) * _Color;
+    GetMToonGeometry_Alpha(litColor);
+
+    return 0;
+}
+
+#endif
+
+#endif

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthonly_fragment.hlsl.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthonly_fragment.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 68d7d7ebb0ec69440b052da859a20d74
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthonly_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthonly_vertex.hlsl
@@ -1,0 +1,30 @@
+#ifndef VRMC_MATERIALS_MTOON_DEPTHONLY_VERTEX_INCLUDED
+#define VRMC_MATERIALS_MTOON_DEPTHONLY_VERTEX_INCLUDED
+
+#ifdef MTOON_URP
+
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+#include "./vrmc_materials_mtoon_define.hlsl"
+#include "./vrmc_materials_mtoon_utility.hlsl"
+#include "./vrmc_materials_mtoon_input.hlsl"
+#include "./vrmc_materials_mtoon_attribute.hlsl"
+#include "./vrmc_materials_mtoon_geometry_vertex.hlsl"
+
+Varyings MToonDepthOnlyVertex(const Attributes v)
+{
+    Varyings output = (Varyings)0;
+
+    UNITY_SETUP_INSTANCE_ID(v);
+    UNITY_TRANSFER_INSTANCE_ID(v, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+    output.pos = TransformObjectToHClip(v.vertex.xyz);
+    output.uv = v.texcoord0;
+
+    return output;
+}
+
+#endif
+
+#endif

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthonly_vertex.hlsl.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_depthonly_vertex.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 6957b39e3ab2cbc43aa0de76d9b4a411
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_shadowcaster_vertex.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_shadowcaster_vertex.hlsl
@@ -41,10 +41,9 @@ Varyings MToonShadowCasterVertex(const Attributes v)
 
     float3 normalWS = TransformObjectToWorldNormal(v.normalOS);
     const VertexPositionInfo position = MToon_GetShadowCasterVertex(v.vertex.xyz, normalWS);
+
     output.pos = position.positionCS;
-    output.positionWS = position.positionWS.xyz;
-    output.normalWS = TransformObjectToWorldNormal(normalWS);
-    output.viewDirWS = MToon_GetWorldSpaceNormalizedViewDir(output.positionWS);
+    output.uv = v.texcoord0;
 
     return output;
 }

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_urp.shader
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_urp.shader
@@ -161,7 +161,63 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
             ENDHLSL
         }
 
-        //  Shadow Caster Path
+        //  Depth Only Pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags { "LightMode" = "DepthOnly" }
+
+            Cull [_M_CullMode]
+            ZWrite On
+            ColorMask 0
+
+            HLSLPROGRAM
+            #pragma target 3.0
+
+            // Unity defined keywords
+            #pragma multi_compile_instancing
+
+            #pragma multi_compile __ _ALPHATEST_ON _ALPHABLEND_ON
+
+            #pragma vertex MToonDepthOnlyVertex
+            #pragma fragment MToonDepthOnlyFragment
+
+            #define MTOON_URP
+            
+            #include "./vrmc_materials_mtoon_depthonly_vertex.hlsl"
+            #include "./vrmc_materials_mtoon_depthonly_fragment.hlsl"
+            ENDHLSL
+        }
+
+        //  Depth Normals Pass
+        Pass
+        {
+            Name "DepthNormals"
+            Tags { "LightMode" = "DepthNormals" }
+
+            Cull [_M_CullMode]
+            ZWrite On
+
+            HLSLPROGRAM
+            #pragma target 3.0
+
+            // Unity defined keywords
+            #pragma multi_compile_instancing
+
+            #pragma multi_compile __ _ALPHATEST_ON _ALPHABLEND_ON
+            #pragma multi_compile __ _NORMALMAP
+
+            #pragma vertex MToonDepthNormalsVertex
+            #pragma fragment MToonDepthNormalsFragment
+
+            #define MTOON_URP
+            
+            #include "./vrmc_materials_mtoon_depthnormals_vertex.hlsl"
+            #include "./vrmc_materials_mtoon_depthnormals_fragment.hlsl"
+            ENDHLSL
+        }
+
+        //  Shadow Caster Pass
         Pass
         {
             Name "ShadowCaster"

--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_urp.shader
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_urp.shader
@@ -75,7 +75,7 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
             "IgnoreProjector" = "True"
         }
 
-        // Built-in Forward Base Pass
+        // Universal Forward Pass
         Pass
         {
             Name "UniversalForward"
@@ -92,7 +92,6 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
             #pragma target 3.0
 
             // Unity defined keywords
-            #pragma multi_compile_fwdbase nolightmap nodynlightmap nodirlightmap novertexlight
             #pragma multi_compile_fog
             #pragma multi_compile_instancing
 
@@ -123,7 +122,7 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
             ENDHLSL
         }
 
-        // Built-in Forward Base Pass
+        // MToon Outline Pass
         Pass
         {
             Name "MToonOutline"
@@ -141,7 +140,6 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
             #pragma target 3.0
 
             // Unity defined keywords
-            #pragma multi_compile_fwdbase nolightmap nodynlightmap nodirlightmap novertexlight
             #pragma multi_compile_fog
             #pragma multi_compile_instancing
 
@@ -163,7 +161,7 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
             ENDHLSL
         }
 
-        //  Shadow rendering pass
+        //  Shadow Caster Path
         Pass
         {
             Name "ShadowCaster"
@@ -177,7 +175,6 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
             #pragma target 3.0
 
             // Unity defined keywords
-            #pragma multi_compile_shadowcaster nolightmap nodynlightmap nodirlightmap novertexlight
             #pragma multi_compile_instancing
 
             #pragma multi_compile __ _ALPHATEST_ON _ALPHABLEND_ON


### PR DESCRIPTION
MToon10のURP向けシェーダに不具合、Passの不備があったため以下の修正を行いました。
ご確認の程よろしくお願いいたします。

* ShadowCasterの不具合修正

Cutoutモデルのキャストシャドーが正常に行われていない不具合を修正しました。
これは、AlphaClipを行うべきUV座標が正しくFragmentシェーダに渡されていなかったため発生していました。

* 不要なBuilt-inキーワードの削除

URPシェーダにおいて必要のないBuilt-in専用のキーワード群を削除しました。
以下はBuilt-inシェーダ専用なので不要です。
`#pragma multi_compile_fwdbase nolightmap nodynlightmap nodirlightmap novertexlight`

* DepthOnlyPass、DepthNormalsPassの追加

DepthOnlyとDepthNormalsパスを追加しました。
_CameraDepthTextureや_CameraNormalsTextureを使うポストプロセスには上記のパスはほぼ必須であり、また、DepthPrepassが使われるプロジェクトはDepthOnlyもしくはDepthNormalsパスがPrepassとして使われるため、URPにおいてはこれらが存在しないと様々なポストプロセス表現や正常な深度テストが行えない場合があります。