### PR TITLE
Speed up ExpressionKey's comparison.

### DIFF
--- a/Assets/VRM10/Runtime/Components/Expression/ExpressionKey.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/ExpressionKey.cs
@@ -194,15 +194,10 @@ namespace UniVRM10
             }
         }
 
-        public static EqualityComparer Comparer { get; } = new();
+        public static IEqualityComparer<ExpressionKey> Comparer { get; } = new EqualityComparer();
 
-        public sealed class EqualityComparer : IEqualityComparer<ExpressionKey>
+        internal sealed class EqualityComparer : IEqualityComparer<ExpressionKey>
         {
-            internal EqualityComparer()
-            {
-
-            }
-
             public bool Equals(ExpressionKey x, ExpressionKey y)
             {
                 return x.Equals(y);

--- a/Assets/VRM10/Runtime/Components/Expression/ExpressionMerger.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/ExpressionMerger.cs
@@ -28,10 +28,12 @@ namespace UniVRM10
 
         public ExpressionMerger(VRM10ObjectExpression expressions, Transform root)
         {
-            m_clipMap = expressions.Clips.ToDictionary(x => expressions.CreateKey(x.Clip), x => x.Clip);
-
-            m_valueMap = new Dictionary<ExpressionKey, float>();
-
+            m_clipMap = expressions.Clips.ToDictionary(
+                x => expressions.CreateKey(x.Clip),
+                x => x.Clip,
+                ExpressionKey.Comparer
+            );
+            m_valueMap = new Dictionary<ExpressionKey, float>(ExpressionKey.Comparer);
             m_morphTargetBindingMerger = new MorphTargetBindingMerger(m_clipMap, root);
             m_materialValueBindingMerger = new MaterialValueBindingMerger(m_clipMap, root);
         }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeExpression.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeExpression.cs
@@ -31,15 +31,25 @@ namespace UniVRM10
             Restore();
 
             _merger = new ExpressionMerger(target.Vrm.Expression, target.transform);
-            _keys = target.Vrm.Expression.Clips.Select(x => target.Vrm.Expression.CreateKey(x.Clip)).ToList();
+            _keys = target.Vrm.Expression.Clips
+                .Select(x => target.Vrm.Expression.CreateKey(x.Clip))
+                .ToList();
             var oldInputWeights = _inputWeights;
-            _inputWeights = _keys.ToDictionary(x => x, x => 0f);
+            _inputWeights = _keys.ToDictionary(
+                x => x,
+                x => 0f,
+                ExpressionKey.Comparer
+            );
             foreach (var key in _keys)
             {
                 // remain user input weights.
                 if (oldInputWeights.ContainsKey(key)) _inputWeights[key] = oldInputWeights[key];
             }
-            _actualWeights = _keys.ToDictionary(x => x, x => 0f);
+            _actualWeights = _keys.ToDictionary(
+                x => x,
+                x => 0f,
+                ExpressionKey.Comparer
+            );
             _validator = ExpressionValidatorFactory.Create(target.Vrm.Expression);
             _eyeDirectionProvider = eyeDirectionProvider;
             _eyeDirectionApplicable = eyeDirectionApplicable;

--- a/Assets/VRM10/Tests/ExpressionKeyTests.cs
+++ b/Assets/VRM10/Tests/ExpressionKeyTests.cs
@@ -9,8 +9,7 @@ namespace UniVRM10.Test
         {
             Assert.Catch(() => ExpressionKey.CreateCustom(""));
             Assert.Catch(() => ExpressionKey.CreateCustom(null));
-
-            ExpressionKey.CreateCustom("a");
+            Assert.Catch(() => ExpressionKey.CreateFromPreset(ExpressionPreset.custom));
         }
 
         [Test]

--- a/Assets/VRM10/Tests/ExpressionKeyTests.cs
+++ b/Assets/VRM10/Tests/ExpressionKeyTests.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+
+namespace UniVRM10.Test
+{
+    public sealed class ExpressionKeyTests
+    {
+        [Test]
+        public void InvalidExpressionKey()
+        {
+            Assert.Catch(() => ExpressionKey.CreateCustom(""));
+            Assert.Catch(() => ExpressionKey.CreateCustom(null));
+
+            ExpressionKey.CreateCustom("a");
+        }
+
+        [Test]
+        public void ExpressionKeyEquality()
+        {
+            var happy = ExpressionKey.CreateFromPreset(ExpressionPreset.happy);
+            Assert.AreEqual(happy, ExpressionKey.CreateFromPreset(ExpressionPreset.happy));
+            Assert.AreNotEqual(happy, ExpressionKey.CreateFromPreset(ExpressionPreset.sad));
+            Assert.AreNotEqual(happy, ExpressionKey.CreateFromPreset(ExpressionPreset.aa));
+            Assert.AreNotEqual(happy, ExpressionKey.CreateCustom("happy"));
+            Assert.AreNotEqual(happy, ExpressionKey.CreateCustom("my_custom"));
+
+            var custom = ExpressionKey.CreateCustom("my_custom");
+            Assert.AreEqual(custom, ExpressionKey.CreateCustom("my_custom"));
+            Assert.AreNotEqual(custom, ExpressionKey.CreateCustom("my_custom_2"));
+            Assert.AreNotEqual(custom, ExpressionKey.CreateFromPreset(ExpressionPreset.happy));
+        }
+
+        [Test]
+        public void ExpressionKeyName()
+        {
+            var happy = ExpressionKey.CreateFromPreset(ExpressionPreset.happy);
+            Assert.AreEqual("happy", happy.Name);
+
+            var custom = ExpressionKey.CreateCustom("my_custom");
+            Assert.AreEqual("my_custom", custom.Name);
+        }
+    }
+}

--- a/Assets/VRM10/Tests/ExpressionKeyTests.cs.meta
+++ b/Assets/VRM10/Tests/ExpressionKeyTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 370f4995d6964d059eb63ee5f9c97439
+timeCreated: 1692083961


### PR DESCRIPTION
毎フレーム呼び出される `Vrm10RuntimeExpression` 中の処理で `ExpressionKey` の Dictionary Key としての比較処理がそこそこ負荷が高い。

これを public な挙動を変更せずに改善する。

13 % くらいは高速化した、かも。