### PR TITLE
[vrm1.0] impl mesh split by blendshape existence

### DIFF
--- a/Assets/UniGLTF/Editor/MeshUtility/TabMeshIntegrator.cs
+++ b/Assets/UniGLTF/Editor/MeshUtility/TabMeshIntegrator.cs
@@ -90,7 +90,7 @@ namespace UniGLTF.MeshUtility
             // write mesh asset.
             foreach (var result in results)
             {
-                var mesh = result.MeshMap.Integrated;
+                var mesh = result.Integrated.Mesh;
                 var assetPath = GetMeshWritePath(mesh);
                 Debug.LogFormat("CreateAsset: {0}", assetPath);
                 AssetDatabase.CreateAsset(mesh, assetPath);

--- a/Assets/UniGLTF/Runtime/MeshUtility/BoneMeshEraser.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/BoneMeshEraser.cs
@@ -131,7 +131,7 @@ namespace UniGLTF.MeshUtility
         /// <param name="boneWeights"></param>
         /// <param name="eraseBoneIndices"></param>
         /// <returns></returns>
-        public static int[] GetExcludedIndices(int[] indices, BoneWeight[] boneWeights, int[] eraseBoneIndices)
+        static int[] GetExcludedIndices(int[] indices, BoneWeight[] boneWeights, int[] eraseBoneIndices)
         {
             var count = ExcludeTriangles(indices, boneWeights, eraseBoneIndices);
             var dst = new int[count];

--- a/Assets/UniGLTF/Runtime/MeshUtility/BoneMeshEraser.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/BoneMeshEraser.cs
@@ -56,7 +56,7 @@ namespace UniGLTF.MeshUtility
 
                     {
                         var bw = bws[a];
-                        var eb = AreBoneContains(ref exclude, bw.boneIndex0, bw.boneIndex1, bw.boneIndex2, bw.boneIndex3);
+                        var eb = AreBoneContains(exclude, bw.boneIndex0, bw.boneIndex1, bw.boneIndex2, bw.boneIndex3);
                         if (bw.weight0 > 0 && eb.Bone0) continue;
                         if (bw.weight1 > 0 && eb.Bone1) continue;
                         if (bw.weight2 > 0 && eb.Bone2) continue;
@@ -64,7 +64,7 @@ namespace UniGLTF.MeshUtility
                     }
                     {
                         var bw = bws[b];
-                        var eb = AreBoneContains(ref exclude, bw.boneIndex0, bw.boneIndex1, bw.boneIndex2, bw.boneIndex3);
+                        var eb = AreBoneContains(exclude, bw.boneIndex0, bw.boneIndex1, bw.boneIndex2, bw.boneIndex3);
                         if (bw.weight0 > 0 && eb.Bone0) continue;
                         if (bw.weight1 > 0 && eb.Bone1) continue;
                         if (bw.weight2 > 0 && eb.Bone2) continue;
@@ -72,7 +72,7 @@ namespace UniGLTF.MeshUtility
                     }
                     {
                         var bw = bws[c];
-                        var eb = AreBoneContains(ref exclude, bw.boneIndex0, bw.boneIndex1, bw.boneIndex2, bw.boneIndex3);
+                        var eb = AreBoneContains(exclude, bw.boneIndex0, bw.boneIndex1, bw.boneIndex2, bw.boneIndex3);
                         if (bw.weight0 > 0 && eb.Bone0) continue;
                         if (bw.weight1 > 0 && eb.Bone1) continue;
                         if (bw.weight2 > 0 && eb.Bone2) continue;
@@ -88,7 +88,7 @@ namespace UniGLTF.MeshUtility
             return count;
         }
 
-        private static ExcludeBoneIndex AreBoneContains(ref int[] exclude, int boneIndex0, int boneIndex1,
+        private static ExcludeBoneIndex AreBoneContains(in int[] exclude, int boneIndex0, int boneIndex1,
             int boneIndex2, int boneIndex3)
         {
             var b0 = false;

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshFreezer.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshFreezer.cs
@@ -356,10 +356,6 @@ namespace UniGLTF.MeshUtility
                 }
             }
 
-            if (report.Count > 0)
-            {
-                Debug.LogFormat("{0}", report.ToString());
-            }
             // restore blendshape weights
             for (int i = 0; i < backcup.Count; ++i)
             {

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrationGroup.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrationGroup.cs
@@ -1,14 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace UniGLTF.MeshUtility
 {
     public class MeshIntegrationGroup
     {
-        /// <summary>
-        /// FirstPerson flag
-        /// TODO: enum
-        /// </summary>
         public string Name;
         public List<Renderer> Renderers = new List<Renderer>();
     }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrationResult.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrationResult.cs
@@ -46,15 +46,17 @@ namespace UniGLTF.MeshUtility
             throw new NotImplementedException();
         }
 
-        public void AddIntegratedRendererTo(GameObject parent)
+        public IEnumerable<GameObject> AddIntegratedRendererTo(GameObject parent)
         {
             if (Integrated != null)
             {
                 Integrated.AddIntegratedRendererTo(parent, Bones);
+                yield return Integrated.IntegratedRenderer.gameObject;
             }
             if (IntegratedNoBlendShape != null)
             {
                 IntegratedNoBlendShape.AddIntegratedRendererTo(parent, Bones);
+                yield return IntegratedNoBlendShape.IntegratedRenderer.gameObject;
             }
         }
     }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrator.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrator.cs
@@ -165,6 +165,12 @@ namespace UniGLTF.MeshUtility
 
         public void Push(SkinnedMeshRenderer renderer)
         {
+            if (renderer == null)
+            {
+                // Debug.LogWarningFormat("{0} was destroyed", renderer);
+                return;
+            }
+
             var mesh = renderer.sharedMesh;
             if (mesh == null)
             {

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrator.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -6,9 +7,14 @@ namespace UniGLTF.MeshUtility
 {
     public class MeshIntegrator
     {
-        private MeshIntegrator()
+        public enum BlendShapeOperation
         {
-
+            // No BlendShape(drop if mesh has blendshape)
+            None,
+            // Use blendShape(keep blendshape)
+            Use,
+            // Integrate to two mesh that is with blendShape and is without blendshape
+            Split,
         }
 
         struct SubMesh
@@ -233,7 +239,7 @@ namespace UniGLTF.MeshUtility
             }
         }
 
-        public static MeshIntegrationResult Integrate(MeshIntegrationGroup group, bool useBlendShape)
+        public static MeshIntegrationResult Integrate(MeshIntegrationGroup group, BlendShapeOperation op)
         {
             var integrator = new MeshUtility.MeshIntegrator();
             foreach (var x in group.Renderers)
@@ -247,11 +253,16 @@ namespace UniGLTF.MeshUtility
                     integrator.Push(mr);
                 }
             }
-            return integrator.Integrate(group.Name, useBlendShape);
+            return integrator.Integrate(group.Name, op);
         }
 
-        public MeshIntegrationResult Integrate(string name, bool useBlendShape)
+        public MeshIntegrationResult Integrate(string name, BlendShapeOperation op)
         {
+            if (op == BlendShapeOperation.Split)
+            {
+                throw new NotImplementedException();
+            }
+
             var mesh = new Mesh();
 
             if (Positions.Count > ushort.MaxValue)
@@ -271,7 +282,7 @@ namespace UniGLTF.MeshUtility
                 mesh.SetIndices(SubMeshes[i].Indices.ToArray(), MeshTopology.Triangles, i);
             }
             mesh.bindposes = BindPoses.ToArray();
-            if (useBlendShape)
+            if (op == BlendShapeOperation.Use)
             {
                 AddBlendShapesToMesh(mesh);
             }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegratorUtility.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegratorUtility.cs
@@ -191,7 +191,7 @@ namespace UniGLTF.MeshUtility
 
             // Add integrated
             foreach (var result in results)
-            {
+            {               
                 result.AddIntegratedRendererTo(copy);
             }
         }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegratorUtility.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegratorUtility.cs
@@ -99,7 +99,9 @@ namespace UniGLTF.MeshUtility
                     }
             }
 
