### PR TITLE
Add `ReplaceResource` Method to `RuntimeGltfInstance`

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs
@@ -166,6 +166,61 @@ namespace UniGLTF
             }
         }
 
+        public void ReplaceResource(UnityEngine.Object oldResource, UnityEngine.Object newResource)
+        {
+            if (oldResource == null || newResource == null || oldResource.GetType() != newResource.GetType())
+            {
+                Debug.LogError($"{nameof(RuntimeGltfInstance)} - Could not replace resource: mismatched or null types.");
+                return;
+            }
+            
+            for (int i = 0; i < _resources.Count; i++)
+            {
+                if (_resources[i].Item2 == oldResource)
+                {
+                    _resources[i] = (_resources[i].Item1, newResource);
+                    break;
+                }
+            }
+
+            switch (oldResource)
+            {
+                case Texture oldTexture when newResource is Texture newTexture:
+                    int texIndex = _textures.IndexOf(oldTexture);
+                    if (texIndex != -1)
+                    {
+                        _textures[texIndex] = newTexture;
+                    }
+                    break;
+
+                case Material oldMaterial when newResource is Material newMaterial:
+                    int matIndex = _materials.IndexOf(oldMaterial);
+                    if (matIndex != -1)
+                    {
+                        _materials[matIndex] = newMaterial;
+                    }
+                    break;
+
+                case AnimationClip oldClip when newResource is AnimationClip newClip:
+                    int clipIndex = _animationClips.IndexOf(oldClip);
+                    if (clipIndex != -1)
+                    {
+                        _animationClips[clipIndex] = newClip;
+                    }
+                    break;
+
+                case Mesh oldMesh when newResource is Mesh newMesh:
+                    int meshIndex = _meshes.IndexOf(oldMesh);
+                    if (meshIndex != -1)
+                    {
+                        _meshes[meshIndex] = newMesh;
+                    }
+                    break;
+            }
+
+            Destroy(oldResource);
+        }
+
         void OnDestroy()
         {
             Debug.Log("UnityResourceDestroyer.OnDestroy");


### PR DESCRIPTION
This PR introduces the `ReplaceResource` method to the `RuntimeGltfInstance` class. This enables resource replacement of Textures, Materials, AnimationClips, and Meshes. The old resource is destroyed after replacement.

In our project we integrated UniVRM for handling VRM imports. In a recent optimization effort we encountered the need to downscale the textures of imported VRMs during runtime. However we ran into issues regarding UniGLTF as the `RuntimeGltfInstance` class stores textures and other resources in a readonly list with no way to modify the contents from an external class. The `ReplaceResource` method is our solution to this limitation. By introducing this method, we can effectively modify and replace resources in the readonly list, ensuring efficient memory in our project.