### PR TITLE
avatar 代入時に姿勢が変わる対策

### DIFF
--- a/Assets/VRM/Editor/Format/VRMEditorExporter.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorExporter.cs
@@ -199,12 +199,10 @@ namespace VRM
                 }
             }
 
-            // 正規化
             if (settings.PoseFreeze)
             {
-                // BoneNormalizer.Execute は Copy を作って正規化する。UNDO無用
-                target = VRMBoneNormalizer.Execute(target, settings.ForceTPose);
-                destroy.Add(target);
+                // 正規化
+                VRMBoneNormalizer.Execute(target, settings.ForceTPose);
             }
 
             var fp = target.GetComponent<VRMFirstPerson>();

--- a/Assets/VRM/Editor/Format/VRMHumanoidNormalizerMenu.cs
+++ b/Assets/VRM/Editor/Format/VRMHumanoidNormalizerMenu.cs
@@ -46,8 +46,7 @@ namespace VRM
         {
             var go = Selection.activeObject as GameObject;
 
-            // BoneNormalizer.Execute はコピーを正規化する。UNDO無用
-            Selection.activeGameObject = VRMBoneNormalizer.Execute(go, true);
+            VRMBoneNormalizer.Execute(go, true);
         }
     }
 }

--- a/Assets/VRM/Runtime/SkinnedMeshUtility/VRMBoneNormalizer.cs
+++ b/Assets/VRM/Runtime/SkinnedMeshUtility/VRMBoneNormalizer.cs
@@ -45,7 +45,7 @@ namespace VRM
         /// <param name="go">対象モデルのルート</param>
         /// <param name="forceTPose">強制的にT-Pose化するか</param>
         /// <returns>正規化済みのモデル</returns>
-        public static GameObject Execute(GameObject go, bool forceTPose)
+        public static void Execute(GameObject go, bool forceTPose)
         {
             //
             // T-Poseにする
@@ -67,18 +67,26 @@ namespace VRM
             }
 
             // Meshの焼きこみ
-            var newMesh = BoneNormalizer.NormalizeHierarchyFreezeMesh(go, true);
+            var newMeshMap = BoneNormalizer.NormalizeHierarchyFreezeMesh(go, true);
             // 焼いたMeshで置き換える
-            BoneNormalizer.Replace(go, newMesh, true, true);
+            BoneNormalizer.Replace(go, newMeshMap, true, true);
 
             // 新しいヒエラルキーからAvatarを作る
-            var newAnimator = go.GetComponent<Animator>();
-            var newAvatar = UniHumanoid.AvatarDescription.RecreateAvatar(newAnimator);
-            newAnimator.avatar = newAvatar;
+            var animator = go.GetComponent<Animator>();
+            var newAvatar = UniHumanoid.AvatarDescription.RecreateAvatar(animator);
 
-            // CopyVRMComponents(go, normalized, bMap);
+            // workaround: animator を作り直す
+            if (Application.isPlaying)
+            {
+                GameObject.Destroy(animator);
+            }
+            else
+            {
+                GameObject.DestroyImmediate(animator);
+            }
+            animator = go.AddComponent<Animator>();
 
-            return go;
+            animator.avatar = newAvatar;
         }
 
         /// <summary>

--- a/Assets/VRM_Samples/RuntimeExporterSample/VRMRuntimeExporter.cs
+++ b/Assets/VRM_Samples/RuntimeExporterSample/VRMRuntimeExporter.cs
@@ -141,17 +141,9 @@ namespace VRM.RuntimeExporterSample
         static byte[] ExportCustom(GameObject exportRoot, bool forceTPose = false)
         {
             // normalize
-            var target = VRMBoneNormalizer.Execute(exportRoot, forceTPose);
+            VRMBoneNormalizer.Execute(exportRoot, forceTPose);
 
-            try
-            {
-                return ExportSimple(target);
-            }
-            finally
-            {
-                // cleanup
-                GameObject.Destroy(target);
-            }
+            return ExportSimple(exportRoot);
         }
 
         void OnExported(UniGLTF.glTF vrm)


### PR DESCRIPTION
fixed #2201

```cs
animator.avatar = newAvatar
```

としたときに元の値を維持する？挙動があります。
そのため 旧avatar と newAvatar で元になる姿勢が異なる(例えば正規化)場合に姿勢が壊れます。
対策として、 Destory(Animator) して作り直します。

`v0.116` より前はヒエラルキーをコピーしていたため代入時の元の値を維持する挙動をたまたま回避できていたようです。
`v0.116` はコピーせずに同一のヒエラルキーで実行します。