-            return MeshIntegrator.Integrate(group, useBlendShape);
+            return MeshIntegrator.Integrate(group, useBlendShape
+                ? MeshIntegrator.BlendShapeOperation.Use
+                : MeshIntegrator.BlendShapeOperation.None);
         }
 
         public static IEnumerable<SkinnedMeshRenderer> EnumerateSkinnedMeshRenderer(Transform root, MeshEnumerateOption hasBlendShape)

--- a/Assets/UniGLTF/Runtime/MeshUtility/TriangleSeparator.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/TriangleSeparator.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace UniGLTF.MeshUtility
+{
+    class TriangleSeparator
+    {
+        bool[] VertexHasBlendShape;
+
+        public bool ShouldSplit
+        {
+            get
+            {
+                var count = VertexHasBlendShape.Count(x => x);
+                // すべて true か false の場合は分割しない
+                return count > 0 && count < VertexHasBlendShape.Length;
+            }
+        }
+
+        public bool TriangleHasBlendShape(int i0, int i1, int i2)
+        {
+            return VertexHasBlendShape[i0]
+            || VertexHasBlendShape[i1]
+            || VertexHasBlendShape[i2];
+        }
+
+        public bool TriangleHasNotBlendShape(int i0, int i1, int i2)
+        {
+            return !TriangleHasBlendShape(i0, i1, i2);
+        }
+
+        public TriangleSeparator(int vertexCount)
+        {
+            VertexHasBlendShape = new bool[vertexCount];
+        }
+
+        public void CheckPositions(IReadOnlyList<Vector3> positions)
+        {
+            for (int i = 0; i < positions.Count; ++i)
+            {
+                if (positions[i] != Vector3.zero)
+                {
+                    VertexHasBlendShape[i] = true;
+                }
+            }
+        }
+    }
+}

--- a/Assets/UniGLTF/Runtime/MeshUtility/TriangleSeparator.cs.meta
+++ b/Assets/UniGLTF/Runtime/MeshUtility/TriangleSeparator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8936c9c948d10447a6899410bac3c07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM/Editor/SkinnedMeshUtility/VRMMeshIntegratorUtility.cs
+++ b/Assets/VRM/Editor/SkinnedMeshUtility/VRMMeshIntegratorUtility.cs
@@ -21,7 +21,7 @@ namespace VRM
             {
                 return clips;
             }
