### PR TITLE
ColliderGroupsはあるがColliderが全く存在しない場合にVRM0.xの読み込みで発生するエラーを解消する

### DIFF
--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -539,7 +539,11 @@ namespace UniVRM10
                         throw new Vrm10Exception("unknown shape");
                     }
                 }
+            }
 
+            // colliderGroup
+            if (gltfVrmSpringBone.ColliderGroups != null)
+            {
                 var secondary = Root.transform.Find("secondary");
                 if (secondary == null)
                 {
@@ -547,21 +551,23 @@ namespace UniVRM10
                     secondary.SetParent(Root.transform, false);
                 }
 
-                // colliderGroup
-                if (gltfVrmSpringBone.ColliderGroups != null)
+                foreach (var g in gltfVrmSpringBone.ColliderGroups)
                 {
-                    foreach (var g in gltfVrmSpringBone.ColliderGroups)
-                    {
-                        var colliderGroup = secondary.gameObject.AddComponent<VRM10SpringBoneColliderGroup>();
-                        controller.SpringBone.ColliderGroups.Add(colliderGroup);
+                    var colliderGroup = secondary.gameObject.AddComponent<VRM10SpringBoneColliderGroup>();
+                    controller.SpringBone.ColliderGroups.Add(colliderGroup);
 
-                        if (g != null && g.Colliders != null)
+                    if (g != null && g.Colliders != null)
+                    {
+                        foreach (var c in g.Colliders)
                         {
-                            foreach (var c in g.Colliders)
+                            if (c < 0 || c >= colliders.Count)
                             {
-                                var collider = colliders[c];
-                                colliderGroup.Colliders.Add(collider);
+                                // 不正なindexの場合は無視する
+                                continue;
                             }
+
+                            var collider = colliders[c];
+                            colliderGroup.Colliders.Add(collider);
                         }
                     }
                 }


### PR DESCRIPTION
## 環境情報

 - UniVRM version: `v0.117.0`
 - Unity version: `Unity-2021.3.27f1`
 - OS: `Windows 10`

# 概要
ColliderGroupsはあるがColliderが全く存在しない場合にVRM0.xの読み込みで[こちらの行](https://github.com/vrm-c/UniVRM/blob/88f2c11d5cff8d3ebb2e25acf67521a9feb9be3d/Assets/VRM10/Runtime/IO/Vrm10Importer.cs#L590)にて`ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
` のエラーが発生するを確認しましたため、その対応案を提出します。

以下のように`VRMSpringBone`の`ColliderGroups`に`VRMSpringBoneColliderGroup`が指定されているが、その `Colliders`の要素数が0だった場合が該当します。

![スクリーンショット 2024-01-11 231530](https://github.com/vrm-c/UniVRM/assets/19503967/c9915bae-b9f4-48cf-a68c-a990f7584886)

上記の条件に合致すると Vrm10Importer.csの518行目の `if (gltfVrmSpringBone.Colliders != null)` 内の処理が実施されず、結果的に `VRM10SpringBoneColliderGroup`の作成とそのプロパティ `Colliders` への登録が実施されないことで、後のSpringBoneの読み込みで `ArgumentOutOfRangeException` に繋がったようです。

対応としては、glTF内にColliderがなくてもColliderGroupがあれば `VRM10SpringBoneColliderGroup`が生成されるようにして、 上記問題を回避するようにしています。

# 問題の再現方法
- VRM10Viewerで [こちらのVRM](https://github.com/tsgcpp/UniVRM/blob/report_20240106/Tests/Models/vroid_a_0x_springbone_with_colliderless_collidergroup/vroid_a_0x_springbone_with_colliderless_collidergroup.vrm) をロードする
  - 概要で述べた条件を満たすVRMです

# 備考
今回の修正に際して、GameObject `secondary` が生成される条件も少し変わっておりますため、その点についても問題がないかも合わせてご判断いただければと思います。

変更前: VRM内にCollidersが存在する場合(= `if (gltfVrmSpringBone.ColliderGroups != null)`)
変更後: VRM内にColliderGroupsが存在する場合(= `if (gltfVrmSpringBone.ColliderGroups != null)`)