### PR TITLE
Define ExtensionSupportFlags for limited supporting KHR_texture_basisu

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ExtensionSupportFlags.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ExtensionSupportFlags.cs
@@ -1,0 +1,19 @@
+﻿namespace UniGLTF
+{
+    public sealed class ExtensionSupportFlags
+    {
+        /// <summary>
+        /// KHR_texture_basisu 拡張を考慮するかどうか。
+        /// </summary>
+        public bool ConsiderKhrTextureBasisu { get; set; }
+
+        /// <summary>
+        /// ファイルに含まれる "全ての" テクスチャの画像が Y 軸反転しているかどうか。
+        /// 標準的なファイルは false。
+        ///
+        /// Unity は内部で画像を Y 軸反転させているため、あらかじめ Y 軸反転させておくほうが効率的であり、その場合に対応。
+        /// https://docs.unity3d.com/Packages/com.unity.cloud.ktx@3.2/manual/creating-textures.html
+        /// </summary>
+        public bool IsAllTexturesYFlipped { get; set; }
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ExtensionSupportFlags.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ExtensionSupportFlags.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5b1a24ae974547b4bfec426c33c5d612
+timeCreated: 1714458314

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs
@@ -54,6 +54,13 @@ namespace UniGLTF
         public MigrationFlags MigrationFlags { get; }
 
         /// <summary>
+        /// Extension Supporting flags.
+        ///
+        /// User can set flags to enable or disable some extensions.
+        /// </summary>
+        public ExtensionSupportFlags ExtensionSupportFlags { get; } = new ExtensionSupportFlags();
+
+        /// <summary>
         /// URI access
         /// </summary>
         IStorage _storage;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -36,6 +36,7 @@ namespace UniGLTF
             ITextureDeserializer textureDeserializer = null,
             IMaterialDescriptorGenerator materialGenerator = null)
         {
+            TryValidateGltfData(data);
             Data = data;
             TextureDescriptorGenerator = new GltfTextureDescriptorGenerator(Data);
             MaterialDescriptorGenerator = materialGenerator ?? new BuiltInGltfMaterialDescriptorGenerator();
@@ -73,6 +74,21 @@ namespace UniGLTF
             // https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression
             "KHR_draco_mesh_compression",
         };
+
+        /// <summary>
+        /// GltfData をバリデートし、読み込み不可能な問題があれば例外を投げる
+        /// </summary>
+        private static void TryValidateGltfData(GltfData data)
+        {
+            if (data.ExtensionSupportFlags.ConsiderKhrTextureBasisu && !Application.isPlaying)
+            {
+                throw new UniGLTFNotSupportedException("KHR_texture_basisu is only available in play mode.");
+            }
+            if (data.ExtensionSupportFlags.ConsiderKhrTextureBasisu && !data.ExtensionSupportFlags.IsAllTexturesYFlipped)
+            {
+                throw new UniGLTFNotSupportedException("KHR_texture_basisu is only supported with all textures Y-flipped.");
+            }
+        }
 
         #region Load. Build unity objects
         public virtual async Task<RuntimeGltfInstance> LoadAsync(IAwaitCaller awaitCaller, Func<string, IDisposable> MeasureTime = null)

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/GltfTextureImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/GltfTextureImporter.cs
@@ -12,8 +12,6 @@ namespace UniGLTF
     /// </summary>
     public static class GltfTextureImporter
     {
-        public static bool ImportKhrTextureBasisuExtension { get; set; } = true;
-
         /// <summary>
         /// glTF の Texture が存在せず Image のみのものを、Texture として扱いたい場合の関数.
         /// </summary>
@@ -240,9 +238,7 @@ namespace UniGLTF
             {
                 var texture = data.GLTF.textures[textureIndex];
 
-                // NOTE: Runtime の場合は KHR_texture_basisu 拡張を考える.
-                if (ImportKhrTextureBasisuExtension &&
-                    Application.isPlaying &&
+                if (data.ExtensionSupportFlags.ConsiderKhrTextureBasisu &&
                     glTF_KHR_texture_basisu.TryGet(texture, out var basisuExtension))
                 {
                     var basisuImageIndex = basisuExtension.source;


### PR DESCRIPTION
Y 軸反転された basisu テクスチャを含む glTF/VRM/VRM10 ファイルを、Runtime でのみインポート可能にします。

| Supporting basisu texture  | Editor | Runtime |
|--|--|--|
| regular | - | - |
| Y-Flipped | - | ✅ |

```csharp
public class LoadYFlippedBasisuModel : MonoBehaviour
{
    async void Start()
    {
        var path = @"C:\foo\bar\baz.gltf";

        using var data = new AutoGltfFileParser(path).Parse();
        data.ExtensionSupportFlags.ConsiderKhrTextureBasisu = true;
        data.ExtensionSupportFlags.IsAllTexturesYFlipped = true;
        using var loader = new ImporterContext(data, materialGenerator: RenderPipelineMaterialDescriptorGeneratorUtility.GetValidGLTFMaterialDescriptorGenerator());
        var model = await loader.LoadAsync(new RuntimeOnlyAwaitCaller());
        model.ShowMeshes();
    }
}
```