### PR TITLE
Add Humanoid as RequireComponent

### DIFF
--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -16,6 +16,7 @@ namespace UniVRM10
     [AddComponentMenu("VRM10/VRMInstance")]
     [DisallowMultipleComponent]
     [DefaultExecutionOrder(11000)]
+    [RequireComponent(typeof(UniHumanoid.Humanoid))]
     public class Vrm10Instance : MonoBehaviour
     {
         /// <summary>


### PR DESCRIPTION
全体を見渡したところインポート処理・マイグレーション処理ではHumanoidコンポーネントが事前に追加されている影響で、VR10Instanceのm_humanoidに依存するコードが多いようです。そのためHumanoidをRequireComponentに指定するのが良いかなと思いました。なお現在はUnityEditorでVRM 1系セットアップをして再生ボタンを押すとHumanoidを追加しないとエラーが出ます。

![image](https://github.com/vrm-c/UniVRM/assets/20571538/f4827268-cdd5-4d77-9f3d-86151edfc059)
