### PR TITLE
VRM0.xでMeshAnnotationsのmeshに-1が指定されていると一人称メッシュ作成時にNotImplementedExceptionが発生する問題を回避する

### DIFF
--- a/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
+++ b/Assets/VRM10/Runtime/Migration/MigrationVrmFirstPersonAndLookAt.cs
@@ -70,6 +70,10 @@ namespace UniVRM10
             if (meshAnnotationJsonNode.TryGet(key, out var meshIndexJsonNode))
             {
                 var meshIndex = meshIndexJsonNode.GetInt32();
+                if (meshIndex < 0)
+                {
+                    return default;
+                }
 
                 // NOTE: VRM 1.0 では glTF の Node Index を記録するため、それに変換する.
                 // TODO: mesh が共有されたノードの場合はどうなる？ 0x の場合はどうなっていたかを調べて挙動を追従する.


### PR DESCRIPTION
## 環境情報

 - UniVRM version: `v0.116.0`
 - Unity version: `Unity-2021.3.27f1`
 - OS: `Windows 10`

# 概要
MeshAnnotationのmeshに-1が指定されているとNotImplementedExceptionが発生することを確認したため、その問題を回避案を提出させていただきます。

問題の流れは以下です。

- Migration時にmeshAnnotationsのmeshに-1が指定されているVRM0.xをロードする
- `glTFNode.node`の初期値 -1 と一致してしまいMeshがあるNodeとして扱われる
- Meshが存在しないNodeにMeshAnnotationsを設定しようとして [ここ](https://github.com/vrm-c/UniVRM/blob/e3d4ea53e8002a60b8f13b607f21ba8359e61da2/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs#L125)に入り、`NotImplementedException` が発生する

```json
        "meshAnnotations": [
          {
            "firstPersonFlag": "Auto",
            "mesh": 0
          },
          {
            "firstPersonFlag": "Auto",
            "mesh": -1
          },
          {
            "firstPersonFlag": "Auto",
            "mesh": 2
          }
        ]
```

UniVRM以外のツールでVRM0.xで上記のようなVRMが作られる場合が有るようでした。

# 問題の再現方法
- https://github.com/tsgcpp/UniVRM/releases/tag/report_20240106 をcheckout
- `Assets/Report/Scenes/Report_ErrorWithMeshAnnotationMinusOne_Vrm10LoadWithFirstPerson.unity` を開いてPlayを実行

# 対応案
- meshAnnotationsのmeshに0未満が指定されていた場合は処理しない