### PR TITLE
Add MToon0X -> MToon10 material migration command

### DIFF
--- a/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
+++ b/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
@@ -353,8 +353,8 @@ namespace UniVRM10
                         );
                     }
                 }
-                // TODO: ミスってる？
-                dst.UvAnimationRotationSpeedFactor = mtoon.Definition.TextureOption.UvAnimationRotationSpeedValue;
+                const float rotationPerSecToRadianPerSec = Mathf.PI * 2f;
+                dst.UvAnimationRotationSpeedFactor = mtoon.Definition.TextureOption.UvAnimationRotationSpeedValue * rotationPerSecToRadianPerSec;
                 dst.UvAnimationScrollXSpeedFactor = mtoon.Definition.TextureOption.UvAnimationScrollXSpeedValue;
                 const float invertY = -1f;
                 dst.UvAnimationScrollYSpeedFactor = mtoon.Definition.TextureOption.UvAnimationScrollYSpeedValue * invertY;

--- a/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
+++ b/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
@@ -353,6 +353,7 @@ namespace UniVRM10
                         );
                     }
                 }
+                // TODO: ミスってる？
                 dst.UvAnimationRotationSpeedFactor = mtoon.Definition.TextureOption.UvAnimationRotationSpeedValue;
                 dst.UvAnimationScrollXSpeedFactor = mtoon.Definition.TextureOption.UvAnimationScrollXSpeedValue;
                 const float invertY = -1f;

--- a/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
+++ b/Assets/VRM10/Runtime/Migration/Materials/MigrationMToonMaterial.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections.Generic;
-using MToon;
 using UniGLTF;
 using UniGLTF.Extensions.VRMC_materials_mtoon;
 using UniJSON;
 using UnityEngine;
 using VRMShaders.VRM10.MToon10.Runtime;
+using VRMShaders.VRM10.MToon10.Runtime.MToon0X;
 using ColorSpace = VRMShaders.ColorSpace;
