### PR TITLE
If MaterialDescriptorGenerator is not specified, automatically determine it.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -38,7 +38,7 @@ namespace UniGLTF
         {
             Data = data;
             TextureDescriptorGenerator = new GltfTextureDescriptorGenerator(Data);
-            MaterialDescriptorGenerator = materialGenerator ?? new BuiltInGltfMaterialDescriptorGenerator();
+            MaterialDescriptorGenerator = materialGenerator ?? MaterialDescriptorGeneratorUtility.GetValidGltfMaterialDescriptorGenerator();
 
             ExternalObjectMap = externalObjectMap ?? new Dictionary<SubAssetKey, UnityEngine.Object>();
             textureDeserializer = textureDeserializer ?? new UnityTextureDeserializer();

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineMaterialDescriptorUtility.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineMaterialDescriptorUtility.cs
@@ -1,38 +1,40 @@
-using UniGLTF;
 using UnityEngine.Rendering;
 
-public class RenderPipelineMaterialDescriptorGeneratorUtility
+namespace UniGLTF
 {
-    protected static RenderPipelineTypes GetRenderPipelineType()
+    public static class MaterialDescriptorGeneratorUtility
     {
-        RenderPipeline currentPipeline = RenderPipelineManager.currentPipeline;
+        public static RenderPipelineTypes GetRenderPipelineType()
+        {
+            RenderPipeline currentPipeline = RenderPipelineManager.currentPipeline;
 
-        if (currentPipeline == null)
-        {
-            return RenderPipelineTypes.BuiltinRenderPipeline;
-        }
-        if (currentPipeline.GetType().Name.Contains("HDRenderPipeline"))
-        {
-            return RenderPipelineTypes.HighDefinitionRenderPipeline;
-        }
-        if (currentPipeline.GetType().Name.Contains("UniversalRenderPipeline"))
-        {
-            return RenderPipelineTypes.UniversalRenderPipeline;
-        }
-        return RenderPipelineTypes.Unknown;
-    }
-    
-    public static IMaterialDescriptorGenerator GetValidGLTFMaterialDescriptorGenerator()
-    {
-        switch (GetRenderPipelineType())
-        {
-            case RenderPipelineTypes.UniversalRenderPipeline:
-                return new UrpGltfMaterialDescriptorGenerator();
-            case RenderPipelineTypes.BuiltinRenderPipeline:
-                return new BuiltInGltfMaterialDescriptorGenerator();
+            if (currentPipeline == null)
+            {
+                return RenderPipelineTypes.BuiltinRenderPipeline;
+            }
+
+            if (currentPipeline.GetType().Name.Contains("HDRenderPipeline"))
+            {
+                return RenderPipelineTypes.HighDefinitionRenderPipeline;
+            }
+
+            if (currentPipeline.GetType().Name.Contains("UniversalRenderPipeline"))
+            {
+                return RenderPipelineTypes.UniversalRenderPipeline;
+            }
+
+            return RenderPipelineTypes.Unknown;
         }
 
-        return null;
+        public static IMaterialDescriptorGenerator GetValidGltfMaterialDescriptorGenerator()
+        {
+            return GetRenderPipelineType() switch
+            {
+                RenderPipelineTypes.UniversalRenderPipeline => new UrpGltfMaterialDescriptorGenerator(),
+                RenderPipelineTypes.BuiltinRenderPipeline => new BuiltInGltfMaterialDescriptorGenerator(),
+                _ => new BuiltInGltfMaterialDescriptorGenerator(),
+            };
+        }
     }
 }
 

--- a/Assets/VRM/Runtime/IO/MaterialIO/VRMRenderPipelineMaterialDescriptorGeneratorUtility.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/VRMRenderPipelineMaterialDescriptorGeneratorUtility.cs
@@ -1,21 +1,17 @@
 using UniGLTF;
-using VRM;
 
-namespace UniVRM
+namespace VRM
 {
-    public class VrmRenderPipelineMaterialDescriptorGeneratorDescriptorUtility : RenderPipelineMaterialDescriptorGeneratorUtility
+    public static class VrmMaterialDescriptorGeneratorUtility
     {
-        public static IMaterialDescriptorGenerator GetValidVrm10MaterialDescriptorGenerator(glTF_VRM_extensions vrm)
+        public static IMaterialDescriptorGenerator GetValidVrmMaterialDescriptorGenerator(glTF_VRM_extensions vrm)
         {
-            switch (GetRenderPipelineType())
+            return MaterialDescriptorGeneratorUtility.GetRenderPipelineType() switch
             {
-                case RenderPipelineTypes.UniversalRenderPipeline:
-                    return new UrpVrmMaterialDescriptorGenerator(vrm);
-                case RenderPipelineTypes.BuiltinRenderPipeline:
-                    return new BuiltInVrmMaterialDescriptorGenerator(vrm);
-            }
-
-            return null;
+                RenderPipelineTypes.UniversalRenderPipeline => new UrpVrmMaterialDescriptorGenerator(vrm),
+                RenderPipelineTypes.BuiltinRenderPipeline => new BuiltInVrmMaterialDescriptorGenerator(vrm),
+                _ => new BuiltInVrmMaterialDescriptorGenerator(vrm),
+            };
         }
     }
 }

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -27,7 +27,7 @@ namespace VRM
             ITextureDeserializer textureDeserializer = null,
             IMaterialDescriptorGenerator materialGenerator = null,
             bool loadAnimation = false)
