### PR TITLE
メッシュ名が.から始まってたり空だとimport時に失敗する?

### DIFF
--- a/Assets/UniGLTF/Runtime/Extensions/StringExtensions.cs
+++ b/Assets/UniGLTF/Runtime/Extensions/StringExtensions.cs
@@ -74,6 +74,9 @@ namespace UniGLTF
             if (path.StartsWith('.'))
                 path = '+' + path;
 
+            if (path == "")
+                path = "(empty)";
+
             return path;
         }
 

--- a/Assets/UniGLTF/Runtime/Extensions/StringExtensions.cs
+++ b/Assets/UniGLTF/Runtime/Extensions/StringExtensions.cs
@@ -70,6 +70,10 @@ namespace UniGLTF
             {
                 path = path.Replace(x, '+');
             }
+
+            if (path.StartsWith('.'))
+                path = '+' + path;
+
             return path;
         }
 

--- a/Assets/VRM10/Runtime/StringExtensions.cs
+++ b/Assets/VRM10/Runtime/StringExtensions.cs
@@ -69,6 +69,8 @@ namespace UniVRM10
             }
             if (path.StartsWith('.'))
                 path = '+' + path;
+            if (path == "")
+                path = "(empty)";
             return path;
         }
     }

--- a/Assets/VRM10/Runtime/StringExtensions.cs
+++ b/Assets/VRM10/Runtime/StringExtensions.cs
@@ -67,6 +67,8 @@ namespace UniVRM10
             {
                 path = path.Replace(x, '+');
             }
+            if (path.StartsWith('.'))
+                path = '+' + path;
             return path;
         }
     }


### PR DESCRIPTION
https://misskey.niri.la/notes/9iqp7u6432

> AAOでmergeしたときにメッシュ名が空欄ににゃるからか、VRM出力の際にメッシュ名が ".baked"みたいににゃってしまって何かおかしくにゃってしまう…

のUniVRM側での対策です。AAOのメッシュ名が空で、その後変換時に`.baked`が追加された結果`.baked`という名称になり、これがアセットファイルの名前になるのが原因だと推測しました