### PR TITLE
nodeにmatrixを使用したVRM0.xのロードを実施すると "Exception: matrix with translation" が発生する問題を解消する

### DIFF
--- a/Assets/VRM10/Runtime/Migration/MeshUpdater.cs
+++ b/Assets/VRM10/Runtime/Migration/MeshUpdater.cs
@@ -152,6 +152,9 @@ namespace UniVRM10
                 gltfNode.rotation = node.LocalRotation.ToFloat4();
                 gltfNode.scale = node.LocalScaling.ToFloat3();
 
+                // remove matrix properties because TRS is used
+                gltfNode.matrix = null;
+
                 if (gltfNode.mesh >= 0)
                 {
                     if (gltfNode.skin >= 0)


### PR DESCRIPTION
## 環境情報

 - UniVRM version: `v0.116.0`
 - Unity version: `Unity-2021.3.27f1`
 - OS: `Windows 10`

# 概要
nodeにmatrixを使用したVRM0.xのロードを実施すると "Exception: matrix with translation" が発生する問題がありましたため、対策案を提出させていただきます

- Migration後にnodeがmatrixとTRS両方保持することになって [こちら](https://github.com/vrm-c/UniVRM/blob/e3d4ea53e8002a60b8f13b607f21ba8359e61da2/Assets/VRM10/Runtime/IO/Vrm10ImportData.cs#L392) で `Exception: matrix with translation` が発生していました
- Migration時にTRS側が作成されているので、matrix側を除外するようにしています

# 問題の再現方法
- VRM10Viewerで [こちら](https://github.com/tsgcpp/UniVRM/blob/report_20240106/Tests/Models/vroid_a_0x_nodes_with_matrix/vroid_a_0x_nodes_with_matrix.vrm)のVRM0.x (nodeにmatrixを使用したVRM0.x) をロードすると再現します