### PR TITLE
Create UnityPackage Action でとりあえず EditMode Tests まで走らせる

### DIFF
--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -62,6 +62,8 @@ jobs:
     - name: Run Editor Tests
       id: run-edit-mode-tests
       run: |
+        echo "Run Editor Tests..."
+        # RunEditModeTests の実行の結果、終了コードが 0 でない場合でもテストの結果を表示したいので set +e して一時的に回避する
         set +e
         "${{ needs.detect-unity-version.outputs.unity-editor-executable }}" \
           -batchmode \
@@ -72,9 +74,10 @@ jobs:
         RET=$?
         set -e
 
+        echo "TestRunnerLog:"
         cat output.log | sed -n -E "s/^\[\[TestRunnerLog\]\] //p" | echo
 
-        if [${RET} -eq 0]; then
+        if [ ${RET} -eq 0 ]; then
           echo "Test succeeded."
           exit 0
         else

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -34,6 +34,14 @@ jobs:
       run: |
         PROJECT_VERSION_PATH="${UNITY_PROJECT_PATH}/ProjectSettings/ProjectVersion.txt"
 
+        if type yq > /dev/null 2>&1; then
+          echo "yq is already installed."
+        else
+          echo "yq is not installed."
+          echo "install yq..."
+          winget install --silent --id MikeFarah.yq
+        fi
+
         UNITY_VERSION_RAW=`cat ${PROJECT_VERSION_PATH} | yq .m_EditorVersionWithRevision`
         UNITY_VERSION=`echo ${UNITY_VERSION_RAW} | sed -E "s/^(\S+)\s+\((\S+)\)$/\1/"`
         UNITY_CHANGESET=`echo ${UNITY_VERSION_RAW} | sed -E "s/^(\S+)\s+\((\S+)\)$/\2/"`

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -2,6 +2,9 @@ name: Create UnityPackage
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - workflow-wip
 
 env:
   UNITY_PROJECT_PATH: .
@@ -24,9 +27,10 @@ jobs:
     needs: checkout
     runs-on: [self-hosted, Windows, X64, Unity]
     outputs:
-      unity-editor-executable: ${{ steps.unity-editor-installation-check.outputs.unity-editor-executable }}
+      unity-editor-executable: ${{ steps.check-unity-editor-installation.outputs.unity-editor-executable }}
     steps:
-    - id: get-project-unity-version
+    - name: Get Project Unity Version
+      id: get-project-unity-version
       run: |
         PROJECT_VERSION_PATH="${UNITY_PROJECT_PATH}/ProjectSettings/ProjectVersion.txt"
 
@@ -34,7 +38,8 @@ jobs:
         UNITY_VERSION=`echo ${UNITY_VERSION_RAW} | sed -E "s/^(\S+)\s+\((\S+)\)$/\1/"`
         UNITY_CHANGESET=`echo ${UNITY_VERSION_RAW} | sed -E "s/^(\S+)\s+\((\S+)\)$/\2/"`
 
-    - id: unity-editor-installation-check
+    - name: Check Unity Editor Installation
+      id: check-unity-editor-installation
       run: |
         UNITY_HUB="C:\Program Files\Unity Hub\Unity Hub.exe"
 
@@ -60,7 +65,8 @@ jobs:
     needs: detect-unity-version
     runs-on: [self-hosted, Windows, X64, Unity]
     steps:
-    - id: run
+    - name: Run Editor Tests
+      id: run-editor-tests
       run: |
         "${{ needs.detect-unity-version.outputs.unity-editor-executable }}" \
           -quit \

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -55,21 +55,19 @@ jobs:
 
         echo "unity-editor-executable=${UNITY_EDITOR_EXECUTABLE}" >> "${GITHUB_OUTPUT}"
 
-  run-editor-tests:
+  run-edit-mode-tests:
     needs: detect-unity-version
     runs-on: [self-hosted, Windows, X64, Unity]
     steps:
     - name: Run Editor Tests
-      id: run-editor-tests
+      id: run-edit-mode-tests
       run: |
         "${{ needs.detect-unity-version.outputs.unity-editor-executable }}" \
-          -quit \
           -batchmode \
-          -nographics \
           -silent-crashes \
-          -logFile \
           -projectPath "${UNITY_PROJECT_PATH}" \