-using OutlineWidthMode = MToon.OutlineWidthMode;
-using RenderMode = MToon.RenderMode;
 
 namespace UniVRM10
 {
@@ -44,14 +42,14 @@ namespace UniVRM10
                 }
                 switch (mtoon.Definition.Rendering.RenderMode)
                 {
-                    case RenderMode.Opaque:
+                    case MToon0XRenderMode.Opaque:
                         break;
-                    case RenderMode.Cutout:
+                    case MToon0XRenderMode.Cutout:
                         break;
-                    case RenderMode.Transparent:
+                    case MToon0XRenderMode.Transparent:
                         transparentRenderQueues.Add(mtoon.Definition.Rendering.RenderQueueOffsetNumber);
                         break;
-                    case RenderMode.TransparentWithZWrite:
+                    case MToon0XRenderMode.TransparentWithZWrite:
                         transparentZWriteRenderQueues.Add(mtoon.Definition.Rendering.RenderQueueOffsetNumber);
                         break;
                     default:
@@ -104,25 +102,25 @@ namespace UniVRM10
                 // Rendering
                 switch (mtoon.Definition.Rendering.RenderMode)
                 {
-                    case RenderMode.Opaque:
+                    case MToon0XRenderMode.Opaque:
                         gltfMaterial.alphaMode = "OPAQUE";
                         dst.TransparentWithZWrite = false;
                         gltfMaterial.alphaCutoff = 0.5f;
                         dst.RenderQueueOffsetNumber = 0;
                         break;
-                    case RenderMode.Cutout:
+                    case MToon0XRenderMode.Cutout:
                         gltfMaterial.alphaMode = "MASK";
                         dst.TransparentWithZWrite = false;
                         gltfMaterial.alphaCutoff = mtoon.Definition.Color.CutoutThresholdValue;
                         dst.RenderQueueOffsetNumber = 0;
                         break;
-                    case RenderMode.Transparent:
+                    case MToon0XRenderMode.Transparent:
                         gltfMaterial.alphaMode = "BLEND";
                         dst.TransparentWithZWrite = false;
                         gltfMaterial.alphaCutoff = 0.5f;
                         dst.RenderQueueOffsetNumber = Mathf.Clamp(transparentRenderQueueMap[mtoon.Definition.Rendering.RenderQueueOffsetNumber], -9, 0);
                         break;
-                    case RenderMode.TransparentWithZWrite:
+                    case MToon0XRenderMode.TransparentWithZWrite:
                         gltfMaterial.alphaMode = "BLEND";
                         dst.TransparentWithZWrite = true;
                         gltfMaterial.alphaCutoff = 0.5f;
@@ -133,13 +131,13 @@ namespace UniVRM10
                 }
                 switch (mtoon.Definition.Rendering.CullMode)
                 {
-                    case MToon.CullMode.Back:
+                    case MToon0XCullMode.Back:
                         gltfMaterial.doubleSided = false;
                         break;
-                    case MToon.CullMode.Off:
+                    case MToon0XCullMode.Off:
                         gltfMaterial.doubleSided = true;
                         break;
-                    case MToon.CullMode.Front:
+                    case MToon0XCullMode.Front:
                         // GLTF not support
                         gltfMaterial.doubleSided = true;
                         break;
@@ -294,15 +292,15 @@ namespace UniVRM10
                 const float oneHundredth = 0.01f;
                 switch (mtoon.Definition.Outline.OutlineWidthMode)
                 {
-                    case OutlineWidthMode.None:
+                    case MToon0XOutlineWidthMode.None:
                         dst.OutlineWidthMode = UniGLTF.Extensions.VRMC_materials_mtoon.OutlineWidthMode.none;
                         dst.OutlineWidthFactor = null;
                         break;
-                    case OutlineWidthMode.WorldCoordinates:
+                    case MToon0XOutlineWidthMode.WorldCoordinates:
                         dst.OutlineWidthMode = UniGLTF.Extensions.VRMC_materials_mtoon.OutlineWidthMode.worldCoordinates;
                         dst.OutlineWidthFactor = mtoon.Definition.Outline.OutlineWidthValue * centimeterToMeter;
                         break;
-                    case OutlineWidthMode.ScreenCoordinates:
+                    case MToon0XOutlineWidthMode.ScreenCoordinates:
                         dst.OutlineWidthMode = UniGLTF.Extensions.VRMC_materials_mtoon.OutlineWidthMode.screenCoordinates;
                         // NOTE: 従来は、縦幅の半分を 100% としたときの % の値だった。
                         //       1.0 では縦幅を 1 としたときの値とするので、 1/200 する。
@@ -329,10 +327,10 @@ namespace UniVRM10
                 dst.OutlineColorFactor = mtoon.Definition.Outline.OutlineColor.ToFloat3(ColorSpace.sRGB, ColorSpace.Linear);
                 switch (mtoon.Definition.Outline.OutlineColorMode)
                 {
-                    case OutlineColorMode.FixedColor:
+                    case MToon0XOutlineColorMode.FixedColor:
                         dst.OutlineLightingMixFactor = 0.0f;
                         break;
-                    case OutlineColorMode.MixedLighting:
+                    case MToon0XOutlineColorMode.MixedLighting:
                         dst.OutlineLightingMixFactor = mtoon.Definition.Outline.OutlineLightingMixValue;
                         break;
                     default:

--- a/Assets/VRM10/Runtime/Migration/Materials/Vrm0XMToonValue.cs
+++ b/Assets/VRM10/Runtime/Migration/Materials/Vrm0XMToonValue.cs
@@ -4,6 +4,7 @@ using UniGLTF;
 using UniJSON;
 using UnityEngine;
 using VRMShaders;
+using VRMShaders.VRM10.MToon10.Runtime.MToon0X;
 using ColorSpace = VRMShaders.ColorSpace;
 
 namespace UniVRM10
@@ -16,28 +17,28 @@ namespace UniVRM10
     /// </summary>
     internal sealed class Vrm0XMToonValue
     {
-        public MToon.MToonDefinition Definition { get; }
+        public MToon0XDefinition Definition { get; }
         public Dictionary<string, float[]> TextureOffsetScales { get; }
         public Vrm0XMToonTextureIndexMap TextureIndexMap { get; }
 
         public Vrm0XMToonValue(JsonNode vrmMaterial)
         {
-            var definition = new MToon.MToonDefinition
+            var definition = new MToon0XDefinition
             {
-                Color = new MToon.ColorDefinition { },
-                Lighting = new MToon.LightingDefinition
+                Color = new MToon0XColorDefinition { },
+                Lighting = new MToon0XLightingDefinition
                 {
-                    LightingInfluence = new MToon.LightingInfluenceDefinition { },
-                    LitAndShadeMixing = new MToon.LitAndShadeMixingDefinition { },
-                    Normal = new MToon.NormalDefinition { }
+                    LightingInfluence = new MToon0XLightingInfluenceDefinition { },
+                    LitAndShadeMixing = new MToon0XLitAndShadeMixingDefinition { },
+                    Normal = new MToon0XNormalDefinition { }
                 },
-                Emission = new MToon.EmissionDefinition { },
-                MatCap = new MToon.MatCapDefinition { },
-                Meta = new MToon.MetaDefinition { },
-                Outline = new MToon.OutlineDefinition { },
-                Rendering = new MToon.RenderingDefinition { },
-                Rim = new MToon.RimDefinition { },
-                TextureOption = new MToon.TextureUvCoordsDefinition { }
+                Emission = new MToon0XEmissionDefinition { },
+                MatCap = new MToon0XMatCapDefinition { },
+                Meta = new MToon0XMetaDefinition { },
+                Outline = new MToon0XOutlineDefinition { },
+                Rendering = new MToon0XRenderingDefinition { },
+                Rim = new MToon0XRimDefinition { },
+                TextureOption = new MToon0XTextureUvCoordsDefinition { }
             };
 
             var offsetScale = new Dictionary<string, float[]>();
@@ -100,10 +101,10 @@ namespace UniVRM10
                 {
                     // Rendering
                     case "_BlendMode":
-                        definition.Rendering.RenderMode = (MToon.RenderMode)(int)value;
+                        definition.Rendering.RenderMode = (MToon0XRenderMode)(int)value;
                         break;
                     case "_CullMode":
-                        definition.Rendering.CullMode = (MToon.CullMode)(int)value;
+                        definition.Rendering.CullMode = (MToon0XCullMode)(int)value;
                         break;
                     case "_Cutoff":
                         definition.Color.CutoutThresholdValue = value;
@@ -147,7 +148,7 @@ namespace UniVRM10
 
                     // Outline
                     case "_OutlineColorMode":
-                        definition.Outline.OutlineColorMode = (MToon.OutlineColorMode)value;
+                        definition.Outline.OutlineColorMode = (MToon0XOutlineColorMode)value;
                         break;
                     case "_OutlineLightingMix":
                         definition.Outline.OutlineLightingMixValue = value;
@@ -163,7 +164,7 @@ namespace UniVRM10
                         {
                             value = 0;
                         }
-                        definition.Outline.OutlineWidthMode = (MToon.OutlineWidthMode)value;
+                        definition.Outline.OutlineWidthMode = (MToon0XOutlineWidthMode)value;
                         break;
 
                     // UV Animation
@@ -230,7 +231,7 @@ namespace UniVRM10
 
             definition.Rendering.RenderQueueOffsetNumber =
                 vrmMaterial["renderQueue"].GetInt32() -
-                MToon.Utils.GetRenderQueueRequirement(definition.Rendering.RenderMode).DefaultValue;
+                MToon0XUtils.GetRenderQueueRequirement(definition.Rendering.RenderMode).DefaultValue;
 
             Definition = definition;
             TextureOffsetScales = offsetScale;

--- a/Assets/VRM10/Runtime/VRM10.asmdef
+++ b/Assets/VRM10/Runtime/VRM10.asmdef
@@ -3,7 +3,6 @@
     "rootNamespace": "",
     "references": [
         "GUID:2ef84b520212e174a94668c7a0862d3b",
-        "GUID:a9bc101fb0471f94a8f99fd242fdd934",
         "GUID:8d76e605759c3f64a957d63ef96ada7c",
         "GUID:da3e51d19d51a544fa14d43fee843098",
         "GUID:bce005214fa49654d93927908c15b1f2",

--- a/Assets/VRMShaders/VRM10/MToon10/Editor/EditorMenu.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Editor/EditorMenu.cs
@@ -1,34 +1,35 @@
-﻿using UnityEditor;
+﻿using System.Linq;
+using UnityEditor;
 using UnityEngine;
 
 namespace VRMShaders.VRM10.MToon10.Editor
 {
     internal static class EditorMenu
     {
-        [MenuItem("Assets/VRM10/MToon -> MToon10 Migration", isValidateFunction: true, priority: 910)]
+        [MenuItem("Assets/VRM10/MToon -> MToon10 Material Migration", isValidateFunction: true, priority: 1100)]
         private static bool MigrateMToonMaterialValidation()
         {
-            if (Selection.activeObject is Material material)
-            {
-                return material.shader != null && material.shader.name == "VRM/MToon";
-            }
-            return false;
+            var objects = Selection.objects;
+            return objects.All(x => x is Material);
         }
 
-        [MenuItem("Assets/VRM10/MToon -> MToon10 Migration", isValidateFunction: false, priority: 910)]
+        [MenuItem("Assets/VRM10/MToon -> MToon10 Material Migration", isValidateFunction: false, priority: 1100)]
         private static void MigrateMToonMaterial()
         {
-            if (Selection.activeObject is Material material)
+            var objects = Selection.objects;
+            var migrator = new MToonMaterialMigrator();
+            Undo.RecordObjects(objects, nameof(MigrateMToonMaterial));
+            foreach (var obj in Selection.objects)
             {
-                Undo.RecordObject(material, nameof(MigrateMToonMaterial));
-                var migrator = new MToonMaterialMigrator();
-                if (migrator.TryMigrate(material))
+                if (obj == null) continue;
+
+                if (obj is Material material && migrator.TryMigrate(material, validateShaderName: true))
                 {
                     Debug.Log($"Migrated {material.name} to MToon10");
                 }
                 else
                 {
-                    Debug.LogWarning($"Failed to migrate {material.name} to MToon10");
+                    Debug.LogWarning($"Failed to migrate {obj.name} to MToon10");
                 }
             }
         }

--- a/Assets/VRMShaders/VRM10/MToon10/Editor/EditorMenu.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Editor/EditorMenu.cs
@@ -1,0 +1,36 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRMShaders.VRM10.MToon10.Editor
+{
+    internal static class EditorMenu
+    {
+        [MenuItem("Assets/VRM10/MToon -> MToon10 Migration", isValidateFunction: true, priority: 910)]
+        private static bool MigrateMToonMaterialValidation()
+        {
+            if (Selection.activeObject is Material material)
+            {
+                return material.shader != null && material.shader.name == "VRM/MToon";
+            }
+            return false;
+        }
+
+        [MenuItem("Assets/VRM10/MToon -> MToon10 Migration", isValidateFunction: false, priority: 910)]
+        private static void MigrateMToonMaterial()
+        {
+            if (Selection.activeObject is Material material)
+            {
+                Undo.RecordObject(material, nameof(MigrateMToonMaterial));
+                var migrator = new MToonMaterialMigrator();
+                if (migrator.TryMigrate(material))
+                {
+                    Debug.Log($"Migrated {material.name} to MToon10");
+                }
+                else
+                {
+                    Debug.LogWarning($"Failed to migrate {material.name} to MToon10");
+                }
+            }
+        }
+    }
+}

--- a/Assets/VRMShaders/VRM10/MToon10/Editor/EditorMenu.cs.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Editor/EditorMenu.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bd9f851945dd4e66ad4fbd6c92f6b27e
+timeCreated: 1716646767

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/Extensions/MaterialExtensions.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/Extensions/MaterialExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using VRMShaders.VRM10.MToon10.Runtime;
 
 namespace VRMShaders.VRM10.MToon10.Runtime
 {
@@ -32,9 +31,19 @@ namespace VRMShaders.VRM10.MToon10.Runtime
             return mat.GetTexture(prop.ToUnityShaderLabName());
         }
 
+        public static void SetTexture(this Material mat, MToon10Prop prop, Texture val)
+        {
+            mat.SetTexture(prop.ToUnityShaderLabName(), val);
+        }
+
         public static Vector2 GetTextureScale(this Material mat, MToon10Prop prop)
         {
             return mat.GetTextureScale(prop.ToUnityShaderLabName());
+        }
+
+        public static void SetTextureScale(this Material mat, MToon10Prop prop, Vector2 val)
+        {
+            mat.SetTextureScale(prop.ToUnityShaderLabName(), val);
         }
 
         public static Vector2 GetTextureOffset(this Material mat, MToon10Prop prop)
@@ -42,14 +51,29 @@ namespace VRMShaders.VRM10.MToon10.Runtime
             return mat.GetTextureOffset(prop.ToUnityShaderLabName());
         }
 
+        public static void SetTextureOffset(this Material mat, MToon10Prop prop, Vector2 val)
+        {
+            mat.SetTextureOffset(prop.ToUnityShaderLabName(), val);
+        }
+
         public static float GetFloat(this Material mat, MToon10Prop prop)
         {
             return mat.GetFloat(prop.ToUnityShaderLabName());
         }
 
+        public static void SetFloat(this Material mat, MToon10Prop prop, float val)
+        {
+            mat.SetFloat(prop.ToUnityShaderLabName(), val);
+        }
+
         public static Color GetColor(this Material mat, MToon10Prop prop)
         {
             return mat.GetColor(prop.ToUnityShaderLabName());
+        }
+
+        public static void SetColor(this Material mat, MToon10Prop prop, Color val)
+        {
+            mat.SetColor(prop.ToUnityShaderLabName(), val);
         }
     }
 }

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 877449241d1d463dae7623e78e27a772
+timeCreated: 1716647773

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XDefinition.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XDefinition.cs
@@ -1,0 +1,109 @@
+using UnityEngine;
+
+namespace VRMShaders.VRM10.MToon10.Runtime.MToon0X
+{
+    public class MToon0XDefinition
+    {
+        public MToon0XMetaDefinition Meta;
+        public MToon0XRenderingDefinition Rendering;
+        public MToon0XColorDefinition Color;
+        public MToon0XLightingDefinition Lighting;
+        public MToon0XEmissionDefinition Emission;
+        public MToon0XMatCapDefinition MatCap;
+        public MToon0XRimDefinition Rim;
+        public MToon0XOutlineDefinition Outline;
+        public MToon0XTextureUvCoordsDefinition TextureOption;
+    }
+
+    public class MToon0XMetaDefinition
+    {
+        public string Implementation;
+        public int VersionNumber;
+    }
+
+    public class MToon0XRenderingDefinition
+    {
+        public MToon0XRenderMode RenderMode;
+        public MToon0XCullMode CullMode;
+        public int RenderQueueOffsetNumber;
+    }
+
+    public class MToon0XColorDefinition
+    {
+        public Color LitColor;
+        public Texture2D LitMultiplyTexture;
+        public Color ShadeColor;
+        public Texture2D ShadeMultiplyTexture;
+        public float CutoutThresholdValue;
+    }
+
+    public class MToon0XLightingDefinition
+    {
+        public MToon0XLitAndShadeMixingDefinition LitAndShadeMixing;
+        public MToon0XLightingInfluenceDefinition LightingInfluence;
+        public MToon0XNormalDefinition Normal;
+    }
+
+    public class MToon0XLitAndShadeMixingDefinition
+    {
+        public float ShadingShiftValue;
+        public float ShadingToonyValue;
+        public float ShadowReceiveMultiplierValue;
+        public Texture2D ShadowReceiveMultiplierMultiplyTexture;
+        public float LitAndShadeMixingMultiplierValue;
+        public Texture2D LitAndShadeMixingMultiplierMultiplyTexture;
+    }
+
+    public class MToon0XLightingInfluenceDefinition
+    {
+        public float LightColorAttenuationValue;
+        public float GiIntensityValue;
+    }
+
+    public class MToon0XEmissionDefinition
+    {
+        public Color EmissionColor;
+        public Texture2D EmissionMultiplyTexture;
+    }
+
+    public class MToon0XMatCapDefinition
+    {
+        public Texture2D AdditiveTexture;
+    }
+
+    public class MToon0XRimDefinition
+    {
+        public Color RimColor;
+        public Texture2D RimMultiplyTexture;
+        public float RimLightingMixValue;
+        public float RimFresnelPowerValue;
+        public float RimLiftValue;
+    }
+
+    public class MToon0XNormalDefinition
+    {
+        public Texture2D NormalTexture;
+        public float NormalScaleValue;
+    }
+
+    public class MToon0XOutlineDefinition
+    {
+        public MToon0XOutlineWidthMode OutlineWidthMode;
+        public float OutlineWidthValue;
+        public Texture2D OutlineWidthMultiplyTexture;
+        public float OutlineScaledMaxDistanceValue;
+        public MToon0XOutlineColorMode OutlineColorMode;
+        public Color OutlineColor;
+        public float OutlineLightingMixValue;
+    }
+
+    public class MToon0XTextureUvCoordsDefinition
+    {
+        public Vector2 MainTextureLeftBottomOriginScale;
+        public Vector2 MainTextureLeftBottomOriginOffset;
+        public Texture2D UvAnimationMaskTexture;
+        public float UvAnimationScrollXSpeedValue;
+        public float UvAnimationScrollYSpeedValue;
+        public float UvAnimationRotationSpeedValue;
+    }
+}

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XDefinition.cs.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XDefinition.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 21bea29fcd9a4f15981b4c6c33ac9d87
+timeCreated: 1716647784

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XEnums.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XEnums.cs
@@ -1,0 +1,44 @@
+namespace VRMShaders.VRM10.MToon10.Runtime.MToon0X
+{
+    public enum MToon0XDebugMode
+    {
+        None = 0,
+        Normal = 1,
+        LitShadeRate = 2,
+    }
+
+    public enum MToon0XOutlineColorMode
+    {
+        FixedColor = 0,
+        MixedLighting = 1,
+    }
+
+    public enum MToon0XOutlineWidthMode
+    {
+        None = 0,
+        WorldCoordinates = 1,
+        ScreenCoordinates = 2,
+    }
+
+    public enum MToon0XRenderMode
+    {
+        Opaque = 0,
+        Cutout = 1,
+        Transparent = 2,
+        TransparentWithZWrite = 3,
+    }
+
+    public enum MToon0XCullMode
+    {
+        Off = 0,
+        Front = 1,
+        Back = 2,
+    }
+
+    public struct MToon0XRenderQueueRequirement
+    {
+        public int DefaultValue;
+        public int MinValue;
+        public int MaxValue;
+    }
+}

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XEnums.cs.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XEnums.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1214b566b5cd4dc390d11b3bed7f2a50
+timeCreated: 1716647818

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtils.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtils.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace VRMShaders.VRM10.MToon10.Runtime.MToon0X
+{
+    public static partial class MToon0XUtils
+    {
+        public const string ShaderName = "VRM/MToon";
+
+        public const string PropVersion = "_MToonVersion";
+        public const string PropDebugMode = "_DebugMode";
+        public const string PropOutlineWidthMode = "_OutlineWidthMode";
+        public const string PropOutlineColorMode = "_OutlineColorMode";
+        public const string PropBlendMode = "_BlendMode";
+        public const string PropCullMode = "_CullMode";
+        public const string PropOutlineCullMode = "_OutlineCullMode";
+        public const string PropCutoff = "_Cutoff";
+        public const string PropColor = "_Color";
+        public const string PropShadeColor = "_ShadeColor";
+        public const string PropMainTex = "_MainTex";
+        public const string PropShadeTexture = "_ShadeTexture";
+        public const string PropBumpScale = "_BumpScale";
+        public const string PropBumpMap = "_BumpMap";
+        public const string PropReceiveShadowRate = "_ReceiveShadowRate";
+        public const string PropReceiveShadowTexture = "_ReceiveShadowTexture";
+        public const string PropShadingGradeRate = "_ShadingGradeRate";
+        public const string PropShadingGradeTexture = "_ShadingGradeTexture";
+        public const string PropShadeShift = "_ShadeShift";
+        public const string PropShadeToony = "_ShadeToony";
+        public const string PropLightColorAttenuation = "_LightColorAttenuation";
+        public const string PropIndirectLightIntensity = "_IndirectLightIntensity";
+        public const string PropRimColor = "_RimColor";
+        public const string PropRimTexture = "_RimTexture";
+        public const string PropRimLightingMix = "_RimLightingMix";
+        public const string PropRimFresnelPower = "_RimFresnelPower";
+        public const string PropRimLift = "_RimLift";
+        public const string PropSphereAdd = "_SphereAdd";
+        public const string PropEmissionColor = "_EmissionColor";
+        public const string PropEmissionMap = "_EmissionMap";
+        public const string PropOutlineWidthTexture = "_OutlineWidthTexture";
+        public const string PropOutlineWidth = "_OutlineWidth";
+        public const string PropOutlineScaledMaxDistance = "_OutlineScaledMaxDistance";
+        public const string PropOutlineColor = "_OutlineColor";
+        public const string PropOutlineLightingMix = "_OutlineLightingMix";
+        public const string PropUvAnimMaskTexture = "_UvAnimMaskTexture";
+        public const string PropUvAnimScrollX = "_UvAnimScrollX";
+        public const string PropUvAnimScrollY = "_UvAnimScrollY";
+        public const string PropUvAnimRotation = "_UvAnimRotation";
+        public const string PropSrcBlend = "_SrcBlend";
+        public const string PropDstBlend = "_DstBlend";
+        public const string PropZWrite = "_ZWrite";
+        public const string PropAlphaToMask = "_AlphaToMask";
+
+        public const string KeyNormalMap = "_NORMALMAP";
+        public const string KeyAlphaTestOn = "_ALPHATEST_ON";
+        public const string KeyAlphaBlendOn = "_ALPHABLEND_ON";
+        public const string KeyAlphaPremultiplyOn = "_ALPHAPREMULTIPLY_ON";
+        public const string KeyOutlineWidthWorld = "MTOON_OUTLINE_WIDTH_WORLD";
+        public const string KeyOutlineWidthScreen = "MTOON_OUTLINE_WIDTH_SCREEN";
+        public const string KeyOutlineColorFixed = "MTOON_OUTLINE_COLOR_FIXED";
+        public const string KeyOutlineColorMixed = "MTOON_OUTLINE_COLOR_MIXED";
+        public const string KeyDebugNormal = "MTOON_DEBUG_NORMAL";
+        public const string KeyDebugLitShadeRate = "MTOON_DEBUG_LITSHADERATE";
+
+        public const string TagRenderTypeKey = "RenderType";
+        public const string TagRenderTypeValueOpaque = "Opaque";
+        public const string TagRenderTypeValueTransparentCutout = "TransparentCutout";
+        public const string TagRenderTypeValueTransparent = "Transparent";
+
+        public const int DisabledIntValue = 0;
+        public const int EnabledIntValue = 1;
+        
+        public static MToon0XRenderQueueRequirement GetRenderQueueRequirement(MToon0XRenderMode renderMode)
+        {
+            const int shaderDefaultQueue = -1;
+            const int firstTransparentQueue = 2501;
+            const int spanOfQueue = 50;
+            
+            switch (renderMode)
+            {
+                case MToon0XRenderMode.Opaque:
+                    return new MToon0XRenderQueueRequirement()
+                    {
+                        DefaultValue = shaderDefaultQueue,
+                        MinValue = shaderDefaultQueue,
+                        MaxValue = shaderDefaultQueue,
+                    };
+                case MToon0XRenderMode.Cutout:
+                    return new MToon0XRenderQueueRequirement()
+                    {
+                        DefaultValue = (int) RenderQueue.AlphaTest,
+                        MinValue = (int) RenderQueue.AlphaTest,
+                        MaxValue = (int) RenderQueue.AlphaTest,
+                    };
+                case MToon0XRenderMode.Transparent:
+                    return new MToon0XRenderQueueRequirement()
+                    {
+                        DefaultValue = (int) RenderQueue.Transparent,
+                        MinValue = (int) RenderQueue.Transparent - spanOfQueue + 1,
+                        MaxValue = (int) RenderQueue.Transparent,
+                    };
+                case MToon0XRenderMode.TransparentWithZWrite:
+                    return new MToon0XRenderQueueRequirement()
+                    {
+                        DefaultValue = firstTransparentQueue,
+                        MinValue = firstTransparentQueue,
+                        MaxValue = firstTransparentQueue + spanOfQueue - 1,
+                    };
+                default:
+                    throw new ArgumentOutOfRangeException("renderMode", renderMode, null);
+            }
+        }
+        
+    }
+}

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtils.cs.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 19cbe2ec05fb49daa74a8728583dcdf6
+timeCreated: 1716647798

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtilsGetter.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtilsGetter.cs
@@ -1,0 +1,180 @@
+using System;
+using UnityEngine;
+
+namespace VRMShaders.VRM10.MToon10.Runtime.MToon0X
+{
+    public static partial class MToon0XUtils
+    {
+        public static MToon0XDefinition GetMToonParametersFromMaterial(Material material)
+        {
+            return new MToon0XDefinition
+            {
+                Meta = new MToon0XMetaDefinition
+                {
+                    Implementation = Implementation,
+                    VersionNumber = material.GetInt(PropVersion),
+                },
+                Rendering = new MToon0XRenderingDefinition
+                {
+                    RenderMode = GetBlendMode(material),
+                    CullMode = GetCullMode(material),
+                    RenderQueueOffsetNumber = GetRenderQueueOffset(material, GetRenderQueueOriginMode(material)),
+                },
+                Color = new MToon0XColorDefinition
+                {
+                    LitColor = GetColor(material, PropColor),
+                    LitMultiplyTexture = GetTexture(material, PropMainTex),
+                    ShadeColor = GetColor(material, PropShadeColor),
+                    ShadeMultiplyTexture = GetTexture(material, PropShadeTexture),
+                    CutoutThresholdValue = GetValue(material, PropCutoff),
+                },
+                Lighting = new MToon0XLightingDefinition
+                {
+                    LitAndShadeMixing = new MToon0XLitAndShadeMixingDefinition
+                    {
+                        ShadingShiftValue = GetValue(material, PropShadeShift),
+                        ShadingToonyValue = GetValue(material, PropShadeToony),
+                        ShadowReceiveMultiplierValue = GetValue(material, PropReceiveShadowRate),
+                        ShadowReceiveMultiplierMultiplyTexture = GetTexture(material, PropReceiveShadowTexture),
+                        LitAndShadeMixingMultiplierValue = GetValue(material, PropShadingGradeRate),
+                        LitAndShadeMixingMultiplierMultiplyTexture = GetTexture(material, PropShadingGradeTexture),
+                    },
+                    LightingInfluence = new MToon0XLightingInfluenceDefinition
+                    {
+                        LightColorAttenuationValue = GetValue(material, PropLightColorAttenuation),
+                        GiIntensityValue = GetValue(material, PropIndirectLightIntensity),
+                    },
+                    Normal = new MToon0XNormalDefinition
+                    {
+                        NormalTexture = GetTexture(material, PropBumpMap),
+                        NormalScaleValue = GetValue(material, PropBumpScale),
+                    },
+                },
+                Emission = new MToon0XEmissionDefinition
+                {
+                    EmissionColor = GetColor(material, PropEmissionColor),
+                    EmissionMultiplyTexture = GetTexture(material, PropEmissionMap),
+                },
+                MatCap = new MToon0XMatCapDefinition
+                {
+                    AdditiveTexture = GetTexture(material, PropSphereAdd),
+                },
+                Rim = new MToon0XRimDefinition
+                {
+                    RimColor = GetColor(material, PropRimColor),
+                    RimMultiplyTexture = GetTexture(material, PropRimTexture),
+                    RimLightingMixValue = GetValue(material, PropRimLightingMix),
+                    RimFresnelPowerValue = GetValue(material, PropRimFresnelPower),
+                    RimLiftValue = GetValue(material, PropRimLift),
+                },
+                Outline = new MToon0XOutlineDefinition
+                {
+                    OutlineWidthMode = GetOutlineWidthMode(material),
+                    OutlineWidthValue = GetValue(material, PropOutlineWidth),
+                    OutlineWidthMultiplyTexture = GetTexture(material, PropOutlineWidthTexture),
+                    OutlineScaledMaxDistanceValue = GetValue(material, PropOutlineScaledMaxDistance),
+                    OutlineColorMode = GetOutlineColorMode(material),
+                    OutlineColor = GetColor(material, PropOutlineColor),
+                    OutlineLightingMixValue = GetValue(material, PropOutlineLightingMix),
+                },
+                TextureOption = new MToon0XTextureUvCoordsDefinition
+                {
+                    MainTextureLeftBottomOriginScale = material.GetTextureScale(PropMainTex),
+                    MainTextureLeftBottomOriginOffset = material.GetTextureOffset(PropMainTex),
+                    UvAnimationMaskTexture = GetTexture(material, PropUvAnimMaskTexture),
+                    UvAnimationScrollXSpeedValue = GetValue(material, PropUvAnimScrollX),
+                    UvAnimationScrollYSpeedValue = GetValue(material, PropUvAnimScrollY),
+                    UvAnimationRotationSpeedValue = GetValue(material, PropUvAnimRotation),
+                },
+            };
+        }
+
+        private static float GetValue(Material material, string propertyName)
+        {
+            return material.GetFloat(propertyName);
+        }
+
+        private static Color GetColor(Material material, string propertyName)
+        {
+            return material.GetColor(propertyName);
+        }
+
+        private static Texture2D GetTexture(Material material, string propertyName)
+        {
+            return (Texture2D) material.GetTexture(propertyName);
+        }
+
+        private static MToon0XRenderMode GetBlendMode(Material material)
+        {
+            if (material.IsKeywordEnabled(KeyAlphaTestOn))
+            {
+                return MToon0XRenderMode.Cutout;
+            }
+            else if (material.IsKeywordEnabled(KeyAlphaBlendOn))
+            {
+                switch (material.GetInt(PropZWrite))
+                {
+                    case EnabledIntValue:
+                        return MToon0XRenderMode.TransparentWithZWrite;
+                    case DisabledIntValue:
+                        return MToon0XRenderMode.Transparent;
+                    default:
+                        Debug.LogWarning("Invalid ZWrite Int Value.");
+                        return MToon0XRenderMode.Transparent;
+                }
+            }
+            else
+            {
+                return MToon0XRenderMode.Opaque;
+            }
+        }
+
+        private static MToon0XCullMode GetCullMode(Material material)
+        {
+            switch ((MToon0XCullMode) material.GetInt(PropCullMode))
+            {
+                case MToon0XCullMode.Off:
+                    return MToon0XCullMode.Off;
+                case MToon0XCullMode.Front:
+                    return MToon0XCullMode.Front;
+                case MToon0XCullMode.Back:
+                    return MToon0XCullMode.Back;
+                default:
+                    Debug.LogWarning("Invalid CullMode.");
+                    return MToon0XCullMode.Back;
+            }
+        }
+
+        private static MToon0XOutlineWidthMode GetOutlineWidthMode(Material material)
+        {
+            if (material.IsKeywordEnabled(KeyOutlineWidthWorld)) return MToon0XOutlineWidthMode.WorldCoordinates;
+            if (material.IsKeywordEnabled(KeyOutlineWidthScreen)) return MToon0XOutlineWidthMode.ScreenCoordinates;
+            
+            return MToon0XOutlineWidthMode.None;
+        }
+
+        private static MToon0XOutlineColorMode GetOutlineColorMode(Material material)
+        {
+            if (material.IsKeywordEnabled(KeyOutlineColorFixed)) return MToon0XOutlineColorMode.FixedColor;
+            if (material.IsKeywordEnabled(KeyOutlineColorMixed)) return MToon0XOutlineColorMode.MixedLighting;
+            
+            return MToon0XOutlineColorMode.FixedColor;
+        }
+
+        private static MToon0XRenderMode GetRenderQueueOriginMode(Material material)
+        {
+            return GetBlendMode(material);
+        }
+
+        private static int GetRenderQueueOffset(Material material, MToon0XRenderMode originMode)
+        {
+            var rawValue = material.renderQueue;
+            var requirement = GetRenderQueueRequirement(originMode);
+            if (rawValue < requirement.MinValue || rawValue > requirement.MaxValue)
+            {
+                return 0;
+            }
+            return rawValue - requirement.DefaultValue;
+        }
+    }
+}

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtilsGetter.cs.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtilsGetter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: efe45d6033e1413d8273a411c9fab601
+timeCreated: 1716647798

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtilsVersion.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtilsVersion.cs
@@ -1,0 +1,8 @@
+namespace VRMShaders.VRM10.MToon10.Runtime.MToon0X
+{
+    public static partial class MToon0XUtils
+    {
+        public const string Implementation = "Santarh/MToon";
+        public const int VersionNumber = 39;
+    }
+}

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtilsVersion.cs.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon0X/MToon0XUtilsVersion.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 48606eb94ede4ce88f49a8abf19b8b26
+timeCreated: 1716647836

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon10Context.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToon10Context.cs
@@ -20,83 +20,99 @@ namespace VRMShaders.VRM10.MToon10.Runtime
         public MToon10AlphaMode AlphaMode
         {
             get => (MToon10AlphaMode) _material.GetInt(MToon10Prop.AlphaMode);
+            set => _material.SetInt(MToon10Prop.AlphaMode, (int) value);
         }
 
         public MToon10TransparentWithZWriteMode TransparentWithZWriteMode
         {
             get => (MToon10TransparentWithZWriteMode) _material.GetInt(MToon10Prop.TransparentWithZWrite);
+            set => _material.SetInt(MToon10Prop.TransparentWithZWrite, (int) value);
         }
 
         public float AlphaCutoff
         {
             get => _material.GetFloat(MToon10Prop.AlphaCutoff);
+            set => _material.SetFloat(MToon10Prop.AlphaCutoff, value);
         }
 
         public int RenderQueueOffsetNumber
         {
             get => _material.GetInt(MToon10Prop.RenderQueueOffsetNumber);
+            set => _material.SetInt(MToon10Prop.RenderQueueOffsetNumber, value);
         }
 
         public MToon10DoubleSidedMode DoubleSidedMode
         {
             get => (MToon10DoubleSidedMode) _material.GetInt(MToon10Prop.DoubleSided);
+            set => _material.SetInt(MToon10Prop.DoubleSided, (int) value);
         }
 
         // Lighting
         public Color BaseColorFactorSrgb
         {
             get => _material.GetColor(MToon10Prop.BaseColorFactor);
+            set => _material.SetColor(MToon10Prop.BaseColorFactor, value);
         }
 
         public Texture BaseColorTexture
         {
             get => _material.GetTexture(MToon10Prop.BaseColorTexture);
+            set => _material.SetTexture(MToon10Prop.BaseColorTexture, value);
         }
 
         public Color ShadeColorFactorSrgb
         {
             get => _material.GetColor(MToon10Prop.ShadeColorFactor);
+            set => _material.SetColor(MToon10Prop.ShadeColorFactor, value);
         }
 
         public Texture ShadeColorTexture
         {
             get => _material.GetTexture(MToon10Prop.ShadeColorTexture);
+            set => _material.SetTexture(MToon10Prop.ShadeColorTexture, value);
         }
 
         public Texture NormalTexture
         {
             get => _material.GetTexture(MToon10Prop.NormalTexture);
+            set => _material.SetTexture(MToon10Prop.NormalTexture, value);
         }
 
         public float NormalTextureScale
         {
             get => _material.GetFloat(MToon10Prop.NormalTextureScale);
+            set => _material.SetFloat(MToon10Prop.NormalTextureScale, value);
         }
 
         public float ShadingShiftFactor
         {
             get => _material.GetFloat(MToon10Prop.ShadingShiftFactor);
+            set => _material.SetFloat(MToon10Prop.ShadingShiftFactor, value);
         }
 
         public Texture ShadingShiftTexture
         {
             get => _material.GetTexture(MToon10Prop.ShadingShiftTexture);
+            set => _material.SetTexture(MToon10Prop.ShadingShiftTexture, value);
         }
 
         public float ShadingShiftTextureScale
         {
             get => _material.GetFloat(MToon10Prop.ShadingShiftTextureScale);
+            set => _material.SetFloat(MToon10Prop.ShadingShiftTextureScale, value);
         }
 
         public float ShadingToonyFactor
         {
             get => _material.GetFloat(MToon10Prop.ShadingToonyFactor);
+            set => _material.SetFloat(MToon10Prop.ShadingToonyFactor, value);
         }
 
         // GI
         public float GiEqualizationFactor
         {
             get => _material.GetFloat(MToon10Prop.GiEqualizationFactor);
+            set => _material.SetFloat(MToon10Prop.GiEqualizationFactor, value);
         }
 
         // Emission
@@ -104,103 +120,123 @@ namespace VRMShaders.VRM10.MToon10.Runtime
         {
             // Emissive factor is stored in Linear space
             get => _material.GetColor(MToon10Prop.EmissiveFactor);
+            set => _material.SetColor(MToon10Prop.EmissiveFactor, value);
         }
 
         public Texture EmissiveTexture
         {
             get => _material.GetTexture(MToon10Prop.EmissiveTexture);
+            set => _material.SetTexture(MToon10Prop.EmissiveTexture, value);
         }
         // Rim Lighting
         public Color MatcapColorFactorSrgb
         {
             get => _material.GetColor(MToon10Prop.MatcapColorFactor);
+            set => _material.SetColor(MToon10Prop.MatcapColorFactor, value);
         }
         public Texture MatcapTexture
         {
             get => _material.GetTexture(MToon10Prop.MatcapTexture);
+            set => _material.SetTexture(MToon10Prop.MatcapTexture, value);
         }
 
         public Color ParametricRimColorFactorSrgb
         {
             get => _material.GetColor(MToon10Prop.ParametricRimColorFactor);
+            set => _material.SetColor(MToon10Prop.ParametricRimColorFactor, value);
         }
 
         public float ParametricRimFresnelPowerFactor
         {
             get => _material.GetFloat(MToon10Prop.ParametricRimFresnelPowerFactor);
+            set => _material.SetFloat(MToon10Prop.ParametricRimFresnelPowerFactor, value);
         }
 
         public float ParametricRimLiftFactor
         {
             get => _material.GetFloat(MToon10Prop.ParametricRimLiftFactor);
+            set => _material.SetFloat(MToon10Prop.ParametricRimLiftFactor, value);
         }
 
         public Texture RimMultiplyTexture
         {
             get => _material.GetTexture(MToon10Prop.RimMultiplyTexture);
+            set => _material.SetTexture(MToon10Prop.RimMultiplyTexture, value);
         }
 
         public float RimLightingMixFactor
         {
             get => _material.GetFloat(MToon10Prop.RimLightingMixFactor);
+            set => _material.SetFloat(MToon10Prop.RimLightingMixFactor, value);
         }
 
         // Outline
         public MToon10OutlineMode OutlineWidthMode
         {
             get => (MToon10OutlineMode) _material.GetInt(MToon10Prop.OutlineWidthMode);
+            set => _material.SetInt(MToon10Prop.OutlineWidthMode, (int) value);
         }
 
         public float OutlineWidthFactor
         {
             get => _material.GetFloat(MToon10Prop.OutlineWidthFactor);
+            set => _material.SetFloat(MToon10Prop.OutlineWidthFactor, value);
         }
 
         public Texture OutlineWidthMultiplyTexture
         {
             get => _material.GetTexture(MToon10Prop.OutlineWidthMultiplyTexture);
+            set => _material.SetTexture(MToon10Prop.OutlineWidthMultiplyTexture, value);
         }
 
         public Color OutlineColorFactorSrgb
         {
             get => _material.GetColor(MToon10Prop.OutlineColorFactor);
+            set => _material.SetColor(MToon10Prop.OutlineColorFactor, value);
         }
 
         public float OutlineLightingMixFactor
         {
             get => _material.GetFloat(MToon10Prop.OutlineLightingMixFactor);
+            set => _material.SetFloat(MToon10Prop.OutlineLightingMixFactor, value);
         }
 
         // UV Animation
         public Texture UvAnimationMaskTexture
         {
             get => _material.GetTexture(MToon10Prop.UvAnimationMaskTexture);
+            set => _material.SetTexture(MToon10Prop.UvAnimationMaskTexture, value);
         }
 
         public float UvAnimationScrollXSpeedFactor
         {
             get => _material.GetFloat(MToon10Prop.UvAnimationScrollXSpeedFactor);
+            set => _material.SetFloat(MToon10Prop.UvAnimationScrollXSpeedFactor, value);
         }
 
         public float UvAnimationScrollYSpeedFactor
         {
             get => _material.GetFloat(MToon10Prop.UvAnimationScrollYSpeedFactor);
+            set => _material.SetFloat(MToon10Prop.UvAnimationScrollYSpeedFactor, value);
         }
 
         public float UvAnimationRotationSpeedFactor
         {
             get => _material.GetFloat(MToon10Prop.UvAnimationRotationSpeedFactor);
+            set => _material.SetFloat(MToon10Prop.UvAnimationRotationSpeedFactor, value);
         }
 
         // etc
         public Vector2 TextureScale
         {
             get => _material.GetTextureScale(MToon10Prop.BaseColorTexture);
+            set => _material.SetTextureScale(MToon10Prop.BaseColorTexture, value);
         }
 
         public Vector2 TextureOffset
         {
             get => _material.GetTextureOffset(MToon10Prop.BaseColorTexture);
+            set => _material.SetTextureOffset(MToon10Prop.BaseColorTexture, value);
         }
     }
 }

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToonMaterialMigrator.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToonMaterialMigrator.cs
@@ -1,0 +1,130 @@
+using System;
+using UnityEngine;
+using VRMShaders.VRM10.MToon10.Runtime;
+using VRMShaders.VRM10.MToon10.Runtime.MToon0X;
+using Object = UnityEngine.Object;
+
+namespace VRMShaders.VRM10.MToon10.Editor
+{
+    public sealed class MToonMaterialMigrator
+    {
+        public MToonMaterialMigrator()
+        {
+
+        }
+
+        public bool TryMigrate(Material material, bool validateShaderName = true)
+        {
+            var tempMat = new Material(Shader.Find("VRM10/MToon10"));
+            try
+            {
+                if (validateShaderName && material.shader.name != MToon0XUtils.ShaderName)
+                {
+                    throw new ArgumentException($"The shader of the material is not {MToon0XUtils.ShaderName}");
+                }
+
+                var src = MToon0XUtils.GetMToonParametersFromMaterial(material);
+                var dst = new MToon10Context(tempMat);
+
+                dst.AlphaMode = src.Rendering.RenderMode switch
+                {
+                    MToon0XRenderMode.Opaque => MToon10AlphaMode.Opaque,
+                    MToon0XRenderMode.Cutout => MToon10AlphaMode.Cutout,
+                    MToon0XRenderMode.Transparent => MToon10AlphaMode.Transparent,
+                    MToon0XRenderMode.TransparentWithZWrite => MToon10AlphaMode.Transparent,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+                dst.TransparentWithZWriteMode = src.Rendering.RenderMode switch
+                {
+                    MToon0XRenderMode.Opaque => MToon10TransparentWithZWriteMode.Off,
+                    MToon0XRenderMode.Cutout => MToon10TransparentWithZWriteMode.Off,
+                    MToon0XRenderMode.Transparent => MToon10TransparentWithZWriteMode.Off,
+                    MToon0XRenderMode.TransparentWithZWrite => MToon10TransparentWithZWriteMode.On,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+                dst.AlphaCutoff = src.Color.CutoutThresholdValue;
+                dst.RenderQueueOffsetNumber = src.Rendering.RenderQueueOffsetNumber; // NOTE: Breaking Change
+                dst.DoubleSidedMode = src.Rendering.CullMode switch
+                {
+                    MToon0XCullMode.Back => MToon10DoubleSidedMode.Off,
+                    MToon0XCullMode.Off => MToon10DoubleSidedMode.On,
+                    MToon0XCullMode.Front => MToon10DoubleSidedMode.On, // NOTE: Breaking Change
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+                dst.BaseColorFactorSrgb = src.Color.LitColor; // NOTE: gamma -> gamma
+                dst.BaseColorTexture = src.Color.LitMultiplyTexture;
+                dst.ShadeColorFactorSrgb = src.Color.ShadeColor; // NOTE: gamma -> gamma
+                dst.ShadeColorTexture = src.Color.ShadeMultiplyTexture;
+                dst.NormalTexture = src.Lighting.Normal.NormalTexture;
+                dst.NormalTextureScale = src.Lighting.Normal.NormalScaleValue;
+                dst.ShadingShiftFactor = MToon10Migrator.MigrateToShadingShift(src.Lighting.LitAndShadeMixing.ShadingToonyValue, src.Lighting.LitAndShadeMixing.ShadingShiftValue);
+                dst.ShadingShiftTexture = src.Lighting.LitAndShadeMixing.LitAndShadeMixingMultiplierMultiplyTexture;
+                dst.ShadingShiftTexture = null;
+                dst.ShadingShiftTextureScale = 1f;
+                dst.ShadingToonyFactor = MToon10Migrator.MigrateToShadingToony(src.Lighting.LitAndShadeMixing.ShadingToonyValue, src.Lighting.LitAndShadeMixing.ShadingShiftValue);
+                dst.GiEqualizationFactor = MToon10Migrator.MigrateToGiEqualization(src.Lighting.LightingInfluence.GiIntensityValue);
+                dst.EmissiveFactorLinear = src.Emission.EmissionColor; // NOTE: linear -> linear
+                dst.EmissiveTexture = src.Emission.EmissionMultiplyTexture;
+                dst.MatcapColorFactorSrgb = src.MatCap.AdditiveTexture != null ? new Color(1, 1, 1) : new Color(0, 0, 0); // NOTE: gamma -> gamma
+                dst.MatcapTexture = src.MatCap.AdditiveTexture;
+                dst.ParametricRimColorFactorSrgb = src.Rim.RimColor; // NOTE: gamma -> gamma
+                dst.ParametricRimFresnelPowerFactor = src.Rim.RimFresnelPowerValue;
+                dst.ParametricRimLiftFactor = src.Rim.RimLiftValue;
+                dst.RimMultiplyTexture = src.Rim.RimMultiplyTexture;
+                dst.RimLightingMixFactor = 1.0f; // NOTE: Breaking Change
+                dst.OutlineWidthMode = src.Outline.OutlineWidthMode switch
+                {
+                    MToon0XOutlineWidthMode.None => MToon10OutlineMode.None,
+                    MToon0XOutlineWidthMode.WorldCoordinates => MToon10OutlineMode.World,
+                    MToon0XOutlineWidthMode.ScreenCoordinates => MToon10OutlineMode.Screen,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+                const float centimeterToMeter = 0.01f;
+                const float oneHundredth = 0.01f;
+                dst.OutlineWidthFactor = src.Outline.OutlineWidthMode switch
+                {
+                    MToon0XOutlineWidthMode.None => 0f,
+                    MToon0XOutlineWidthMode.WorldCoordinates => src.Outline.OutlineWidthValue * centimeterToMeter,
+                    MToon0XOutlineWidthMode.ScreenCoordinates => src.Outline.OutlineWidthValue * oneHundredth * 0.5f,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+                dst.OutlineWidthMultiplyTexture = src.Outline.OutlineWidthMultiplyTexture;
+                dst.OutlineColorFactorSrgb = src.Outline.OutlineColor; // NOTE: gamma -> gamma
+                dst.OutlineLightingMixFactor = src.Outline.OutlineColorMode switch
+                {
+                    MToon0XOutlineColorMode.FixedColor => 0f,
+                    MToon0XOutlineColorMode.MixedLighting => src.Outline.OutlineLightingMixValue,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+                dst.UvAnimationMaskTexture = src.TextureOption.UvAnimationMaskTexture;
+                dst.UvAnimationScrollXSpeedFactor = src.TextureOption.UvAnimationScrollXSpeedValue;
+                dst.UvAnimationScrollYSpeedFactor = src.TextureOption.UvAnimationScrollYSpeedValue;
+                dst.UvAnimationRotationSpeedFactor = src.TextureOption.UvAnimationRotationSpeedValue;
+                dst.TextureScale = src.TextureOption.MainTextureLeftBottomOriginScale;
+                dst.TextureOffset = src.TextureOption.MainTextureLeftBottomOriginOffset;
+
+                dst.Validate();
+
+                material.shader = tempMat.shader;
+                material.CopyPropertiesFromMaterial(tempMat);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+                return false;
+            }
+            finally
+            {
+                if (Application.isPlaying)
+                {
+                    Object.Destroy(tempMat);
+                }
+                else
+                {
+                    Object.DestroyImmediate(tempMat);
+                }
+            }
+        }
+    }
+}

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToonMaterialMigrator.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToonMaterialMigrator.cs
@@ -109,9 +109,8 @@ namespace VRMShaders.VRM10.MToon10.Editor
                 material.CopyPropertiesFromMaterial(tempMat);
                 return true;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                Debug.LogException(ex);
                 return false;
             }
             finally

--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToonMaterialMigrator.cs.meta
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToonMaterialMigrator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2f7043f8da8e43e9bae0ac3013610ba5
+timeCreated: 1716646837


### PR DESCRIPTION
![image](https://github.com/vrm-c/UniVRM/assets/328204/7c259bc4-98c0-46f3-8858-ed6bc8056016)

`VRM/MToon` シェーダの Material アセットを `VRM10/MToon10` シェーダにマイグレーションします。

これは Material アセットに完結した機能で、手動セットアップ時等に便利です。

ついでに
- VRM0X -> VRM10 のマイグレーションのバグを修正
- VRM10 -> MToon0X の asmdef 参照を削除