### PR TITLE
Unity2023.1以降でFindObjectsOfType系APIがObsolete警告を出すのに対応

### DIFF
--- a/Assets/VRM/Runtime/BlendShape/PreviewSceneManager.cs
+++ b/Assets/VRM/Runtime/BlendShape/PreviewSceneManager.cs
@@ -25,7 +25,7 @@ namespace VRM
             PreviewSceneManager manager = null;
 
             // if we already instantiated a PreviewInstance previously but just lost the reference, then use that same instance instead of making a new one
-            var managers = GameObject.FindObjectsOfType<PreviewSceneManager>();
+            var managers = GameObject.FindObjectsByType<PreviewSceneManager>(FindObjectsSortMode.InstanceID);
             foreach (var x in managers)
             {
                 if (x.Prefab == prefab)

--- a/Assets/VRM/Runtime/FirstPerson/VRMFirstPersonCameraManager.cs
+++ b/Assets/VRM/Runtime/FirstPerson/VRMFirstPersonCameraManager.cs
@@ -57,7 +57,7 @@ namespace VRM
 
         void Reset()
         {
-            var cameras = GameObject.FindObjectsOfType<Camera>();
+            var cameras = GameObject.FindObjectsByType<Camera>(FindObjectsSortMode.InstanceID);
             m_firstPersonCamera = Camera.main;
             m_thirdPersonCameras = cameras.Where(x => x != m_firstPersonCamera).ToArray();
         }

--- a/Assets/VRM/Runtime/LookAt/LookAtTargetSwitcher.cs
+++ b/Assets/VRM/Runtime/LookAt/LookAtTargetSwitcher.cs
@@ -20,8 +20,8 @@ namespace VRM
 
         private void Reset()
         {
-            m_lookAtHead = GameObject.FindObjectOfType<VRMLookAtHead>();
-            m_blinker = GameObject.FindObjectOfType<Blinker>();
+            m_lookAtHead = GameObject.FindFirstObjectByType<VRMLookAtHead>();
+            m_blinker = GameObject.FindFirstObjectByType<Blinker>();
         }
 
         float CalcScore(Transform target)

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
@@ -27,7 +27,7 @@ namespace UniVRM10
             PreviewSceneManager manager = null;
 
             // if we already instantiated a PreviewInstance previously but just lost the reference, then use that same instance instead of making a new one
-            var managers = GameObject.FindObjectsOfType<PreviewSceneManager>();
+            var managers = GameObject.FindObjectsByType<PreviewSceneManager>(FindObjectsSortMode.InstanceID);
             foreach (var x in managers)
             {
                 if (x.Prefab == prefab)

--- a/Assets/VRM10/Runtime/FastSpringBone/System/FastSpringBoneService.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/System/FastSpringBoneService.cs
@@ -49,7 +49,7 @@ namespace UniVRM10.FastSpringBones.System
             {
                 if (_instance) return _instance;
 
-                _instance = FindObjectOfType<FastSpringBoneService>();
+                _instance = FindFirstObjectByType<FastSpringBoneService>();
                 if (_instance) return _instance;
 
                 var gameObject = new GameObject("FastSpringBone Service");

--- a/Assets/VRM10_Samples/VRM10FirstPersonSample/VRM10CanvasManager.cs
+++ b/Assets/VRM10_Samples/VRM10FirstPersonSample/VRM10CanvasManager.cs
@@ -15,8 +15,8 @@ namespace UniVRM10.FirstPersonSample
 
         private void Reset()
         {
-            LoadVRMButton = GameObject.FindObjectsOfType<Button>().FirstOrDefault(x => x.name == "LoadVRM");
-            LoadBVHButton = GameObject.FindObjectsOfType<Button>().FirstOrDefault(x => x.name == "LoadBVH");
+            LoadVRMButton = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID).FirstOrDefault(x => x.name == "LoadVRM");
+            LoadBVHButton = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID).FirstOrDefault(x => x.name == "LoadBVH");
         }
     }
 }

--- a/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerUI.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerUI.cs
@@ -106,7 +106,7 @@ namespace UniVRM10.VRM10Viewer
 
             public void Reset()
             {
-                var texts = GameObject.FindObjectsOfType<Text>();
+                var texts = GameObject.FindObjectsByType<Text>(FindObjectsSortMode.InstanceID);
                 m_textModelTitle = texts.First(x => x.name == "Title (1)");
                 m_textModelVersion = texts.First(x => x.name == "Version (1)");
                 m_textModelAuthor = texts.First(x => x.name == "Author (1)");
@@ -123,7 +123,7 @@ namespace UniVRM10.VRM10Viewer
                 m_textDistributionLicense = texts.First(x => x.name == "LicenseType (1)");
                 m_textDistributionOther = texts.First(x => x.name == "OtherLicense (1)");
 
-                var images = GameObject.FindObjectsOfType<RawImage>();
+                var images = GameObject.FindObjectsByType<RawImage>(FindObjectsSortMode.InstanceID);
                 m_thumbnail = images.First(x => x.name == "RawImage");
             }
 
@@ -205,11 +205,11 @@ namespace UniVRM10.VRM10Viewer
 
             public void Reset()
             {
-                var toggles = GameObject.FindObjectsOfType<Toggle>();
+                var toggles = GameObject.FindObjectsByType<Toggle>(FindObjectsSortMode.InstanceID);
                 ToggleMotionTPose = toggles.First(x => x.name == "TPose");
                 ToggleMotionBVH = toggles.First(x => x.name == "BVH");
 
-                var groups = GameObject.FindObjectsOfType<ToggleGroup>();
+                var groups = GameObject.FindObjectsByType<ToggleGroup>(FindObjectsSortMode.InstanceID);
                 ToggleMotion = groups.First(x => x.name == "_Motion_");
             }
 
