### PR TITLE
Vrm10Instance生成後に非アクティブにしてそのままOnDestroy()が実施された場合にエラーとなる問題の対策

### DIFF
--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -95,6 +95,7 @@ namespace UniVRM10
             {
                 if (m_runtime == null)
                 {
+                    if (this == null) throw new MissingReferenceException("instance was destroyed");
                     m_runtime = new Vrm10Runtime(this, m_useControlRig);
                 }
                 return m_runtime;
@@ -138,7 +139,11 @@ namespace UniVRM10
 
         private void OnDestroy()
         {
-            Runtime.Dispose();
+            if (m_runtime != null)
+            {
+                m_runtime.Dispose();
+                m_runtime = null;
+            }
         }
 
         private void OnDrawGizmosSelected()


### PR DESCRIPTION
## 環境情報

 - UniVRM version: `v0.116.0`
 - Unity version: `Unity-2021.3.27f1`
 - OS: `Windows 10`

# 概要
- Vrm10Instance生成後に非アクティブにしてそのままOnDestroy()が実施されるとエラーになるようなので、対策案を提出させていただきます
- 以下の流れでエラーになるようです
  - `Vrm10Instance.OnDestory` がコールされた時点でGameObjectは破棄されている
  - 非アクティブのままだと `m_runtime` が生成されておらず、その状態で`Vrm10Instance.OnDestory`が発生すると`Runtime`コールで `m_runtime` の生成が動いてしまう
  - Vrm10Runtimeの生成はGameObjectや階層の編集が発生するため、`Cannot set the parent of the GameObject 'Runtime Control Rig' while its new parent 'VRM1' is being destroyed` のエラーが発生する

# 問題の再現方法
- https://github.com/tsgcpp/UniVRM/releases/tag/report_20240106 をcheckout
- `Assets/Report/Scenes/Report_ErrorWhenDestroyedWithoutEnabled_Vrm10Runtime.unity` を開いてPlayを実行