### PR TITLE
[提案] RuntimeGltfInstance.OnDestroy時のDebug.Logを削除する

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs
@@ -223,7 +223,6 @@ namespace UniGLTF
 
         void OnDestroy()
         {
-            Debug.Log("UnityResourceDestroyer.OnDestroy");
             foreach (var (_, obj) in _resources)
             {
                 UnityObjectDestroyer.DestroyRuntimeOrEditor(obj);


### PR DESCRIPTION
# 概要
RuntimeGltfInstance.OnDestroy時のDebug.Logの削除を提案させていただきます。

ロードしたVRMのインスタンスが破棄されたときに発生するログのようですが、情報が `UnityResourceDestroyer.OnDestroy` の文字列とスタックトレースのみで用途があまりなさそうと思ったため、スタックトレース生成を含めたログ出力を回避するために削除を提案させていただきます。