### PR TITLE
Unity2022.2.4以下と2021.3.17以下でFindObjectBy系APIが存在しないのに対応

### DIFF
--- a/Assets/VRM/Runtime/BlendShape/PreviewSceneManager.cs
+++ b/Assets/VRM/Runtime/BlendShape/PreviewSceneManager.cs
@@ -25,7 +25,11 @@ namespace VRM
             PreviewSceneManager manager = null;
 
             // if we already instantiated a PreviewInstance previously but just lost the reference, then use that same instance instead of making a new one
+#if UNITY_2022_3_OR_NEWER
             var managers = GameObject.FindObjectsByType<PreviewSceneManager>(FindObjectsSortMode.InstanceID);
+#else
+            var managers = GameObject.FindObjectsOfType<PreviewSceneManager>();
+#endif
             foreach (var x in managers)
             {
                 if (x.Prefab == prefab)

--- a/Assets/VRM/Runtime/FirstPerson/VRMFirstPersonCameraManager.cs
+++ b/Assets/VRM/Runtime/FirstPerson/VRMFirstPersonCameraManager.cs
@@ -57,7 +57,11 @@ namespace VRM
 
         void Reset()
         {
+#if UNITY_2022_3_OR_NEWER
             var cameras = GameObject.FindObjectsByType<Camera>(FindObjectsSortMode.InstanceID);
+#else
+            var cameras = GameObject.FindObjectsOfType<Camera>();
+#endif
             m_firstPersonCamera = Camera.main;
             m_thirdPersonCameras = cameras.Where(x => x != m_firstPersonCamera).ToArray();
         }

--- a/Assets/VRM/Runtime/LookAt/LookAtTargetSwitcher.cs
+++ b/Assets/VRM/Runtime/LookAt/LookAtTargetSwitcher.cs
@@ -20,8 +20,13 @@ namespace VRM
 
         private void Reset()
         {
+#if UNITY_2022_3_OR_NEWER
             m_lookAtHead = GameObject.FindFirstObjectByType<VRMLookAtHead>();
             m_blinker = GameObject.FindFirstObjectByType<Blinker>();
+#else
+            m_lookAtHead = GameObject.FindObjectOfType<VRMLookAtHead>();
+            m_blinker = GameObject.FindObjectOfType<Blinker>();
+#endif
         }
 
         float CalcScore(Transform target)

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
@@ -27,7 +27,11 @@ namespace UniVRM10
             PreviewSceneManager manager = null;
 
             // if we already instantiated a PreviewInstance previously but just lost the reference, then use that same instance instead of making a new one
+#if UNITY_2022_3_OR_NEWER
             var managers = GameObject.FindObjectsByType<PreviewSceneManager>(FindObjectsSortMode.InstanceID);
+#else
+            var managers = GameObject.FindObjectsOfType<PreviewSceneManager>();
+#endif
             foreach (var x in managers)
             {
                 if (x.Prefab == prefab)

--- a/Assets/VRM10/Runtime/FastSpringBone/System/FastSpringBoneService.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/System/FastSpringBoneService.cs
@@ -49,7 +49,11 @@ namespace UniVRM10.FastSpringBones.System
             {
                 if (_instance) return _instance;
 
+#if UNITY_2022_3_OR_NEWER
                 _instance = FindFirstObjectByType<FastSpringBoneService>();
+#else
+                _instance = FindObjectOfType<FastSpringBoneService>();
+#endif
                 if (_instance) return _instance;
 
                 var gameObject = new GameObject("FastSpringBone Service");

--- a/Assets/VRM10_Samples/VRM10FirstPersonSample/VRM10CanvasManager.cs
+++ b/Assets/VRM10_Samples/VRM10FirstPersonSample/VRM10CanvasManager.cs
@@ -15,8 +15,13 @@ namespace UniVRM10.FirstPersonSample
 
         private void Reset()
         {
+#if UNITY_2022_3_OR_NEWER
             LoadVRMButton = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID).FirstOrDefault(x => x.name == "LoadVRM");
             LoadBVHButton = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID).FirstOrDefault(x => x.name == "LoadBVH");
+#else
+            LoadVRMButton = GameObject.FindObjectsOfType<Button>().FirstOrDefault(x => x.name == "LoadVRM");
+            LoadBVHButton = GameObject.FindObjectsOfType<Button>().FirstOrDefault(x => x.name == "LoadBVH");
+#endif
         }
     }
 }

