### PR TITLE
Run parsing of vrm10 files on a thread pool.

### DIFF
--- a/Assets/VRM10/Runtime/IO/Vrm10.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10.cs
@@ -52,7 +52,11 @@ namespace UniVRM10
                 ? new RuntimeOnlyAwaitCaller()
                 : new ImmediateCaller();
 
-            using var gltfData = new GlbLowLevelParser(path, await File.ReadAllBytesAsync(path, ct)).Parse();
+            using var gltfData = await awaitCaller.Run(() =>
+            {
+                var bytes = File.ReadAllBytes(path);
+                return new GlbLowLevelParser(path, bytes).Parse();
+            });
             return await LoadAsync(
                 gltfData,
                 canLoadVrm0X,
@@ -96,7 +100,7 @@ namespace UniVRM10
                 ? new RuntimeOnlyAwaitCaller()
                 : new ImmediateCaller();
 
-            using var gltfData = new GlbLowLevelParser(string.Empty, bytes).Parse();
+            using var gltfData = await awaitCaller.Run(() => new GlbLowLevelParser(string.Empty, bytes).Parse());
             return await LoadAsync(
                 gltfData,
                 canLoadVrm0X,

--- a/Assets/VRM10/Tests/Vrm10ApiTests.cs
+++ b/Assets/VRM10/Tests/Vrm10ApiTests.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+using UniVRM10;
+using VRMShaders;
+
+namespace VRM10.Tests
+{
+    public sealed class Vrm10ApiTests
+    {
+        [Test]
+        public void LoadImmediately()
+        {
+            var loadTask = Vrm10.LoadPathAsync(
+                TestAsset.AliciaPath,
+                canLoadVrm0X: true,
+                awaitCaller: new ImmediateCaller()
+            );
+
+            Assert.AreEqual(true, loadTask.IsCompleted);
+        }
+    }
+}

--- a/Assets/VRM10/Tests/Vrm10ApiTests.cs
+++ b/Assets/VRM10/Tests/Vrm10ApiTests.cs
@@ -1,9 +1,7 @@
-﻿using System.Threading.Tasks;
-using NUnit.Framework;
-using UniVRM10;
+﻿using NUnit.Framework;
 using VRMShaders;
 
-namespace VRM10.Tests
+namespace UniVRM10.Test
 {
     public sealed class Vrm10ApiTests
     {

--- a/Assets/VRM10/Tests/Vrm10ApiTests.cs.meta
+++ b/Assets/VRM10/Tests/Vrm10ApiTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6bf6de3c68bf4a5994e2b5739f60b913
+timeCreated: 1716261790


### PR DESCRIPTION
https://github.com/vrm-c/UniVRM/pull/2296 のマージ後に見てください。

- `Vrm10.LoadPathAsync`
- `Vrm10.LoadBytesAsync`

の使用時に、選択された `IAwaitCaller` によってはファイルパースの実行をメインスレッドではなくスレッドプール等で働くようにします。
