### PR TITLE
Auto detect render pipelines

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineMaterialDescriptorUtility.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineMaterialDescriptorUtility.cs
@@ -9,24 +9,17 @@ public class RenderPipelineMaterialDescriptorGeneratorUtility
 
         if (currentPipeline == null)
         {
-            return RenderPipelineTypes.Unknown;
+            return RenderPipelineTypes.BuiltinRenderPipeline;
         }
-        else if (currentPipeline.GetType().Name.Contains("HDRenderPipeline"))
+        if (currentPipeline.GetType().Name.Contains("HDRenderPipeline"))
         {
             return RenderPipelineTypes.HighDefinitionRenderPipeline;
         }
-        else if (currentPipeline.GetType().Name.Contains("UniversalRenderPipeline"))
+        if (currentPipeline.GetType().Name.Contains("UniversalRenderPipeline"))
         {
             return RenderPipelineTypes.UniversalRenderPipeline;
         }
-        else if (currentPipeline.GetType().Name.Contains("RenderPipeline"))
-        {
-            return RenderPipelineTypes.BuiltinRenderPipeline;
-        }
-        else
-        {
-            return RenderPipelineTypes.Unknown;
-        }
+        return RenderPipelineTypes.Unknown;
     }
     
     public static IMaterialDescriptorGenerator GetValidGLTFMaterialDescriptorGenerator()

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineMaterialDescriptorUtility.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineMaterialDescriptorUtility.cs
@@ -1,0 +1,45 @@
+using UniGLTF;
+using UnityEngine.Rendering;
+
+public class RenderPipelineMaterialDescriptorGeneratorUtility
+{
+    protected static RenderPipelineTypes GetRenderPipelineType()
+    {
+        RenderPipeline currentPipeline = RenderPipelineManager.currentPipeline;
+
+        if (currentPipeline == null)
+        {
+            return RenderPipelineTypes.Unknown;
+        }
+        else if (currentPipeline.GetType().Name.Contains("HDRenderPipeline"))
+        {
+            return RenderPipelineTypes.HighDefinitionRenderPipeline;
+        }
+        else if (currentPipeline.GetType().Name.Contains("UniversalRenderPipeline"))
+        {
+            return RenderPipelineTypes.UniversalRenderPipeline;
+        }
+        else if (currentPipeline.GetType().Name.Contains("RenderPipeline"))
+        {
+            return RenderPipelineTypes.BuiltinRenderPipeline;
+        }
+        else
+        {
+            return RenderPipelineTypes.Unknown;
+        }
+    }
+    
+    public static IMaterialDescriptorGenerator GetValidGLTFMaterialDescriptorGenerator()
+    {
+        switch (GetRenderPipelineType())
+        {
+            case RenderPipelineTypes.UniversalRenderPipeline:
+                return new UrpGltfMaterialDescriptorGenerator();
+            case RenderPipelineTypes.BuiltinRenderPipeline:
+                return new BuiltInGltfMaterialDescriptorGenerator();
+        }
+
+        return null;
+    }
+}
+

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineMaterialDescriptorUtility.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineMaterialDescriptorUtility.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2a7306f577654254b1fda4dedc322f87
+timeCreated: 1690283093

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineTypes.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineTypes.cs
@@ -8,5 +8,7 @@ namespace UniGLTF
     {
         BuiltinRenderPipeline,
         UniversalRenderPipeline,
+        HighDefinitionRenderPipeline,
+        Unknown
     }
 }

