### PR TITLE
TEXCOORD_1 は export しない

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfExportSettings.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfExportSettings.cs
@@ -29,7 +29,7 @@ namespace UniGLTF
         public bool ExportOnlyBlendShapePosition;
 
         /// <summary>
-        /// tangent を出力する
+        /// Export TANGENT
         /// </summary>
         public bool ExportTangents
 #if GLTF_EXPORT_TANGENTS
@@ -38,9 +38,9 @@ namespace UniGLTF
         ;
 
         /// <summary>
-        /// Keep VertexColor
+        /// Export COLOR_0
         /// </summary>
-        public bool KeepVertexColor;
+        public bool ExportVertexColor;
 
         /// <summary>
         /// https://github.com/vrm-c/UniVRM/issues/1582
@@ -48,5 +48,10 @@ namespace UniGLTF
         /// Allowed hide flags for MeshFilters to be exported
         /// </summary>
         public HideFlags MeshFilterAllowedHideFlags = HideFlags.None;
+
+        /// <summary>
+        /// Export TEXCOORD_1
+        /// </summary>
+        public bool ExportUvSecondary;
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_DividedVertexBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_DividedVertexBuffer.cs
@@ -51,7 +51,7 @@ namespace UniGLTF
 
             var vColorState = VertexColorUtility.DetectVertexColor(mesh, unityMaterials);
             var exportVertexColor = (
-                (settings.KeepVertexColor && mesh.colors != null && mesh.colors.Length == mesh.vertexCount) // vertex color を残す設定
+                (settings.ExportVertexColor && mesh.colors != null && mesh.colors.Length == mesh.vertexCount) // vertex color を残す設定
                 || vColorState == VertexColorState.ExistsAndIsUsed // VColor使っている
                 || vColorState == VertexColorState.ExistsAndMixed // VColorを使っているところと使っていないところが混在(とりあえずExportする)
             );

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
@@ -43,12 +43,16 @@ namespace UniGLTF
             }
 
             var uvAccessorIndex0 = data.ExtendBufferAndGetAccessorIndex(mesh.uv.Select(y => y.ReverseUV()).ToArray(), glBufferTarget.ARRAY_BUFFER);
-            var uvAccessorIndex1 = data.ExtendBufferAndGetAccessorIndex(mesh.uv2.Select(y => y.ReverseUV()).ToArray(), glBufferTarget.ARRAY_BUFFER);
+
+            var uvAccessorIndex1 = -1;
+            if (settings.ExportUvSecondary)
+            {
+                uvAccessorIndex1 = data.ExtendBufferAndGetAccessorIndex(mesh.uv2.Select(y => y.ReverseUV()).ToArray(), glBufferTarget.ARRAY_BUFFER);
+            }
 
             var colorAccessorIndex = -1;
-
             var vColorState = VertexColorUtility.DetectVertexColor(mesh, materials);
-            if ((settings.KeepVertexColor && mesh.colors != null && mesh.colors.Length == mesh.vertexCount) // vertex color を残す設定
+            if ((settings.ExportVertexColor && mesh.colors != null && mesh.colors.Length == mesh.vertexCount) // vertex color を残す設定
             || vColorState == VertexColorState.ExistsAndIsUsed // VColor使っている
             || vColorState == VertexColorState.ExistsAndMixed // VColorを使っているところと使っていないところが混在(とりあえずExportする)
             )

--- a/Assets/VRM/Editor/Format/VRMExportSettings.cs
+++ b/Assets/VRM/Editor/Format/VRMExportSettings.cs
@@ -66,7 +66,7 @@ namespace VRM
             UseSparseAccessorForMorphTarget = UseSparseAccessor,
             ExportOnlyBlendShapePosition = OnlyBlendshapePosition,
             DivideVertexBuffer = DivideVertexBuffer,
-            KeepVertexColor = KeepVertexColor,
+            ExportVertexColor = KeepVertexColor,
         };
 
         public GameObject Root { get; set; }


### PR DESCRIPTION
fixed #2167

現状、Unity 上で２番目以降の UV を正しく反映する実装が無いのでエクスポートしない。

正しく反映 するには glTF と互換性のある shader にする必要があるのだが、
Unity の Standard と glTF の仕様が違うので対応予定無し。

- glTF は TextureInfo 毎に UV のチャンネルを指定することができる

https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/textureInfo.schema.json#L13