-          -executeMethod "UniGLTF.TestRunner.RunEditModeTests"
+          -executeMethod "UniGLTF.TestRunner.RunEditModeTests" \
+          -logFile output.log
         
         echo $?
 

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -69,9 +69,8 @@ jobs:
           -silent-crashes \
           -logFile \
           -projectPath "${UNITY_PROJECT_PATH}" \
-          -runEditorTests \
-          -editorTestsResultFile "${UNITY_PROJECT_PATH}/EditorTestResults.xml"
+          -executeMethod "UniGLTF.TestRunner.RunEditModeTests"
         
-        cat "${UNITY_PROJECT_PATH}/EditorTestResults.xml"
+        echo $?
 
 

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -34,17 +34,8 @@ jobs:
       run: |
         PROJECT_VERSION_PATH="${UNITY_PROJECT_PATH}/ProjectSettings/ProjectVersion.txt"
 
-        if type yq > /dev/null 2>&1; then
-          echo "yq is already installed."
-        else
-          echo "yq is not installed."
-          echo "install yq..."
-          winget install --silent --id MikeFarah.yq
-        fi
-
-        UNITY_VERSION_RAW=`cat ${PROJECT_VERSION_PATH} | yq .m_EditorVersionWithRevision`
-        UNITY_VERSION=`echo ${UNITY_VERSION_RAW} | sed -E "s/^(\S+)\s+\((\S+)\)$/\1/"`
-        UNITY_CHANGESET=`echo ${UNITY_VERSION_RAW} | sed -E "s/^(\S+)\s+\((\S+)\)$/\2/"`
+        UNITY_VERSION=`cat ${PROJECT_VERSION_PATH} | sed -n -E "s/^m_EditorVersion:\s+//p" | head`
+        UNITY_CHANGESET=`cat ${PROJECT_VERSION_PATH} | sed -n -E "s/^m_EditorVersionWithRevision:\s+\S+\s+\((\S+)\)/\1/p" | head`
 
     - name: Check Unity Editor Installation
       id: check-unity-editor-installation
@@ -52,7 +43,7 @@ jobs:
         UNITY_HUB="C:\Program Files\Unity Hub\Unity Hub.exe"
 
         UNITY_EDITOR_EXECUTABLE=`"${UNITY_HUB}" -- --headless editors --installed | \
-          sed -n -e "s/^${UNITY_VERSION} , installed at //p" | \
+          sed -n -E "s/^${UNITY_VERSION} , installed at //p" | \
           head`
 
         if [ -z "${UNITY_EDITOR_EXECUTABLE}" ]; then

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -30,41 +30,25 @@ jobs:
       unity-editor-executable: ${{ steps.check-unity-editor-installation.outputs.unity-editor-executable }}
     steps:
     - name: Get Project Unity Version
-      id: get-project-unity-version
-      run: |
-        PROJECT_VERSION_PATH="${UNITY_PROJECT_PATH}/ProjectSettings/ProjectVersion.txt"
-
-        if type yq > /dev/null 2>&1; then
-          echo "yq is already installed."
-        else
-          echo "yq is not installed."
-          echo "install yq..."
-          winget install --silent --id MikeFarah.yq
-        fi
-
-        UNITY_VERSION_RAW=`cat ${PROJECT_VERSION_PATH} | yq .m_EditorVersionWithRevision`
-        UNITY_VERSION=`echo ${UNITY_VERSION_RAW} | sed -E "s/^(\S+)\s+\((\S+)\)$/\1/"`
-        UNITY_CHANGESET=`echo ${UNITY_VERSION_RAW} | sed -E "s/^(\S+)\s+\((\S+)\)$/\2/"`
+      id: project-unity-version
+      uses: mikefarah/yq@v4
+      with:
+        cmd: yq '.m_EditorVersion' ${{ env.UNITY_PROJECT_PATH }}/ProjectSettings/ProjectVersion.txt
 
     - name: Check Unity Editor Installation
       id: check-unity-editor-installation
       run: |
         UNITY_HUB="C:\Program Files\Unity Hub\Unity Hub.exe"
+        UNITY_VERSION="${{ steps.project-unity-version.outputs.result }}"
 
         UNITY_EDITOR_EXECUTABLE=`"${UNITY_HUB}" -- --headless editors --installed | \
           sed -n -e "s/^${UNITY_VERSION} , installed at //p" | \
           head`
 
         if [ -z "${UNITY_EDITOR_EXECUTABLE}" ]; then
+          # コマンドラインからのインストールは UnityHub 3.7.0 時点では UAC 必須で難しい
           echo "Unity ${UNITY_VERSION} is not installed."
           exit 1
