### PR TITLE
Transfer "TextureImportTypes" to ITextureDeserializer.LoadTextureAsync()

### DIFF
--- a/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Importer/DeserializingTextureInfo.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Importer/DeserializingTextureInfo.cs
@@ -42,6 +42,8 @@ namespace VRMShaders
         /// </summary>
         public TextureWrapMode WrapModeV { get; }
 
+        public TextureImportTypes ImportTypes { get; }
+
         public DeserializingTextureInfo(byte[] imageData, string dataMimeType, ColorSpace colorSpace, bool useMipmap, FilterMode filterMode, TextureWrapMode wrapModeU, TextureWrapMode wrapModeV)
         {
             ImageData = imageData;
@@ -53,7 +55,7 @@ namespace VRMShaders
             WrapModeV = wrapModeV;
         }
 
-        public DeserializingTextureInfo(byte[] imageData, string dataMimeType, ColorSpace colorSpace, SamplerParam samplerParam)
+        public DeserializingTextureInfo(byte[] imageData, string dataMimeType, ColorSpace colorSpace, SamplerParam samplerParam, TextureImportTypes importTypes)
         {
             ImageData = imageData;
             DataMimeType = dataMimeType;
@@ -62,6 +64,7 @@ namespace VRMShaders
             FilterMode = samplerParam.FilterMode;
             WrapModeU = samplerParam.WrapModesU;
             WrapModeV = samplerParam.WrapModesV;
+            ImportTypes = importTypes;
         }
     }
 }

--- a/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Importer/TextureFactory.cs
+++ b/Assets/VRMShaders/GLTF/IO/Runtime/Texture/Importer/TextureFactory.cs
@@ -80,7 +80,7 @@ namespace VRMShaders
                         // https://docs.unity3d.com/2018.4/Documentation/Manual/StandardShaderMaterialParameterNormalMap.html
                         var data0 = await texDesc.Index0();
                         var rawTexture = await TextureDeserializer.LoadTextureAsync(
-                            new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler),
+                            new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
                             awaitCaller);
                         rawTexture.name = subAssetKey.Name;
                         _textureCache.Add(subAssetKey, rawTexture);
@@ -96,14 +96,14 @@ namespace VRMShaders
                         {
                             var data0 = await texDesc.Index0();
                             metallicRoughnessTexture = await TextureDeserializer.LoadTextureAsync(
-                                new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler),
+                                new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
                                 awaitCaller);
                         }
                         if (texDesc.Index1 != null)
                         {
                             var data1 = await texDesc.Index1();
                             occlusionTexture = await TextureDeserializer.LoadTextureAsync(
-                                new DeserializingTextureInfo(data1?.binary, data1?.mimeType, ColorSpace.Linear, texDesc.Sampler),
+                                new DeserializingTextureInfo(data1?.binary, data1?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
                                 awaitCaller);
                         }
 
@@ -123,7 +123,7 @@ namespace VRMShaders
                     {
                         var data0 = await texDesc.Index0();
                         var rawTexture = await TextureDeserializer.LoadTextureAsync(
-                            new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.sRGB, texDesc.Sampler),
+                            new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.sRGB, texDesc.Sampler, texDesc.TextureType),
                             awaitCaller);
                         rawTexture.name = subAssetKey.Name;
                         _textureCache.Add(subAssetKey, rawTexture);
@@ -133,7 +133,7 @@ namespace VRMShaders
                     {
                         var data0 = await texDesc.Index0();
                         var rawTexture = await TextureDeserializer.LoadTextureAsync(
-                            new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler),
+                            new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
                             awaitCaller);
                         rawTexture.name = subAssetKey.Name;
                         _textureCache.Add(subAssetKey, rawTexture);


### PR DESCRIPTION
We implement image decoding in multi-thread, except "TextureImportTypes.StandardMap" mode for converting.