### PR TITLE
非Skinned MeshかつMeshAnnotationが指定されていないメッシュがHead直下にある場合にLayerが設定されない現象を解消する

### DIFF
--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -493,7 +493,7 @@ namespace UniVRM10
                 }
             }
             // 設定の無い renderer に auto を割り当てる
-            foreach (var smr in Root.GetComponentsInChildren<SkinnedMeshRenderer>())
+            foreach (var smr in Root.GetComponentsInChildren<Renderer>())
             {
                 var relative = smr.transform.RelativePathFrom(Root.transform);
                 if (!vrm.FirstPerson.Renderers.Any(x => x.Renderer == relative))


### PR DESCRIPTION
## 環境情報

 - UniVRM version: `v0.117.0`
 - Unity version: `Unity-2021.3.27f1`
 - OS: `Windows 10`

# 概要
非Skinned MeshかつMeshAnnotationが指定されていないメッシュがHead直下にある場合にLayerが設定されない現象を確認しましたため、その対応案を提出させていただきます。

`instance.Vrm.FirstPerson.SetupAsync` を実施した場合に、`SkinnedMeshRenderer`の場合はLayerが設定されますが、`MeshRenderer`の場合はLayerが適用されていませんでした。

MeshAnnotationを `auto` として適用する処理の対象コンポーネントが`SkinnedMeshRenderer`になっており、`MeshRenderer`が対象からはずれていることが原因と思われます。

## 問題の再現方法
- https://github.com/tsgcpp/UniVRM/releases/tag/report_20240106 をcheckout
- `Assets/Report/Scenes/Report_MeshAnnotationAutoToMeshUnderHead_Vrm10LoadWithFirstPerson.unity` を開いてPlayを実行
  - VRMロード後に`instance.Vrm.FirstPerson.SetupAsync` を実施しています

Head直下のメッシュのGameObjectのLayerが以下のように`Default`のままになっていることが確認できます。GameViewにレンダリングするCameraのCullingMaskは `VRMThirdPersonOnly` のみを指定しています。

![スクリーンショット 2024-01-11 233751](https://github.com/vrm-c/UniVRM/assets/19503967/2d41aa7d-67c1-44e2-80dc-cdee0b17d4f3)