--- a/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerUI.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerUI.cs
@@ -106,7 +106,11 @@ namespace UniVRM10.VRM10Viewer
 
             public void Reset()
             {
+#if UNITY_2022_3_OR_NEWER
                 var texts = GameObject.FindObjectsByType<Text>(FindObjectsSortMode.InstanceID);
+#else
+                var texts = GameObject.FindObjectsOfType<Text>();
+#endif
                 m_textModelTitle = texts.First(x => x.name == "Title (1)");
                 m_textModelVersion = texts.First(x => x.name == "Version (1)");
                 m_textModelAuthor = texts.First(x => x.name == "Author (1)");
@@ -123,7 +127,11 @@ namespace UniVRM10.VRM10Viewer
                 m_textDistributionLicense = texts.First(x => x.name == "LicenseType (1)");
                 m_textDistributionOther = texts.First(x => x.name == "OtherLicense (1)");
 
+#if UNITY_2022_3_OR_NEWER
                 var images = GameObject.FindObjectsByType<RawImage>(FindObjectsSortMode.InstanceID);
+#else
+                var images = GameObject.FindObjectsOfType<RawImage>();
+#endif
                 m_thumbnail = images.First(x => x.name == "RawImage");
             }
 
@@ -205,11 +213,19 @@ namespace UniVRM10.VRM10Viewer
 
             public void Reset()
             {
+#if UNITY_2022_3_OR_NEWER
                 var toggles = GameObject.FindObjectsByType<Toggle>(FindObjectsSortMode.InstanceID);
+#else
+                var toggles = GameObject.FindObjectsOfType<Toggle>();
+#endif
                 ToggleMotionTPose = toggles.First(x => x.name == "TPose");
                 ToggleMotionBVH = toggles.First(x => x.name == "BVH");
 
+#if UNITY_2022_3_OR_NEWER
                 var groups = GameObject.FindObjectsByType<ToggleGroup>(FindObjectsSortMode.InstanceID);
+#else
+                var groups = GameObject.FindObjectsOfType<ToggleGroup>();
+#endif
                 ToggleMotion = groups.First(x => x.name == "_Motion_");
             }
 
@@ -228,12 +244,20 @@ namespace UniVRM10.VRM10Viewer
 
         private void Reset()
         {
+#if UNITY_2022_3_OR_NEWER
             var buttons = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID);
+#else
+            var buttons = GameObject.FindObjectsOfType<Button>();
+#endif
             m_openModel = buttons.First(x => x.name == "OpenModel");
             m_openMotion = buttons.First(x => x.name == "OpenMotion");
             m_pastePose = buttons.First(x => x.name == "PastePose");
 
+#if UNITY_2022_3_OR_NEWER
             var toggles = GameObject.FindObjectsByType<Toggle>(FindObjectsSortMode.InstanceID);
+#else
+            var toggles = GameObject.FindObjectsOfType<Toggle>();
+#endif
             m_showBoxMan = toggles.First(x => x.name == "ShowBoxMan");
             m_enableLipSync = toggles.First(x => x.name == "EnableLipSync");
             m_enableAutoBlink = toggles.First(x => x.name == "EnableAutoBlink");
@@ -241,13 +265,21 @@ namespace UniVRM10.VRM10Viewer
             m_useUrpMaterial = toggles.First(x => x.name == "UseUrpMaterial");
             m_useAsync = toggles.First(x => x.name == "UseAsync");
 
+#if UNITY_2022_3_OR_NEWER
             var texts = GameObject.FindObjectsByType<Text>(FindObjectsSortMode.InstanceID);
+#else
+            var texts = GameObject.FindObjectsOfType<Text>();
+#endif
             m_version = texts.First(x => x.name == "VrmVersion");
 
             m_texts.Reset();
             m_ui.Reset();
 