-            : base(data.Data, externalObjectMap, textureDeserializer, materialGenerator ?? new BuiltInVrmMaterialDescriptorGenerator(data.VrmExtension))
+            : base(data.Data, externalObjectMap, textureDeserializer, materialGenerator ?? VrmMaterialDescriptorGeneratorUtility.GetValidVrmMaterialDescriptorGenerator(data.VrmExtension))
         {
             _data = data;
             TextureDescriptorGenerator = new VrmTextureDescriptorGenerator(Data, VRM);

--- a/Assets/VRM10/Runtime/IO/Material/URP/Import/VRM10RenderPipelineMaterialDescriptorGeneratorUtility.cs
+++ b/Assets/VRM10/Runtime/IO/Material/URP/Import/VRM10RenderPipelineMaterialDescriptorGeneratorUtility.cs
@@ -2,19 +2,16 @@ using UniGLTF;
 
 namespace UniVRM10
 {
-    public class Vrm10RenderPipelineMaterialDescriptorGeneratorDescriptorUtility : RenderPipelineMaterialDescriptorGeneratorUtility
+    public static class Vrm10MaterialDescriptorGeneratorDescriptorUtility
     {
         public static IMaterialDescriptorGenerator GetValidVrm10MaterialDescriptorGenerator()
         {
-            switch (GetRenderPipelineType())
+            return MaterialDescriptorGeneratorUtility.GetRenderPipelineType() switch
             {
-                case RenderPipelineTypes.UniversalRenderPipeline:
-                    return new UrpVrm10MaterialDescriptorGenerator();
-                case RenderPipelineTypes.BuiltinRenderPipeline:
-                    return new BuiltInVrm10MaterialDescriptorGenerator();
-            }
-
-            return null;
+                RenderPipelineTypes.UniversalRenderPipeline => new UrpVrm10MaterialDescriptorGenerator(),
+                RenderPipelineTypes.BuiltinRenderPipeline => new BuiltInVrm10MaterialDescriptorGenerator(),
+                _ => new BuiltInVrm10MaterialDescriptorGenerator(),
+            };
         }
     }
 }

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -43,7 +43,7 @@ namespace UniVRM10
             m_useControlRig = useControlRig;
 
             TextureDescriptorGenerator = new Vrm10TextureDescriptorGenerator(Data);
-            MaterialDescriptorGenerator = materialGenerator ?? Vrm10RenderPipelineMaterialDescriptorGeneratorDescriptorUtility.GetValidVrm10MaterialDescriptorGenerator();
+            MaterialDescriptorGenerator = materialGenerator ?? Vrm10MaterialDescriptorGeneratorDescriptorUtility.GetValidVrm10MaterialDescriptorGenerator();
 
             m_externalMap = externalObjectMap;
             if (m_externalMap == null)


### PR DESCRIPTION
GLTF 読み込み時に `ImporterContext` に `IMaterialDescriptorGenerator` が未指定の場合、自動決定できていなかった問題を修正