### PR TITLE
[VRM10] FirstPerson の修正

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/RuntimeGltfInstance.cs
@@ -221,6 +221,11 @@ namespace UniGLTF
             Destroy(oldResource);
         }
 
+        public void AddResource<T>(T resource) where T : UnityEngine.Object
+        {
+            _resources.Add((SubAssetKey.Create(resource), resource));
+        }
+
         void OnDestroy()
         {
             foreach (var (_, obj) in _resources)

--- a/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
@@ -93,19 +93,23 @@ namespace UniVRM10
                     {
                         if (x.GetRenderer(go.transform) is SkinnedMeshRenderer smr)
                         {
-                            // オリジナルのモデルを３人称用にする                                
-                            smr.gameObject.layer = layer.ThirdPersonOnly;
-
                             // 頭を取り除いた複製モデルを作成し、１人称用にする
                             var headless = await CreateHeadlessMeshAsync(smr, firstPersonBone, awaitCaller);
                             if (headless != null)
                             {
+                                // オリジナルのモデルを３人称用にする                                
+                                smr.gameObject.layer = layer.ThirdPersonOnly;
+
                                 headless.gameObject.layer = layer.FirstPersonOnly;
                                 headless.transform.SetParent(smr.transform, false);
                                 if (runtime != null)
                                 {
                                     runtime.AddRenderer(headless);
                                 }
+                            }
+                            else
+                            {
+                                // ヘッドレスを作成しなかった場合は何もしない => both と同じ
                             }
                         }
                         else if (x.GetRenderer(go.transform) is MeshRenderer mr)

--- a/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
@@ -104,6 +104,7 @@ namespace UniVRM10
                                 headless.transform.SetParent(smr.transform, false);
                                 if (runtime != null)
                                 {
+                                    runtime.AddResource(headless.sharedMesh);
                                     runtime.AddRenderer(headless);
                                 }
                             }

--- a/Assets/VRM10_Samples/VRM10FirstPersonSample/VRM10RuntimeLoader.cs
+++ b/Assets/VRM10_Samples/VRM10FirstPersonSample/VRM10RuntimeLoader.cs
@@ -86,10 +86,12 @@ namespace UniVRM10.FirstPersonSample
 
         async Task<Vrm10Instance> LoadAsync(string path, VRMShaders.IAwaitCaller awaitCaller)
         {
-            var instance = await Vrm10.LoadPathAsync(path, awaitCaller: awaitCaller);
+            var instance = await Vrm10.LoadPathAsync(path, awaitCaller: awaitCaller, showMeshes: false);
 
             // VR用 FirstPerson 設定
             await instance.Vrm.FirstPerson.SetupAsync(instance.gameObject, awaitCaller);
+
+            instance.GetComponent<RuntimeGltfInstance>().ShowMeshes();
 
             return instance;
         }


### PR DESCRIPTION
fixed #2209 

- headless モデルのリソース破棄
- auto で headless を作成する必要が無かった場合は both
- firstperson sample の ShowMesh の呼び方

#2209 の修正が主でしたが、関連して問題がある部分も修正しました。