@@ -228,12 +228,12 @@ namespace UniVRM10.VRM10Viewer
 
         private void Reset()
         {
-            var buttons = GameObject.FindObjectsOfType<Button>();
+            var buttons = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID);
             m_openModel = buttons.First(x => x.name == "OpenModel");
             m_openMotion = buttons.First(x => x.name == "OpenMotion");
             m_pastePose = buttons.First(x => x.name == "PastePose");
 
-            var toggles = GameObject.FindObjectsOfType<Toggle>();
+            var toggles = GameObject.FindObjectsByType<Toggle>(FindObjectsSortMode.InstanceID);
             m_showBoxMan = toggles.First(x => x.name == "ShowBoxMan");
             m_enableLipSync = toggles.First(x => x.name == "EnableLipSync");
             m_enableAutoBlink = toggles.First(x => x.name == "EnableAutoBlink");
@@ -241,13 +241,13 @@ namespace UniVRM10.VRM10Viewer
             m_useUrpMaterial = toggles.First(x => x.name == "UseUrpMaterial");
             m_useAsync = toggles.First(x => x.name == "UseAsync");
 
-            var texts = GameObject.FindObjectsOfType<Text>();
+            var texts = GameObject.FindObjectsByType<Text>(FindObjectsSortMode.InstanceID);
             m_version = texts.First(x => x.name == "VrmVersion");
 
             m_texts.Reset();
             m_ui.Reset();
 
-            m_target = GameObject.FindObjectOfType<VRM10TargetMover>().gameObject;
+            m_target = GameObject.FindFirstObjectByType<VRM10TargetMover>().gameObject;
         }
 
         Loaded m_loaded;

--- a/Assets/VRM_Samples/FirstPersonSample/CanvasManager.cs
+++ b/Assets/VRM_Samples/FirstPersonSample/CanvasManager.cs
@@ -15,8 +15,8 @@ namespace VRM.FirstPersonSample
 
         private void Reset()
         {
-            LoadVRMButton = GameObject.FindObjectsOfType<Button>().FirstOrDefault(x => x.name == "LoadVRM");
-            LoadBVHButton = GameObject.FindObjectsOfType<Button>().FirstOrDefault(x => x.name == "LoadBVH");
+            LoadVRMButton = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID).FirstOrDefault(x => x.name == "LoadVRM");
+            LoadBVHButton = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID).FirstOrDefault(x => x.name == "LoadBVH");
         }
     }
 }

--- a/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
+++ b/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
@@ -175,22 +175,22 @@ namespace VRM.SimpleViewer
 
         private void Reset()
         {
-            var buttons = GameObject.FindObjectsOfType<Button>();
+            var buttons = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID);
             m_open = buttons.First(x => x.name == "Open");
 
             m_reset = buttons.First(x => x.name == "ResetSpringBone");
 
-            var toggles = GameObject.FindObjectsOfType<Toggle>();
+            var toggles = GameObject.FindObjectsByType<Toggle>(FindObjectsSortMode.InstanceID);
             m_useFastSpringBone = toggles.First(x => x.name == "UseFastSpringBone");
             m_enableLipSync = toggles.First(x => x.name == "EnableLipSync");
             m_enableAutoBlink = toggles.First(x => x.name == "EnableAutoBlink");
 
-            var texts = GameObject.FindObjectsOfType<Text>();
+            var texts = GameObject.FindObjectsByType<Text>(FindObjectsSortMode.InstanceID);
             m_version = texts.First(x => x.name == "Version");
 
-            m_src = GameObject.FindObjectOfType<HumanPoseTransfer>();
+            m_src = GameObject.FindFirstObjectByType<HumanPoseTransfer>();
 
-            m_target = GameObject.FindObjectOfType<TargetMover>().gameObject;
+            m_target = GameObject.FindFirstObjectByType<TargetMover>().gameObject;
         }
 
         Loaded m_loaded;


### PR DESCRIPTION
Unity 2023.1以降のバージョンでUnityEngine.Object.FindObjectsOfType系APIがObsoleteになり、次の警告が発生していました。

```
Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerUI.cs(250,24): warning CS0618: 'Object.FindObjectOfType<T>()' is obsolete: 'Object.FindObjectOfType has been deprecated. Use Object.FindFirstObjectByType instead or if finding any instance is acceptable the faster Object.FindAnyObjectByType'
Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerUI.cs(208,31): warning CS0618: 'Object.FindObjectsOfType<T>()' is obsolete: 'Object.FindObjectsOfType has been deprecated. Use Object.FindObjectsByType instead which lets you decide whether you need the results sorted or not.  FindObjectsOfType sorts the results by InstanceID but if you do not need this using FindObjectSortMode.None is considerably faster.'
```

代わりにFindObjectsBy系APIを使うようにしました。これはUnity 2021.3にも存在しているので、そのまま使うことができました。

FindObjectOfType()とFindFirstObjectByType()の違いに関してはドキュメントからは読み取れませんでしたが、 Unity-Technologiesgが公開しているUnity 6000のソースコードを見る限り、動作は同一に見えるためそのまま置き換えました。
https://github.com/Unity-Technologies/UnityCsReference/blob/6000.0/Runtime/Export/Scripting/UnityEngineObject.bindings.cs#L586-L602