-            var result = results.FirstOrDefault(x => x.MeshMap.Integrated.blendShapeCount > 0);
+            var result = results.FirstOrDefault(x => x.Integrated.Mesh.blendShapeCount > 0);
             if (result == null)
             {
                 return clips;
@@ -32,7 +32,7 @@ namespace VRM
             {
                 rendererDict.Add(x.transform.RelativePathFrom(root.transform), x);
             }
-            var dstPath = result.IntegratedRenderer.transform.RelativePathFrom(root.transform);
+            var dstPath = result.Integrated.IntegratedRenderer.transform.RelativePathFrom(root.transform);
 
             // copy modify and write
             var clipAssetPathList = new List<string>();
@@ -54,7 +54,7 @@ namespace VRM
                     {
                         var srcRenderer = rendererDict[val.RelativePath];
                         var name = srcRenderer.sharedMesh.GetBlendShapeName(val.Index);
-                        var newIndex = result.IntegratedRenderer.sharedMesh.GetBlendShapeIndex(name);
+                        var newIndex = result.Integrated.IntegratedRenderer.sharedMesh.GetBlendShapeIndex(name);
                         if (newIndex == -1)
                         {
                             throw new KeyNotFoundException($"blendshape:{name} not found");

--- a/Assets/VRM/Editor/SkinnedMeshUtility/VrmMeshIntegratorWizard.cs
+++ b/Assets/VRM/Editor/SkinnedMeshUtility/VrmMeshIntegratorWizard.cs
@@ -91,7 +91,7 @@ namespace VRM
 
         [Header("Result")]
         [SerializeField]
-        MeshMap[] integrationResults;
+        MeshInfo[] integrationResults;
 
         public static void CreateWizard()
         {
@@ -279,17 +279,17 @@ namespace VRM
             // write mesh asset
             foreach (var result in results)
             {
-                var childAssetPath = $"{assetFolder}/{result.IntegratedRenderer.gameObject.name}{ASSET_SUFFIX}";
+                var childAssetPath = $"{assetFolder}/{result.Integrated.IntegratedRenderer.gameObject.name}{ASSET_SUFFIX}";
                 Debug.LogFormat("CreateAsset: {0}", childAssetPath);
-                AssetDatabase.CreateAsset(result.IntegratedRenderer.sharedMesh, childAssetPath);
+                AssetDatabase.CreateAsset(result.Integrated.IntegratedRenderer.sharedMesh, childAssetPath);
             }
 
             // 統合した結果をヒエラルキーに追加する
             foreach (var result in results)
             {
-                if (result.IntegratedRenderer != null)
+                if (result.Integrated.IntegratedRenderer != null)
                 {
-                    result.IntegratedRenderer.transform.SetParent(copy.transform, false);
+                    result.Integrated.IntegratedRenderer.transform.SetParent(copy.transform, false);
                 }
             }
 

--- a/Assets/VRM10/Editor/MeshUtility/Vrm10MeshUtilityDialog.cs
+++ b/Assets/VRM10/Editor/MeshUtility/Vrm10MeshUtilityDialog.cs
@@ -13,9 +13,8 @@ namespace UniVRM10
         const string TITLE = "Vrm10 Mesh Utility Window";
         enum Tabs
         {
-            MeshFreeze,
-            MeshIntegration,
-            MeshSplitter,
+            Freeze,
+            IntegrateSplit,
         }
         Tabs _tab;
 
@@ -78,7 +77,7 @@ namespace UniVRM10
 
             switch (_tab)
             {
-                case Tabs.MeshFreeze:
+                case Tabs.Freeze:
                     {
                         if (MeshFreezeGui())
                         {
@@ -87,18 +86,9 @@ namespace UniVRM10
                         break;
                     }
 
-                case Tabs.MeshIntegration:
+                case Tabs.IntegrateSplit:
                     {
                         if (MeshIntegrateGui())
-                        {
-                            modified = true;
-                        }
-                        break;
-                    }
-
-                case Tabs.MeshSplitter:
-                    {
-                        if (MeshSplitGui())
                         {
                             modified = true;
                         }
@@ -147,6 +137,7 @@ namespace UniVRM10
         bool MeshIntegrateGui()
         {
             var firstPerson = ToggleIsModified("FirstPerson == AUTO の生成", ref _meshUtility.GenerateMeshForFirstPersonAuto);
+            var split = ToggleIsModified("Separate by BlendShape", ref _meshUtility.SplitByBlendShape);
             var p = position;
             var last = GUILayoutUtility.GetLastRect();
             var y = last.y + last.height;
@@ -160,12 +151,7 @@ namespace UniVRM10
                 - 30
             };
             var mod = _meshIntegration.OnGui(rect);
-            return firstPerson || mod;
-        }
-
-        bool MeshSplitGui()
-        {
-            return ToggleIsModified("Separate by BlendShape", ref _meshUtility.SplitByBlendShape);
+            return firstPerson || split || mod;
         }
     }
 }

--- a/Assets/VRM10/Editor/MeshUtility/Vrm10MeshUtilityDialog.cs
+++ b/Assets/VRM10/Editor/MeshUtility/Vrm10MeshUtilityDialog.cs
@@ -107,7 +107,9 @@ namespace UniVRM10
             GUI.enabled = true;
             if (pressed)
             {
+                Undo.RegisterFullObjectHierarchyUndo(exportTarget, "MeshUtility");
                 _meshUtility.Process(exportTarget);
+
                 // Show Result ?
                 // Close();
                 // GUIUtility.ExitGUI();

--- a/Assets/VRM10/Editor/MeshUtility/Vrm10MeshUtilityDialog.cs
+++ b/Assets/VRM10/Editor/MeshUtility/Vrm10MeshUtilityDialog.cs
@@ -108,8 +108,11 @@ namespace UniVRM10
             if (pressed)
             {
                 Undo.RegisterFullObjectHierarchyUndo(exportTarget, "MeshUtility");
-                _meshUtility.Process(exportTarget);
-
+                foreach (var go in _meshUtility.Process(exportTarget))
+                {
+                    Undo.RegisterCreatedObjectUndo(go, "MeshUtility");
+                }
+                _exportTarget = null;
                 // Show Result ?
                 // Close();
                 // GUIUtility.ExitGUI();

--- a/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
@@ -8,209 +8,210 @@ using VRMShaders;
 
 namespace UniVRM10
 {
-    [Serializable]
-    public class VRM10ObjectFirstPerson
+  [Serializable]
+  public class VRM10ObjectFirstPerson
+  {
+    [SerializeField]
+    public List<RendererFirstPersonFlags> Renderers = new List<RendererFirstPersonFlags>();
+    public void SetDefault(Transform root)
     {
-        [SerializeField]
-        public List<RendererFirstPersonFlags> Renderers = new List<RendererFirstPersonFlags>();
-        public void SetDefault(Transform root)
+      Renderers.Clear();
+
+      var renderers = root.GetComponentsInChildren<Renderer>();
+      var paths = renderers.Select(x => x.transform.RelativePathFrom(root)).ToArray();
+      foreach (var path in paths)
+      {
+        Renderers.Add(new RendererFirstPersonFlags
         {
-            Renderers.Clear();
-
-            var renderers = root.GetComponentsInChildren<Renderer>();
-            var paths = renderers.Select(x => x.transform.RelativePathFrom(root)).ToArray();
-            foreach (var path in paths)
-            {
-                Renderers.Add(new RendererFirstPersonFlags
-                {
-                    FirstPersonFlag = UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto,
-                    Renderer = path,
-                });
-            }
-        }
-
-        static int[] GetBonesThatHasAncestor(SkinnedMeshRenderer smr, Transform ancestor)
-        {
-            var eraseBones = smr.bones
-            .Where(x => x.Ancestor().Any(y => y == ancestor))
-            .Select(x => Array.IndexOf(smr.bones, x))
-            .ToArray();
-            return eraseBones;
-        }
-
-        public static async Task<Mesh> CreateErasedMeshAsync(SkinnedMeshRenderer smr,
-            Transform firstPersonBone,
-            IAwaitCaller awaitCaller)
-        {
-            var eraseBones = GetBonesThatHasAncestor(smr, firstPersonBone);
-            if (eraseBones.Any())
-            {
-                return await BoneMeshEraser.CreateErasedMeshAsync(smr.sharedMesh, eraseBones, awaitCaller);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        // <summary>
-        // 頭部を取り除いたモデルを複製する
-        // </summary>
-        // <parameter>renderer: 元になるSkinnedMeshRenderer</parameter>
-        // <parameter>eraseBones: 削除対象になるボーンのindex</parameter>
-        public async static Task<SkinnedMeshRenderer> CreateHeadlessMeshAsync(SkinnedMeshRenderer renderer,
-            Transform firstPersonBone, IAwaitCaller awaitCaller)
-        {
-            var mesh = await CreateErasedMeshAsync(renderer, firstPersonBone, awaitCaller);
-            if (mesh != null)
-            {
-                var go = new GameObject("_headless_" + renderer.name);
-                var erased = go.AddComponent<SkinnedMeshRenderer>();
-                erased.enabled = false; // hide
-                erased.sharedMesh = mesh;
-                erased.sharedMaterials = renderer.sharedMaterials;
-                erased.bones = renderer.bones;
-                erased.rootBone = renderer.rootBone;
-                return erased;
-            }
-            else
-            {
-                // 削除対象が含まれないので何もしない
-                return null;
-            }
-        }
-
-        bool m_done;
-
-        async Task SetupSelfRendererAsync(GameObject go, UniGLTF.RuntimeGltfInstance runtime,
-            Transform firstPersonBone, RendererFirstPersonFlags x,
-            (int FirstPersonOnly, int ThirdPersonOnly) layer, IAwaitCaller awaitCaller = null)
-        {
-            switch (x.FirstPersonFlag)
-            {
-                case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto:
-                    {
-                        if (x.GetRenderer(go.transform) is SkinnedMeshRenderer smr)
-                        {
-                            // オリジナルのモデルを３人称用にする                                
-                            smr.gameObject.layer = layer.ThirdPersonOnly;
-
-                            // 頭を取り除いた複製モデルを作成し、１人称用にする
-                            var headless = await CreateHeadlessMeshAsync(smr, firstPersonBone, awaitCaller);
-                            if (headless != null)
-                            {
-                                headless.gameObject.layer = layer.FirstPersonOnly;
-                                headless.transform.SetParent(smr.transform, false);
-                                if (runtime != null)
-                                {
-                                    runtime.AddRenderer(headless);
-                                }
-                            }
-                        }
-                        else if (x.GetRenderer(go.transform) is MeshRenderer mr)
-                        {
-                            if (mr.transform.Ancestors().Any(y => y == firstPersonBone))
-                            {
-                                // 頭の子孫なので１人称では非表示に
-                                mr.gameObject.layer = layer.ThirdPersonOnly;
-                            }
-                            else
-                            {
-                                // 特に変更しない => 両方表示
-                            }
-                        }
-                        else
-                        {
-                            throw new NotImplementedException();
-                        }
-                    }
-                    break;
-
-                case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.firstPersonOnly:
-                    // １人称のカメラでだけ描画されるようにする
-                    x.GetRenderer(go.transform).gameObject.layer = layer.FirstPersonOnly;
-                    break;
-
-                case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.thirdPersonOnly:
-                    // ３人称のカメラでだけ描画されるようにする
-                    x.GetRenderer(go.transform).gameObject.layer = layer.ThirdPersonOnly;
-                    break;
-
-                case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.both:
-                    // 特に何もしない。すべてのカメラで描画される
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Each renderer is set according to the first person flag. 
-        /// If the flag is `auto`, headless mesh creation will be performed.
-        /// Creating a headless mesh(Renderer) is a heavy process and can be done in threads.
-        /// </summary>
-        /// <param name="go">The target model root</param>
-        /// <param name="isSelf">The target model is the VR user himself</param>
-        /// <param name="firstPersonOnlyLayer">layer VRMFirstPersonOnly or 9</param>
-        /// <param name="thirdPersonOnlyLayer">layer VRMThirdPersonOnly ir 10</param>
-        /// <param name="awaitCaller">Headless mesh creation task scheduler. By default, creation is immediate</param>
-        /// <returns></returns>
-        public async Task SetupAsync(GameObject go, IAwaitCaller awaitCaller, bool isSelf = true, int? firstPersonOnlyLayer = default, int? thirdPersonOnlyLayer = default)
-        {
-            if (awaitCaller == null)
-            {
-                throw new ArgumentNullException();
-            }
-
-            var layer = (
-                Vrm10FirstPersonLayerSettings.GetFirstPersonOnlyLayer(firstPersonOnlyLayer),
-                Vrm10FirstPersonLayerSettings.GetThirdPersonOnlyLayer(thirdPersonOnlyLayer));
-
-            if (m_done)
-            {
-                return;
-            }
-            m_done = true;
-
-            var runtime = go.GetComponent<UniGLTF.RuntimeGltfInstance>();
-            var vrmInstance = go.GetComponent<Vrm10Instance>();
-            // NOTE: This bone must be referenced by renderers instead of the control rig bone.
-            var firstPersonBone = vrmInstance.Humanoid.Head;
-
-            var used = new HashSet<string>();
-            foreach (var x in Renderers)
-            {
-                if (!used.Add(x.Renderer))
-                {
-                    // 同じ対象が複数回現れた
-                    Debug.LogWarning($"VRM10ObjectFirstPerson.SetupAsync: duplicated {x.Renderer}");
-                    continue;
-                }
-
-                if (isSelf)
-                {
-                    await SetupSelfRendererAsync(go, runtime, firstPersonBone, x, layer, awaitCaller);
-                }
-                else
-                {
-                    switch (x.FirstPersonFlag)
-                    {
-                        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.firstPersonOnly:
-                            if (x.GetRenderer(go.transform) is Renderer r)
-                            {
-                                // invisible
-                                r.enabled = false;
-                                runtime.VisibleRenderers.Remove(r);
-                            }
-                            break;
-
-                        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto:
-                        // => Same as Both
-                        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.both:
-                        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.thirdPersonOnly:
-                            // do nothing
-                            break;
-                    }
-                }
-            }
-        }
+          FirstPersonFlag = UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto,
+          Renderer = path,
+        });
+      }
     }
+
+    static int[] GetBonesThatHasAncestor(SkinnedMeshRenderer smr, Transform ancestor)
+    {
+      var eraseBones = smr.bones
+      .Where(x => x.Ancestor().Any(y => y == ancestor))
+      .Select(x => Array.IndexOf(smr.bones, x))
+      .Distinct()
+      .ToArray();
+      return eraseBones;
+    }
+
+    public static async Task<Mesh> CreateErasedMeshAsync(SkinnedMeshRenderer smr,
+        Transform firstPersonBone,
+        IAwaitCaller awaitCaller)
+    {
+      var eraseBones = GetBonesThatHasAncestor(smr, firstPersonBone);
+      if (eraseBones.Any())
+      {
+        return await BoneMeshEraser.CreateErasedMeshAsync(smr.sharedMesh, eraseBones, awaitCaller);
+      }
+      else
+      {
+        return null;
+      }
+    }
+
+    // <summary>
+    // 頭部を取り除いたモデルを複製する
+    // </summary>
+    // <parameter>renderer: 元になるSkinnedMeshRenderer</parameter>
+    // <parameter>eraseBones: 削除対象になるボーンのindex</parameter>
+    public async static Task<SkinnedMeshRenderer> CreateHeadlessMeshAsync(SkinnedMeshRenderer renderer,
+        Transform firstPersonBone, IAwaitCaller awaitCaller)
+    {
+      var mesh = await CreateErasedMeshAsync(renderer, firstPersonBone, awaitCaller);
+      if (mesh != null)
+      {
+        var go = new GameObject("_headless_" + renderer.name);
+        var erased = go.AddComponent<SkinnedMeshRenderer>();
+        erased.enabled = false; // hide
+        erased.sharedMesh = mesh;
+        erased.sharedMaterials = renderer.sharedMaterials;
+        erased.bones = renderer.bones;
+        erased.rootBone = renderer.rootBone;
+        return erased;
+      }
+      else
+      {
+        // 削除対象が含まれないので何もしない
+        return null;
+      }
+    }
+
+    bool m_done;
+
+    async Task SetupSelfRendererAsync(GameObject go, UniGLTF.RuntimeGltfInstance runtime,
+        Transform firstPersonBone, RendererFirstPersonFlags x,
+        (int FirstPersonOnly, int ThirdPersonOnly) layer, IAwaitCaller awaitCaller = null)
+    {
+      switch (x.FirstPersonFlag)
+      {
+        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto:
+          {
+            if (x.GetRenderer(go.transform) is SkinnedMeshRenderer smr)
+            {
+              // オリジナルのモデルを３人称用にする                                
+              smr.gameObject.layer = layer.ThirdPersonOnly;
+
+              // 頭を取り除いた複製モデルを作成し、１人称用にする
+              var headless = await CreateHeadlessMeshAsync(smr, firstPersonBone, awaitCaller);
+              if (headless != null)
+              {
+                headless.gameObject.layer = layer.FirstPersonOnly;
+                headless.transform.SetParent(smr.transform, false);
+                if (runtime != null)
+                {
+                  runtime.AddRenderer(headless);
+                }
+              }
+            }
+            else if (x.GetRenderer(go.transform) is MeshRenderer mr)
+            {
+              if (mr.transform.Ancestors().Any(y => y == firstPersonBone))
+              {
+                // 頭の子孫なので１人称では非表示に
+                mr.gameObject.layer = layer.ThirdPersonOnly;
+              }
+              else
+              {
+                // 特に変更しない => 両方表示
+              }
+            }
+            else
+            {
+              throw new NotImplementedException();
+            }
+          }
+          break;
+
+        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.firstPersonOnly:
+          // １人称のカメラでだけ描画されるようにする
+          x.GetRenderer(go.transform).gameObject.layer = layer.FirstPersonOnly;
+          break;
+
+        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.thirdPersonOnly:
+          // ３人称のカメラでだけ描画されるようにする
+          x.GetRenderer(go.transform).gameObject.layer = layer.ThirdPersonOnly;
+          break;
+
+        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.both:
+          // 特に何もしない。すべてのカメラで描画される
+          break;
+      }
+    }
+
+    /// <summary>
+    /// Each renderer is set according to the first person flag. 
+    /// If the flag is `auto`, headless mesh creation will be performed.
+    /// Creating a headless mesh(Renderer) is a heavy process and can be done in threads.
+    /// </summary>
+    /// <param name="go">The target model root</param>
+    /// <param name="isSelf">The target model is the VR user himself</param>
+    /// <param name="firstPersonOnlyLayer">layer VRMFirstPersonOnly or 9</param>
+    /// <param name="thirdPersonOnlyLayer">layer VRMThirdPersonOnly ir 10</param>
+    /// <param name="awaitCaller">Headless mesh creation task scheduler. By default, creation is immediate</param>
+    /// <returns></returns>
+    public async Task SetupAsync(GameObject go, IAwaitCaller awaitCaller, bool isSelf = true, int? firstPersonOnlyLayer = default, int? thirdPersonOnlyLayer = default)
+    {
+      if (awaitCaller == null)
+      {
+        throw new ArgumentNullException();
+      }
+
+      var layer = (
+          Vrm10FirstPersonLayerSettings.GetFirstPersonOnlyLayer(firstPersonOnlyLayer),
+          Vrm10FirstPersonLayerSettings.GetThirdPersonOnlyLayer(thirdPersonOnlyLayer));
+
+      if (m_done)
+      {
+        return;
+      }
+      m_done = true;
+
+      var runtime = go.GetComponent<UniGLTF.RuntimeGltfInstance>();
+      var vrmInstance = go.GetComponent<Vrm10Instance>();
+      // NOTE: This bone must be referenced by renderers instead of the control rig bone.
+      var firstPersonBone = vrmInstance.Humanoid.Head;
+
+      var used = new HashSet<string>();
+      foreach (var x in Renderers)
+      {
+        if (!used.Add(x.Renderer))
+        {
+          // 同じ対象が複数回現れた
+          Debug.LogWarning($"VRM10ObjectFirstPerson.SetupAsync: duplicated {x.Renderer}");
+          continue;
+        }
+
+        if (isSelf)
+        {
+          await SetupSelfRendererAsync(go, runtime, firstPersonBone, x, layer, awaitCaller);
+        }
+        else
+        {
+          switch (x.FirstPersonFlag)
+          {
+            case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.firstPersonOnly:
+              if (x.GetRenderer(go.transform) is Renderer r)
+              {
+                // invisible
+                r.enabled = false;
+                runtime.VisibleRenderers.Remove(r);
+              }
+              break;
+
+            case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto:
+            // => Same as Both
+            case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.both:
+            case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.thirdPersonOnly:
+              // do nothing
+              break;
+          }
+        }
+      }
+    }
+  }
 }

--- a/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
@@ -8,210 +8,210 @@ using VRMShaders;
 
 namespace UniVRM10
 {
-  [Serializable]
-  public class VRM10ObjectFirstPerson
-  {
-    [SerializeField]
-    public List<RendererFirstPersonFlags> Renderers = new List<RendererFirstPersonFlags>();
-    public void SetDefault(Transform root)
+    [Serializable]
+    public class VRM10ObjectFirstPerson
     {
-      Renderers.Clear();
-
-      var renderers = root.GetComponentsInChildren<Renderer>();
-      var paths = renderers.Select(x => x.transform.RelativePathFrom(root)).ToArray();
-      foreach (var path in paths)
-      {
-        Renderers.Add(new RendererFirstPersonFlags
+        [SerializeField]
+        public List<RendererFirstPersonFlags> Renderers = new List<RendererFirstPersonFlags>();
+        public void SetDefault(Transform root)
         {
-          FirstPersonFlag = UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto,
-          Renderer = path,
-        });
-      }
-    }
+            Renderers.Clear();
 
-    static int[] GetBonesThatHasAncestor(SkinnedMeshRenderer smr, Transform ancestor)
-    {
-      var eraseBones = smr.bones
-      .Where(x => x.Ancestor().Any(y => y == ancestor))
-      .Select(x => Array.IndexOf(smr.bones, x))
-      .Distinct()
-      .ToArray();
-      return eraseBones;
-    }
-
-    public static async Task<Mesh> CreateErasedMeshAsync(SkinnedMeshRenderer smr,
-        Transform firstPersonBone,
-        IAwaitCaller awaitCaller)
-    {
-      var eraseBones = GetBonesThatHasAncestor(smr, firstPersonBone);
-      if (eraseBones.Any())
-      {
-        return await BoneMeshEraser.CreateErasedMeshAsync(smr.sharedMesh, eraseBones, awaitCaller);
-      }
-      else
-      {
-        return null;
-      }
-    }
-
-    // <summary>
-    // 頭部を取り除いたモデルを複製する
-    // </summary>
-    // <parameter>renderer: 元になるSkinnedMeshRenderer</parameter>
-    // <parameter>eraseBones: 削除対象になるボーンのindex</parameter>
-    public async static Task<SkinnedMeshRenderer> CreateHeadlessMeshAsync(SkinnedMeshRenderer renderer,
-        Transform firstPersonBone, IAwaitCaller awaitCaller)
-    {
-      var mesh = await CreateErasedMeshAsync(renderer, firstPersonBone, awaitCaller);
-      if (mesh != null)
-      {
-        var go = new GameObject("_headless_" + renderer.name);
-        var erased = go.AddComponent<SkinnedMeshRenderer>();
-        erased.enabled = false; // hide
-        erased.sharedMesh = mesh;
-        erased.sharedMaterials = renderer.sharedMaterials;
-        erased.bones = renderer.bones;
-        erased.rootBone = renderer.rootBone;
-        return erased;
-      }
-      else
-      {
-        // 削除対象が含まれないので何もしない
-        return null;
-      }
-    }
-
-    bool m_done;
-
-    async Task SetupSelfRendererAsync(GameObject go, UniGLTF.RuntimeGltfInstance runtime,
-        Transform firstPersonBone, RendererFirstPersonFlags x,
-        (int FirstPersonOnly, int ThirdPersonOnly) layer, IAwaitCaller awaitCaller = null)
-    {
-      switch (x.FirstPersonFlag)
-      {
-        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto:
-          {
-            if (x.GetRenderer(go.transform) is SkinnedMeshRenderer smr)
+            var renderers = root.GetComponentsInChildren<Renderer>();
+            var paths = renderers.Select(x => x.transform.RelativePathFrom(root)).ToArray();
+            foreach (var path in paths)
             {
-              // オリジナルのモデルを３人称用にする                                
-              smr.gameObject.layer = layer.ThirdPersonOnly;
-
-              // 頭を取り除いた複製モデルを作成し、１人称用にする
-              var headless = await CreateHeadlessMeshAsync(smr, firstPersonBone, awaitCaller);
-              if (headless != null)
-              {
-                headless.gameObject.layer = layer.FirstPersonOnly;
-                headless.transform.SetParent(smr.transform, false);
-                if (runtime != null)
+                Renderers.Add(new RendererFirstPersonFlags
                 {
-                  runtime.AddRenderer(headless);
-                }
-              }
+                    FirstPersonFlag = UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto,
+                    Renderer = path,
+                });
             }
-            else if (x.GetRenderer(go.transform) is MeshRenderer mr)
+        }
+
+        static int[] GetBonesThatHasAncestor(SkinnedMeshRenderer smr, Transform ancestor)
+        {
+            var eraseBones = smr.bones
+            .Where(x => x.Ancestor().Any(y => y == ancestor))
+            .Select(x => Array.IndexOf(smr.bones, x))
+            .Distinct()
+            .ToArray();
+            return eraseBones;
+        }
+
+        public static async Task<Mesh> CreateErasedMeshAsync(SkinnedMeshRenderer smr,
+            Transform firstPersonBone,
+            IAwaitCaller awaitCaller)
+        {
+            var eraseBones = GetBonesThatHasAncestor(smr, firstPersonBone);
+            if (eraseBones.Any())
             {
-              if (mr.transform.Ancestors().Any(y => y == firstPersonBone))
-              {
-                // 頭の子孫なので１人称では非表示に
-                mr.gameObject.layer = layer.ThirdPersonOnly;
-              }
-              else
-              {
-                // 特に変更しない => 両方表示
-              }
+                return await BoneMeshEraser.CreateErasedMeshAsync(smr.sharedMesh, eraseBones, awaitCaller);
             }
             else
             {
-              throw new NotImplementedException();
+                return null;
             }
-          }
-          break;
+        }
 
-        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.firstPersonOnly:
-          // １人称のカメラでだけ描画されるようにする
-          x.GetRenderer(go.transform).gameObject.layer = layer.FirstPersonOnly;
-          break;
+        // <summary>
+        // 頭部を取り除いたモデルを複製する
+        // </summary>
+        // <parameter>renderer: 元になるSkinnedMeshRenderer</parameter>
+        // <parameter>eraseBones: 削除対象になるボーンのindex</parameter>
+        public async static Task<SkinnedMeshRenderer> CreateHeadlessMeshAsync(SkinnedMeshRenderer renderer,
+            Transform firstPersonBone, IAwaitCaller awaitCaller)
+        {
+            var mesh = await CreateErasedMeshAsync(renderer, firstPersonBone, awaitCaller);
+            if (mesh != null)
+            {
+                var go = new GameObject("_headless_" + renderer.name);
+                var erased = go.AddComponent<SkinnedMeshRenderer>();
+                erased.enabled = false; // hide
+                erased.sharedMesh = mesh;
+                erased.sharedMaterials = renderer.sharedMaterials;
+                erased.bones = renderer.bones;
+                erased.rootBone = renderer.rootBone;
+                return erased;
+            }
+            else
+            {
+                // 削除対象が含まれないので何もしない
+                return null;
+            }
+        }
 
-        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.thirdPersonOnly:
-          // ３人称のカメラでだけ描画されるようにする
-          x.GetRenderer(go.transform).gameObject.layer = layer.ThirdPersonOnly;
-          break;
+        bool m_done;
 
-        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.both:
-          // 特に何もしない。すべてのカメラで描画される
-          break;
-      }
+        async Task SetupSelfRendererAsync(GameObject go, UniGLTF.RuntimeGltfInstance runtime,
+            Transform firstPersonBone, RendererFirstPersonFlags x,
+            (int FirstPersonOnly, int ThirdPersonOnly) layer, IAwaitCaller awaitCaller = null)
+        {
+            switch (x.FirstPersonFlag)
+            {
+                case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto:
+                    {
+                        if (x.GetRenderer(go.transform) is SkinnedMeshRenderer smr)
+                        {
+                            // オリジナルのモデルを３人称用にする                                
+                            smr.gameObject.layer = layer.ThirdPersonOnly;
+
+                            // 頭を取り除いた複製モデルを作成し、１人称用にする
+                            var headless = await CreateHeadlessMeshAsync(smr, firstPersonBone, awaitCaller);
+                            if (headless != null)
+                            {
+                                headless.gameObject.layer = layer.FirstPersonOnly;
+                                headless.transform.SetParent(smr.transform, false);
+                                if (runtime != null)
+                                {
+                                    runtime.AddRenderer(headless);
+                                }
+                            }
+                        }
+                        else if (x.GetRenderer(go.transform) is MeshRenderer mr)
+                        {
+                            if (mr.transform.Ancestors().Any(y => y == firstPersonBone))
+                            {
+                                // 頭の子孫なので１人称では非表示に
+                                mr.gameObject.layer = layer.ThirdPersonOnly;
+                            }
+                            else
+                            {
+                                // 特に変更しない => 両方表示
+                            }
+                        }
+                        else
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                    break;
+
+                case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.firstPersonOnly:
+                    // １人称のカメラでだけ描画されるようにする
+                    x.GetRenderer(go.transform).gameObject.layer = layer.FirstPersonOnly;
+                    break;
+
+                case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.thirdPersonOnly:
+                    // ３人称のカメラでだけ描画されるようにする
+                    x.GetRenderer(go.transform).gameObject.layer = layer.ThirdPersonOnly;
+                    break;
+
+                case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.both:
+                    // 特に何もしない。すべてのカメラで描画される
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Each renderer is set according to the first person flag. 
+        /// If the flag is `auto`, headless mesh creation will be performed.
+        /// Creating a headless mesh(Renderer) is a heavy process and can be done in threads.
+        /// </summary>
+        /// <param name="go">The target model root</param>
+        /// <param name="isSelf">The target model is the VR user himself</param>
+        /// <param name="firstPersonOnlyLayer">layer VRMFirstPersonOnly or 9</param>
+        /// <param name="thirdPersonOnlyLayer">layer VRMThirdPersonOnly ir 10</param>
+        /// <param name="awaitCaller">Headless mesh creation task scheduler. By default, creation is immediate</param>
+        /// <returns></returns>
+        public async Task SetupAsync(GameObject go, IAwaitCaller awaitCaller, bool isSelf = true, int? firstPersonOnlyLayer = default, int? thirdPersonOnlyLayer = default)
+        {
+            if (awaitCaller == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            var layer = (
+                Vrm10FirstPersonLayerSettings.GetFirstPersonOnlyLayer(firstPersonOnlyLayer),
+                Vrm10FirstPersonLayerSettings.GetThirdPersonOnlyLayer(thirdPersonOnlyLayer));
+
+            if (m_done)
+            {
+                return;
+            }
+            m_done = true;
+
+            var runtime = go.GetComponent<UniGLTF.RuntimeGltfInstance>();
+            var vrmInstance = go.GetComponent<Vrm10Instance>();
+            // NOTE: This bone must be referenced by renderers instead of the control rig bone.
+            var firstPersonBone = vrmInstance.Humanoid.Head;
+
+            var used = new HashSet<string>();
+            foreach (var x in Renderers)
+            {
+                if (!used.Add(x.Renderer))
+                {
+                    // 同じ対象が複数回現れた
+                    Debug.LogWarning($"VRM10ObjectFirstPerson.SetupAsync: duplicated {x.Renderer}");
+                    continue;
+                }
+
+                if (isSelf)
+                {
+                    await SetupSelfRendererAsync(go, runtime, firstPersonBone, x, layer, awaitCaller);
+                }
+                else
+                {
+                    switch (x.FirstPersonFlag)
+                    {
+                        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.firstPersonOnly:
+                            if (x.GetRenderer(go.transform) is Renderer r)
+                            {
+                                // invisible
+                                r.enabled = false;
+                                runtime.VisibleRenderers.Remove(r);
+                            }
+                            break;
+
+                        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto:
+                        // => Same as Both
+                        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.both:
+                        case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.thirdPersonOnly:
+                            // do nothing
+                            break;
+                    }
+                }
+            }
+        }
     }
-
-    /// <summary>
-    /// Each renderer is set according to the first person flag. 
-    /// If the flag is `auto`, headless mesh creation will be performed.
-    /// Creating a headless mesh(Renderer) is a heavy process and can be done in threads.
-    /// </summary>
-    /// <param name="go">The target model root</param>
-    /// <param name="isSelf">The target model is the VR user himself</param>
-    /// <param name="firstPersonOnlyLayer">layer VRMFirstPersonOnly or 9</param>
-    /// <param name="thirdPersonOnlyLayer">layer VRMThirdPersonOnly ir 10</param>
-    /// <param name="awaitCaller">Headless mesh creation task scheduler. By default, creation is immediate</param>
-    /// <returns></returns>
-    public async Task SetupAsync(GameObject go, IAwaitCaller awaitCaller, bool isSelf = true, int? firstPersonOnlyLayer = default, int? thirdPersonOnlyLayer = default)
-    {
-      if (awaitCaller == null)
-      {
-        throw new ArgumentNullException();
-      }
-
-      var layer = (
-          Vrm10FirstPersonLayerSettings.GetFirstPersonOnlyLayer(firstPersonOnlyLayer),
-          Vrm10FirstPersonLayerSettings.GetThirdPersonOnlyLayer(thirdPersonOnlyLayer));
-
-      if (m_done)
-      {
-        return;
-      }
-      m_done = true;
-
-      var runtime = go.GetComponent<UniGLTF.RuntimeGltfInstance>();
-      var vrmInstance = go.GetComponent<Vrm10Instance>();
-      // NOTE: This bone must be referenced by renderers instead of the control rig bone.
-      var firstPersonBone = vrmInstance.Humanoid.Head;
-
-      var used = new HashSet<string>();
-      foreach (var x in Renderers)
-      {
-        if (!used.Add(x.Renderer))
-        {
-          // 同じ対象が複数回現れた
-          Debug.LogWarning($"VRM10ObjectFirstPerson.SetupAsync: duplicated {x.Renderer}");
-          continue;
-        }
-
-        if (isSelf)
-        {
-          await SetupSelfRendererAsync(go, runtime, firstPersonBone, x, layer, awaitCaller);
-        }
-        else
-        {
-          switch (x.FirstPersonFlag)
-          {
-            case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.firstPersonOnly:
-              if (x.GetRenderer(go.transform) is Renderer r)
-              {
-                // invisible
-                r.enabled = false;
-                runtime.VisibleRenderers.Remove(r);
-              }
-              break;
-
-            case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.auto:
-            // => Same as Both
-            case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.both:
-            case UniGLTF.Extensions.VRMC_vrm.FirstPersonType.thirdPersonOnly:
-              // do nothing
-              break;
-          }
-        }
-      }
-    }
-  }
 }

--- a/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
@@ -29,7 +29,7 @@ namespace UniVRM10
             }
         }
 
-        static int[] GetBonesThatHasAncestor(SkinnedMeshRenderer smr, Transform ancestor)
+        public static int[] GetBonesThatHasAncestor(SkinnedMeshRenderer smr, Transform ancestor)
         {
             var eraseBones = smr.bones
             .Where(x => x.Ancestor().Any(y => y == ancestor))

--- a/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
+++ b/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
@@ -290,6 +290,8 @@ namespace UniVRM10
                     }
                 }
             }
+
+            MeshIntegrationGroups.Clear();
         }
     }
 }

--- a/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
+++ b/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
@@ -251,7 +251,7 @@ namespace UniVRM10
                 {
                     var result = MeshIntegrator.Integrate(group, SplitByBlendShape
                         ? MeshIntegrator.BlendShapeOperation.Split
-                        : MeshIntegrator.BlendShapeOperation.None);
+                        : MeshIntegrator.BlendShapeOperation.Use);
                     results.Add(result);
 
                     result.AddIntegratedRendererTo(empty);
@@ -259,21 +259,13 @@ namespace UniVRM10
                     if (generateFirstPerson && group.Name == "auto")
                     {
                         Debug.Log("generateFirstPerson");
-                        var firstPersonBone = vrmInstance.Humanoid.Head;
-                        var task = VRM10ObjectFirstPerson.CreateErasedMeshAsync(
-                            result.IntegratedRenderer,
-                            firstPersonBone,
-                            new ImmediateCaller());
-                        task.Wait();
-
-                        if (task.Result != null)
+                        if (result.Integrated.Mesh != null)
                         {
-                            result.IntegratedRenderer.sharedMesh = task.Result;
-                            result.IntegratedRenderer.name = "auto.headless";
+                            ProcessFirstPerson(vrmInstance, result.Integrated);
                         }
-                        else
+                        if (result.IntegratedNoBlendShape.Mesh != null)
                         {
-                            Debug.LogWarning("no result");
+                            ProcessFirstPerson(vrmInstance, result.IntegratedNoBlendShape);
                         }
                     }
                 }
@@ -292,6 +284,26 @@ namespace UniVRM10
             }
 
             MeshIntegrationGroups.Clear();
+        }
+
+        void ProcessFirstPerson(Vrm10Instance vrmInstance, MeshInfo info)
+        {
+            var firstPersonBone = vrmInstance.Humanoid.Head;
+            var task = VRM10ObjectFirstPerson.CreateErasedMeshAsync(
+                info.IntegratedRenderer,
+                firstPersonBone,
+                new ImmediateCaller());
+            task.Wait();
+
+            if (task.Result != null)
+            {
+                info.IntegratedRenderer.sharedMesh = task.Result;
+                info.IntegratedRenderer.name = "auto.headless";
+            }
+            else
+            {
+                Debug.LogWarning("no result");
+            }
         }
     }
 }

