### PR TITLE
attributesのbufferViewは連続であるが、indicesのbufferViewがprimitivesの順番で連続ではないVRM0.xをロードするとエラーになる問題の対策

### DIFF
--- a/Assets/VRM10/Runtime/IO/Vrm10ImportData.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10ImportData.cs
@@ -320,7 +320,7 @@ namespace UniVRM10
             else
             {
                 // IndexBufferが連続して格納されていない => Int[] を作り直す
-                using (var indices = new NativeArray<byte>(totalCount * Marshal.SizeOf(typeof(int)), Allocator.Persistent))
+                var indices = m_data.NativeArrayManager.CreateNativeArray<byte>(totalCount * Marshal.SizeOf(typeof(int)));
                 {
                     var span = indices.Reinterpret<Int32>(1);
                     var offset = 0;

--- a/Assets/VRM10/Runtime/IO/Vrm10ImportData.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10ImportData.cs
@@ -255,7 +255,8 @@ namespace UniVRM10
         {
             var firstAccessor = Gltf.accessors[accessorIndices[0]];
             var firstView = Gltf.bufferViews[firstAccessor.bufferView.Value];
-            var start = firstView.byteOffset + firstAccessor.byteOffset;
+            var firstAccessorByteOffset = firstAccessor.byteOffset.GetValueOrDefault();
+            var start = firstView.byteOffset + firstAccessorByteOffset;
             var pos = start;
             foreach (var i in accessorIndices)
             {
@@ -264,18 +265,20 @@ namespace UniVRM10
                 {
                     throw new ArgumentException($"accessor.type: {current.type}");
                 }
+
                 if (firstAccessor.componentType != current.componentType)
                 {
                     return false;
                 }
 
                 var view = Gltf.bufferViews[current.bufferView.Value];
-                if (pos != view.byteOffset + current.byteOffset)
+                var currentAccessorByteOffset = current.byteOffset.GetValueOrDefault();
+                if (pos != view.byteOffset + currentAccessorByteOffset)
                 {
                     return false;
                 }
 
-                var begin = view.byteOffset + current.byteOffset;
+                var begin = view.byteOffset + currentAccessorByteOffset;
                 var byteLength = current.CalcByteSize();
 
                 pos += byteLength;

--- a/Assets/VRM10/Runtime/IO/Vrm10ImportData.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10ImportData.cs
@@ -272,6 +272,11 @@ namespace UniVRM10
                 }
 
                 var view = Gltf.bufferViews[current.bufferView.Value];
+                if (firstView.buffer != view.buffer)
+                {
+                    return false;
+                }
+
                 var currentAccessorByteOffset = current.byteOffset.GetValueOrDefault();
                 if (pos != view.byteOffset + currentAccessorByteOffset)
                 {


### PR DESCRIPTION
## 環境情報

 - UniVRM version: `v0.116.0`
 - Unity version: `Unity-2021.3.27f1`
 - OS: `Windows 10`

# 概要
タイトルの通りのエラーを確認しましたため、対策案を提出させていただきます。

2つの事象があり若干関連がありましたため、まとめて提出させていただきます。

# 問題1
以下の条件が揃ったVRM0.xを読み込むとエラーになりました

- `meshes[x].primitives[x]`にてattributesのbufferViewは連続であるが、indicesのbufferViewがprimitivesの順番で連続ではない
- `accessors[x].byteOffset`が指定されていない

この場合、indicesのbufferViewをaccessor経由で読み込む際に、本来はInteger型ではない領域までInteger型として読み込んでしまい、`ArgumentException: Index buffer element #5088 (value 1090921693) is out of bounds; mesh only has 4083 vertices.`のようなエラーが発生していました

## 前提知識
- glTFAccessor.byteOffsetは `int?` でOptional(Nullable)のため、`accessors[x].byteOffset`が指定されていない場合はnullとなる
- `int?` と `int` の演算は `int?`になる
- null + 1 = null となる (C#の仕様)
- null == null は true

## 問題発生までの流れ
- `var start = firstView.byteOffset + firstAccessor.byteOffset;` で `firstAccessor.byteOffset`がnullだった場合、`start`は必ずnullになる
- `var pos = start;` で `start` がnullの場合、`pos`もnullになる
- `if (pos != view.byteOffset + currentAccessorByteOffset)` でbufferの連続性を検証しているが、`currentAccessorByteOffset`側がnullだった場合、右辺と左辺両方nullになるため実際は連続出ない場合も連続であると判定される
- 連続であると判定されたため、本来連続ではないindicesのbufferViewをまとめてロードしてしまいエラーとなる

## 問題の再現方法
- VRM10Viewerで [こちらのVRM](https://github.com/tsgcpp/UniVRM/blob/report_20240106/Tests/Models/vroid_a_0x_face_indices_not_continuous_without_accessor_bufferoffset/vroid_a_0x_face_indices_not_continuous_without_accessor_bufferoffset.vrm)を読み込む
  - ↑で述べた条件に合致するように作成したVRMになります

## 対応案
- `GetValueOrDefault()`を使用して、`accessors[x].byteOffset`が指定されていない場合は、byteOffsetをdefaultの0として処理する

# 問題2
`meshes[x].primitives[x]`にてattributesのbufferViewは連続であるが、indicesのbufferViewがprimitivesの順番で連続ではないVRM0.xをロードすると ``Exception: System.ObjectDisposedException: The Unity.Collections.NativeArray`1[System.Byte] has been deallocated, it is not allowed to access it`` が発生する。

厳密には問題1と分けることができる問題でしたが、`if (AccessorsIsContinuous(accessorIndices))`のelse側で関連があったため解消案を一緒に提出させていただきます。

## 問題発生までの流れ
- `var indices = new NativeArray<byte>(totalCount * Marshal.SizeOf(typeof(int)), Allocator.Persistent)` に `using`宣言されているためスコープを抜けた時点で `NativeArray` が破棄される
- 実際には`Mesh`生成時に使用される `indices` であるがスコープを抜けた時点で破棄されているため、上記のObjectDisposedExceptionが発生した

## 問題の再現方法
- VRM10Viewerで [こちらのVRM](https://github.com/tsgcpp/UniVRM/blob/report_20240106/Tests/Models/vroid_a_0x_face_indices_not_continuous/vroid_a_0x_face_indices_not_continuous.vrm)を読み込む
  - ↑で述べたindices側だけbufferViewが連続になっておらず、`float` のbufferViewの領域がindicesとindicesの間に挟まる形になっています

## 対応案
- NativeArray生成時に `using` 宣言をしない
- `m_data.NativeArrayManager.CreateNativeArray`でNativeArrayを生成し、リソース管理をNativeArrayManagerに任せる

以上です。長文失礼しました。