### PR TITLE
メニューの作業ミスを修正

### DIFF
--- a/Assets/VRM/Editor/VrmTopMenu.cs
+++ b/Assets/VRM/Editor/VrmTopMenu.cs
@@ -43,7 +43,7 @@ namespace VRM
         [MenuItem(UserMenuPrefix + "/" + VRMSpringBoneUtilityEditor.LOAD_MENU_NAME, true, 54)]
         private static bool LoadSpringBoneFromJsonValidation() => VRMSpringBoneUtilityEditor.LoadSpringBoneFromJsonValidation();
         [MenuItem(UserMenuPrefix + "/" + VRMSpringBoneUtilityEditor.LOAD_MENU_NAME, false, 54)]
-
+        private static void LoadSpringBoneFromJson() => VRMSpringBoneUtilityEditor.LoadSpringBoneFromJson();
 
 #if VRM_DEVELOP
         [MenuItem(DevelopmentMenuPrefix + "/Generate Serialization Code", false, 91)]


### PR DESCRIPTION
閉じカッコに属性を付ける判定になりエラーになる。
エラーの有無とは別にメニューが無くなっている。