-
-          # コマンドラインからのインストールは Unity 3.7.0 時点では UAC 必須で難しい
-          UNITY_INSTALL_COMMAND="\"${UNITY_HUB}\" -- --headless install \
-            --version ${UNITY_VERSION} \
-            --changeset ${UNITY_CHANGESET} \
-            --module windows-il2cpp \
-            --childModules"
         fi
 
         echo "unity-editor-executable=\"${UNITY_EDITOR_EXECUTABLE}\"" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -59,10 +59,10 @@ jobs:
     needs: detect-unity-version
     runs-on: [self-hosted, Windows, X64, Unity]
     steps:
-    - name: Run Editor Tests
+    - name: Run EditMode Tests
       id: run-edit-mode-tests
       run: |
-        echo "Run Editor Tests..."
+        echo "Run EditMode Tests..."
         # RunEditModeTests の実行の結果、終了コードが 0 でない場合でもテストの結果を表示したいので set +e して一時的に回避する
         set +e
         "${{ needs.detect-unity-version.outputs.unity-editor-executable }}" \
@@ -74,8 +74,8 @@ jobs:
         RET=$?
         set -e
 
-        echo "TestRunnerLog:"
-        cat output.log | sed -n -E "s/^\[\[TestRunnerLog\]\] //p" | echo
+        echo "Output Log..."
+        cat output.log | egrep "^\[\[TestRunnerLog\]\]"
 
         if [ ${RET} -eq 0 ]; then
           echo "Test succeeded."

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -35,11 +35,11 @@ jobs:
         PROJECT_VERSION_PATH="${UNITY_PROJECT_PATH}/ProjectSettings/ProjectVersion.txt"
         UNITY_HUB="C:\Program Files\Unity Hub\Unity Hub.exe"
 