+#if UNITY_2022_3_OR_NEWER
             m_target = GameObject.FindFirstObjectByType<VRM10TargetMover>().gameObject;
+#else
+            m_target = GameObject.FindObjectOfType<VRM10TargetMover>().gameObject;
+#endif
         }
 
         Loaded m_loaded;

--- a/Assets/VRM_Samples/FirstPersonSample/CanvasManager.cs
+++ b/Assets/VRM_Samples/FirstPersonSample/CanvasManager.cs
@@ -15,8 +15,13 @@ namespace VRM.FirstPersonSample
 
         private void Reset()
         {
+#if UNITY_2022_3_OR_NEWER
             LoadVRMButton = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID).FirstOrDefault(x => x.name == "LoadVRM");
             LoadBVHButton = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID).FirstOrDefault(x => x.name == "LoadBVH");
+#else
+            LoadVRMButton = GameObject.FindObjectsOfType<Button>().FirstOrDefault(x => x.name == "LoadVRM");
+            LoadBVHButton = GameObject.FindObjectsOfType<Button>().FirstOrDefault(x => x.name == "LoadBVH");
+#endif
         }
     }
 }

--- a/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
+++ b/Assets/VRM_Samples/SimpleViewer/ViewerUI.cs
@@ -175,22 +175,40 @@ namespace VRM.SimpleViewer
 
         private void Reset()
         {
+#if UNITY_2022_3_OR_NEWER
             var buttons = GameObject.FindObjectsByType<Button>(FindObjectsSortMode.InstanceID);
+#else
+            var buttons = GameObject.FindObjectsOfType<Button>();
+#endif
             m_open = buttons.First(x => x.name == "Open");
 
             m_reset = buttons.First(x => x.name == "ResetSpringBone");
 
+#if UNITY_2022_3_OR_NEWER
             var toggles = GameObject.FindObjectsByType<Toggle>(FindObjectsSortMode.InstanceID);
+#else
+            var toggles = GameObject.FindObjectsOfType<Toggle>();
+#endif
             m_useFastSpringBone = toggles.First(x => x.name == "UseFastSpringBone");
             m_enableLipSync = toggles.First(x => x.name == "EnableLipSync");
             m_enableAutoBlink = toggles.First(x => x.name == "EnableAutoBlink");
 
+#if UNITY_2022_3_OR_NEWER
             var texts = GameObject.FindObjectsByType<Text>(FindObjectsSortMode.InstanceID);
+#else
+            var texts = GameObject.FindObjectsOfType<Text>();
+#endif
             m_version = texts.First(x => x.name == "Version");
 
+#if UNITY_2022_3_OR_NEWER
             m_src = GameObject.FindFirstObjectByType<HumanPoseTransfer>();
 
             m_target = GameObject.FindFirstObjectByType<TargetMover>().gameObject;
+#else
+            m_src = GameObject.FindObjectOfType<HumanPoseTransfer>();
+
+            m_target = GameObject.FindObjectOfType<TargetMover>().gameObject;
+#endif
         }
 
         Loaded m_loaded;


### PR DESCRIPTION
私が以前提出した PR https://github.com/vrm-c/UniVRM/pull/2285 で、コンパイルエラーのリグレッションを発生させてしまいました。そちらの修正です。お手数おかけしてしまい大変申し訳ありません。

FindObjectsBy系のAPIは、UniVRMがサポートしているUnityのうち、次の範囲のバージョンには存在していませんでした。

- 2021.3.0～2021.3.17
- 2022.1.0～2022.1.24
- 2022.2.0～2022.2.4

そのため、該当するバージョンのUnityではコンパイルエラーが発生していました。UNITY_2022_3_OR_NEWERで分岐することで、旧APIと新APIを安全に選択するようにしました。

厳密にはUNITY_2022_2_5_OR_NEWERを用いたいですが、そのようなシンボルは存在していませんでした。

以前の PR https://github.com/vrm-c/UniVRM/pull/2285 では、Unity 2021.3のドキュメントや2021.3.27f1でメソッドが存在したことで、2021.3以降のバージョンにはすべて存在していると勘違いしてしまっていました。