--- a/Assets/VRM/Runtime/IO/MaterialIO/VRMRenderPipelineMaterialDescriptorGeneratorUtility.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/VRMRenderPipelineMaterialDescriptorGeneratorUtility.cs
@@ -1,0 +1,21 @@
+using UniGLTF;
+using VRM;
+
+namespace UniVRM
+{
+    public class VrmRenderPipelineMaterialDescriptorGeneratorDescriptorUtility : RenderPipelineMaterialDescriptorGeneratorUtility
+    {
+        public static IMaterialDescriptorGenerator GetValidVrm10MaterialDescriptorGenerator(glTF_VRM_extensions vrm)
+        {
+            switch (GetRenderPipelineType())
+            {
+                case RenderPipelineTypes.UniversalRenderPipeline:
+                    return new UrpVrmMaterialDescriptorGenerator(vrm);
+                case RenderPipelineTypes.BuiltinRenderPipeline:
+                    return new BuiltInVrmMaterialDescriptorGenerator(vrm);
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/VRM/Runtime/IO/MaterialIO/VRMRenderPipelineMaterialDescriptorGeneratorUtility.cs.meta
+++ b/Assets/VRM/Runtime/IO/MaterialIO/VRMRenderPipelineMaterialDescriptorGeneratorUtility.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 11d340619a8149cea3dd74a933dc16cc
+timeCreated: 1690283540

--- a/Assets/VRM10/Runtime/IO/Material/URP/Import/VRM10RenderPipelineMaterialDescriptorGeneratorUtility.cs
+++ b/Assets/VRM10/Runtime/IO/Material/URP/Import/VRM10RenderPipelineMaterialDescriptorGeneratorUtility.cs
@@ -1,0 +1,20 @@
+using UniGLTF;
+
+namespace UniVRM10
+{
+    public class Vrm10RenderPipelineMaterialDescriptorGeneratorDescriptorUtility : RenderPipelineMaterialDescriptorGeneratorUtility
+    {
+        public static IMaterialDescriptorGenerator GetValidVrm10MaterialDescriptorGenerator()
+        {
+            switch (GetRenderPipelineType())
+            {
+                case RenderPipelineTypes.UniversalRenderPipeline:
+                    return new UrpVrm10MaterialDescriptorGenerator();
+                case RenderPipelineTypes.BuiltinRenderPipeline:
+                    return new BuiltInVrm10MaterialDescriptorGenerator();
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/VRM10/Runtime/IO/Material/URP/Import/VRM10RenderPipelineMaterialDescriptorGeneratorUtility.cs.meta
+++ b/Assets/VRM10/Runtime/IO/Material/URP/Import/VRM10RenderPipelineMaterialDescriptorGeneratorUtility.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3e8bcf27c69d4fd39e97375f9627ed68
+timeCreated: 1690283374

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -43,7 +43,7 @@ namespace UniVRM10
             m_useControlRig = useControlRig;
 
             TextureDescriptorGenerator = new Vrm10TextureDescriptorGenerator(Data);
-            MaterialDescriptorGenerator = materialGenerator ?? new BuiltInVrm10MaterialDescriptorGenerator();
+            MaterialDescriptorGenerator = materialGenerator ?? Vrm10RenderPipelineMaterialDescriptorGeneratorDescriptorUtility.GetValidVrm10MaterialDescriptorGenerator();
 
             m_externalMap = externalObjectMap;
             if (m_externalMap == null)

--- a/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
+++ b/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
@@ -387,6 +387,7 @@ namespace VRM.SimpleViewer
 
         static IMaterialDescriptorGenerator GetGltfMaterialGenerator(bool useUrp)
         {
+            //Could be refactored to no longer need this check using RenderPipelineMaterialDescriptorGeneratorUtility
             if (useUrp)
             {
                 return new UrpGltfMaterialDescriptorGenerator();
@@ -399,6 +400,7 @@ namespace VRM.SimpleViewer
 
         static IMaterialDescriptorGenerator GetVrmMaterialGenerator(bool useUrp, VRM.glTF_VRM_extensions vrm)
         {
+            //Could be refactored to no longer need this check using VrmRenderPipelineMaterialDescriptorGeneratorDescriptorUtility
             if (useUrp)
             {
                 return new VRM.UrpVrmMaterialDescriptorGenerator(vrm);


### PR DESCRIPTION
This PR adds code to automatically detect the render pipeline and adds utility functions that returns the correct `IMaterialDescriptorGenerator` based on the current pipeline.

It also implements a use case in the  Vrm10Importer that means that in a URP project at runtime a VRM10 is loaded in using the correct materials.