-        UNITY_VERSION=`cat ${PROJECT_VERSION_PATH} | sed -n -E "s/^m_EditorVersion:\s+//p" | head`
-        UNITY_CHANGESET=`cat ${PROJECT_VERSION_PATH} | sed -n -E "s/^m_EditorVersionWithRevision:\s+\S+\s+\((\S+)\)/\1/p" | head`
+        UNITY_VERSION=`cat ${PROJECT_VERSION_PATH} | sed -n -E "s/^m_EditorVersion:\s+//p" | head -n 1`
+        UNITY_CHANGESET=`cat ${PROJECT_VERSION_PATH} | sed -n -E "s/^m_EditorVersionWithRevision:\s+\S+\s+\((\S+)\)/\1/p" | head -n 1`
         UNITY_EDITOR_EXECUTABLE=`"${UNITY_HUB}" -- --headless editors --installed | \
           sed -n -E "s/^${UNITY_VERSION} , installed at //p" | \
-          head`
+          head -n 1`
 
         if [ -z "${UNITY_EDITOR_EXECUTABLE}" ]; then
           echo "Unity ${UNITY_VERSION} is not installed."
@@ -62,13 +62,26 @@ jobs:
     - name: Run Editor Tests
       id: run-edit-mode-tests
       run: |
+        set +e
         "${{ needs.detect-unity-version.outputs.unity-editor-executable }}" \
           -batchmode \
           -silent-crashes \
           -projectPath "${UNITY_PROJECT_PATH}" \
           -executeMethod "UniGLTF.TestRunner.RunEditModeTests" \
           -logFile output.log
-        
-        echo $?
+        RET=$?
+        set -e
+
+        cat output.log | sed -n -E "s/^\[\[TestRunnerLog\]\] //p" | echo
+
+        if [${RET} -eq 0]; then
+          echo "Test succeeded."
+          exit 0
+        else
+          echo "Test failed."
+          exit 1
+        fi
+
+
 
 

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -30,25 +30,41 @@ jobs:
       unity-editor-executable: ${{ steps.check-unity-editor-installation.outputs.unity-editor-executable }}
     steps:
     - name: Get Project Unity Version
-      id: project-unity-version
-      uses: mikefarah/yq@v4
-      with:
-        cmd: yq '.m_EditorVersion' ${{ env.UNITY_PROJECT_PATH }}/ProjectSettings/ProjectVersion.txt
+      id: get-project-unity-version
+      run: |
+        PROJECT_VERSION_PATH="${UNITY_PROJECT_PATH}/ProjectSettings/ProjectVersion.txt"
+
+        if type yq > /dev/null 2>&1; then
+          echo "yq is already installed."
+        else
+          echo "yq is not installed."
+          echo "install yq..."
+          winget install --silent --id MikeFarah.yq
+        fi
+
+        UNITY_VERSION_RAW=`cat ${PROJECT_VERSION_PATH} | yq .m_EditorVersionWithRevision`
+        UNITY_VERSION=`echo ${UNITY_VERSION_RAW} | sed -E "s/^(\S+)\s+\((\S+)\)$/\1/"`
+        UNITY_CHANGESET=`echo ${UNITY_VERSION_RAW} | sed -E "s/^(\S+)\s+\((\S+)\)$/\2/"`
 
     - name: Check Unity Editor Installation
       id: check-unity-editor-installation
       run: |
         UNITY_HUB="C:\Program Files\Unity Hub\Unity Hub.exe"
-        UNITY_VERSION="${{ steps.project-unity-version.outputs.result }}"
 
         UNITY_EDITOR_EXECUTABLE=`"${UNITY_HUB}" -- --headless editors --installed | \
           sed -n -e "s/^${UNITY_VERSION} , installed at //p" | \
           head`
 
         if [ -z "${UNITY_EDITOR_EXECUTABLE}" ]; then
-          # コマンドラインからのインストールは UnityHub 3.7.0 時点では UAC 必須で難しい
           echo "Unity ${UNITY_VERSION} is not installed."
           exit 1
+
+          # コマンドラインからのインストールは Unity 3.7.0 時点では UAC 必須で難しい
+          UNITY_INSTALL_COMMAND="\"${UNITY_HUB}\" -- --headless install \
+            --version ${UNITY_VERSION} \
+            --changeset ${UNITY_CHANGESET} \
+            --module windows-il2cpp \
+            --childModules"
         fi
 
         echo "unity-editor-executable=\"${UNITY_EDITOR_EXECUTABLE}\"" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -27,21 +27,16 @@ jobs:
     needs: checkout
     runs-on: [self-hosted, Windows, X64, Unity]
     outputs:
-      unity-editor-executable: ${{ steps.check-unity-editor-installation.outputs.unity-editor-executable }}
+      unity-editor-executable: ${{ steps.detect-unity-version.outputs.unity-editor-executable }}
     steps:
-    - name: Get Project Unity Version
-      id: get-project-unity-version
+    - name: Detect Unity Version
+      id: detect-unity-version
       run: |
         PROJECT_VERSION_PATH="${UNITY_PROJECT_PATH}/ProjectSettings/ProjectVersion.txt"
+        UNITY_HUB="C:\Program Files\Unity Hub\Unity Hub.exe"
 
         UNITY_VERSION=`cat ${PROJECT_VERSION_PATH} | sed -n -E "s/^m_EditorVersion:\s+//p" | head`
         UNITY_CHANGESET=`cat ${PROJECT_VERSION_PATH} | sed -n -E "s/^m_EditorVersionWithRevision:\s+\S+\s+\((\S+)\)/\1/p" | head`
-
-    - name: Check Unity Editor Installation
-      id: check-unity-editor-installation
-      run: |
-        UNITY_HUB="C:\Program Files\Unity Hub\Unity Hub.exe"
-
         UNITY_EDITOR_EXECUTABLE=`"${UNITY_HUB}" -- --headless editors --installed | \
           sed -n -E "s/^${UNITY_VERSION} , installed at //p" | \
           head`

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -53,7 +53,7 @@ jobs:
             --childModules"
         fi
 
-        echo "unity-editor-executable=\"${UNITY_EDITOR_EXECUTABLE}\"" >> "${GITHUB_OUTPUT}"
+        echo "unity-editor-executable=${UNITY_EDITOR_EXECUTABLE}" >> "${GITHUB_OUTPUT}"
 
   run-editor-tests:
     needs: detect-unity-version

--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -77,7 +77,7 @@ jobs:
         echo "Output Log..."
         cat output.log | egrep "^\[\[TestRunnerLog\]\]"
 
-        if [ ${RET} -eq 0 ]; then
+        if [ ${RET:-1} -eq 0 ]; then
           echo "Test succeeded."
           exit 0
         else

--- a/Assets/UniGLTF/Editor/TestRunner.meta
+++ b/Assets/UniGLTF/Editor/TestRunner.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aa6bba67bdf924544955525c74d8c99a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniGLTF/Editor/TestRunner/TestRunner.cs
+++ b/Assets/UniGLTF/Editor/TestRunner/TestRunner.cs
@@ -9,6 +9,7 @@ namespace UniGLTF
     {
         public static void RunEditModeTests()
         {
+            Debug.Log("Edit Mode Tests Started.");
             var testRunnerApi = ScriptableObject.CreateInstance<TestRunnerApi>();
             testRunnerApi.RegisterCallbacks(new TestCallback());
             testRunnerApi.Execute(new ExecutionSettings(new Filter
@@ -28,6 +29,7 @@ namespace UniGLTF
                 Debug.Log($"Failed Test Count: {result.FailCount}");
                 if (Application.isBatchMode)
                 {
+                    EditorApplication.Exit(1);
                     EditorApplication.Exit(result.FailCount > 0 ? 1 : 0);
                 }
             }

--- a/Assets/UniGLTF/Editor/TestRunner/TestRunner.cs
+++ b/Assets/UniGLTF/Editor/TestRunner/TestRunner.cs
@@ -1,0 +1,44 @@
+
+using UnityEditor;
+using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
+
+namespace UniGLTF
+{
+    public static class TestRunner
+    {
+        public static void RunEditModeTests()
+        {
+            var testRunnerApi = ScriptableObject.CreateInstance<TestRunnerApi>();
+            testRunnerApi.RegisterCallbacks(new TestCallback());
+            testRunnerApi.Execute(new ExecutionSettings(new Filter
+            {
+                testMode = TestMode.EditMode,
+            }));
+        }
+
+        private class TestCallback : ICallbacks
+        {
+            public void RunStarted(ITestAdaptor testsToRun)
+            {
+            }
+
+            public void RunFinished(ITestResultAdaptor result)
+            {
+                Debug.Log($"Failed Test Count: {result.FailCount}");
+                if (Application.isBatchMode)
+                {
+                    EditorApplication.Exit(result.FailCount > 0 ? 1 : 0);
+                }
+            }
+
+            public void TestStarted(ITestAdaptor test)
+            {
+            }
+
+            public void TestFinished(ITestResultAdaptor result)
+            {
+            }
+        }
+    }
+}

--- a/Assets/UniGLTF/Editor/TestRunner/TestRunner.cs.meta
+++ b/Assets/UniGLTF/Editor/TestRunner/TestRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 124e86211e5ad3f418dfeccf07c16b4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniGLTF/Editor/TopMenu.cs
+++ b/Assets/UniGLTF/Editor/TopMenu.cs
@@ -31,18 +31,21 @@ namespace UniGLTF
         private static void OpenMeshProcessingWindow() => MeshUtility.MeshUtilityDialog.OpenWindow();
 
 #if VRM_DEVELOP
-        [MenuItem(DevelopmentMenuPrefix + "/Generate Serialization Code", priority = 51)]
+        [MenuItem(DevelopmentMenuPrefix + "/Run EditMode Tests", priority = 51)]
+        private static void RunEditModeTests() => TestRunner.RunEditModeTests();
+
+        [MenuItem(DevelopmentMenuPrefix + "/Generate Serialization Code", priority = 61)]
         private static void GenerateSerializationCode()
         {
             SerializerGenerator.GenerateSerializer();
             DeserializerGenerator.GenerateSerializer();
         }
 
-        [MenuItem(DevelopmentMenuPrefix + "/Generate UniJSON ConcreteCast", priority = 52)]
+        [MenuItem(DevelopmentMenuPrefix + "/Generate UniJSON ConcreteCast", priority = 62)]
         private static void GenerateUniJsonConcreteCastCode() => UniJSON.ConcreteCast.GenerateGenericCast();
 
-        [MenuItem("GameObject/CheckPrefabType", false, 53)]
-        [MenuItem("Assets/CheckPrefabType", false, 53)]
+        [MenuItem("GameObject/CheckPrefabType", false, 63)]
+        [MenuItem("Assets/CheckPrefabType", false, 64)]
         private static void CheckPrefabType()
         {
             if (Selection.activeObject is GameObject go)


### PR DESCRIPTION
- `-runEditorTests` が廃止されているので自分でテストランナーを定義して `-executeMethod` する必要がある
    - ただし自由度が上がったので、終了コードをどう返すかなどの設計がしやすくなった
    - 今回は失敗したら終了コード `1` を返すようにした

コミットログが汚いのでこれは squash merge します