--- a/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
+++ b/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
@@ -152,6 +152,23 @@ namespace UniVRM10
             }
         }
 
+        static GameObject GetOrCreateEmpty(GameObject go, string name)
+        {
+            foreach (var child in go.transform.GetChildren())
+            {
+                if (child.name == name
+                 && child.localPosition == Vector3.zero
+                 && child.localScale == Vector3.one
+                 && child.localRotation == Quaternion.identity)
+                {
+                    return child.gameObject;
+                }
+            }
+            var empty = new GameObject(name);
+            empty.transform.SetParent(go.transform, false);
+            return empty;
+        }
+
         public void Process(GameObject go)
         {
             var vrmInstance = go.GetComponent<Vrm10Instance>();
@@ -226,6 +243,8 @@ namespace UniVRM10
             }
 
             {
+                var empty = GetOrCreateEmpty(go, "mesh");
+
                 // TODO: UNDO            
                 var results = new List<MeshIntegrationResult>();
                 foreach (var group in copy)
@@ -235,7 +254,7 @@ namespace UniVRM10
                         : MeshIntegrator.BlendShapeOperation.None);
                     results.Add(result);
 
-                    result.AddIntegratedRendererTo(go);
+                    result.AddIntegratedRendererTo(empty);
 
                     if (generateFirstPerson && group.Name == "auto")
                     {

--- a/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
+++ b/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
@@ -181,7 +181,6 @@ namespace UniVRM10
 
             if (ForceUniqueName)
             {
-                // TODO: UNDO            
                 throw new NotImplementedException();
 
                 // 必用？

--- a/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
+++ b/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
@@ -169,7 +169,7 @@ namespace UniVRM10
             return empty;
         }
 
-        public void Process(GameObject go)
+        public List<GameObject> Process(GameObject go)
         {
             var vrmInstance = go.GetComponent<Vrm10Instance>();
             if (vrmInstance == null)
@@ -200,7 +200,8 @@ namespace UniVRM10
 
                 // TODO: update: spring
                 // TODO: update: constraint
-                // TODO: update: firstPoint offset
+                // TODO: update: firstPerson offset
+
                 // write back normalized transform to boneMap
                 BoneNormalizer.WriteBackResult(go, normalized, boneMap);
                 if (Application.isPlaying)
@@ -241,10 +242,10 @@ namespace UniVRM10
                 copy.AddRange(MeshIntegrationGroups);
             }
 
+            var newGo = new List<GameObject>();
             {
                 var empty = GetOrCreateEmpty(go, "mesh");
 
-                // TODO: UNDO            
                 var results = new List<MeshIntegrationResult>();
                 foreach (var group in copy)
                 {
@@ -253,7 +254,10 @@ namespace UniVRM10
                         : MeshIntegrator.BlendShapeOperation.Use);
                     results.Add(result);
 
-                    result.AddIntegratedRendererTo(empty);
+                    foreach (var created in result.AddIntegratedRendererTo(empty))
+                    {
+                        newGo.Add(created);
+                    }
 
                     if (generateFirstPerson && group.Name == "auto")
                     {
@@ -283,6 +287,8 @@ namespace UniVRM10
             }
 
             MeshIntegrationGroups.Clear();
+
+            return newGo;
         }
 
         void ProcessFirstPerson(Vrm10Instance vrmInstance, MeshInfo info)


### PR DESCRIPTION
#2169 の部品

`mesh bake` => `integrate > generate_firstperson_auto > split_by_blendshape`

という一連の処理です。

-  `generate_firstperson_auto` 整理
-  `split_by_blendshape` 追加
- undo の基本実装の追加

この次で Expression, SpringBone などへの影響を実装して完了予定です。

TODO: indexの調整だけで split を実装したので、未使用になった頂点を削除できる。
position, normal, uv, weight, joint, blendShape と indices への対応が必用。あとで。
