### PR TITLE
Improve export of BlendShapes

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/BlendShapeExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/BlendShapeExporter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -48,8 +47,7 @@ namespace UniGLTF
                     positionAccessorIndex = data.ExtendSparseBufferAndGetAccessorIndex(accessorCount,
                         sparseIndices.Select(x => positions[x]).ToArray(), sparseIndices, sparseIndicesViewIndex,
                         glBufferTarget.NONE);
-                    data.Gltf.accessors[positionAccessorIndex].min = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Min(a.x, b.x), Math.Min(a.y, b.y), Mathf.Min(a.z, b.z))).ToArray();
-                    data.Gltf.accessors[positionAccessorIndex].max = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Max(a.x, b.x), Math.Max(a.y, b.y), Mathf.Max(a.z, b.z))).ToArray();
+                    AccessorsBounds.UpdatePositionAccessorsBounds(data.Gltf.accessors[positionAccessorIndex], positions);
                 }
 
                 // normals
@@ -76,8 +74,7 @@ namespace UniGLTF
             {
                 // position
                 var positionAccessorIndex = data.ExtendBufferAndGetAccessorIndex(positions, glBufferTarget.ARRAY_BUFFER);
-                data.Gltf.accessors[positionAccessorIndex].min = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Min(a.x, b.x), Math.Min(a.y, b.y), Mathf.Min(a.z, b.z))).ToArray();
-                data.Gltf.accessors[positionAccessorIndex].max = positions.Aggregate(positions[0], (a, b) => new Vector3(Mathf.Max(a.x, b.x), Math.Max(a.y, b.y), Mathf.Max(a.z, b.z))).ToArray();
+                AccessorsBounds.UpdatePositionAccessorsBounds(data.Gltf.accessors[positionAccessorIndex], positions);
 
                 // normal
                 var normalAccessorIndex = -1;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExporter_SharedVertexBuffer.cs
@@ -166,10 +166,13 @@ namespace UniGLTF
                 var targetNames = new List<string>();
 
                 int exportBlendShapes = 0;
+                Vector3[] blendShapePositions = new Vector3[mesh.vertexCount];
+                Vector3[] blendShapeNormals = new Vector3[mesh.vertexCount];
                 for (int j = 0; j < unityMesh.Mesh.blendShapeCount; ++j)
                 {
                     var morphTarget = ExportMorphTarget(data,
                         unityMesh.Mesh, j,
+                        blendShapePositions, blendShapeNormals,
                         settings.UseSparseAccessorForMorphTarget,
                         settings.ExportOnlyBlendShapePosition, axisInverter);
                     if (morphTarget.POSITION < 0)
@@ -214,14 +217,13 @@ namespace UniGLTF
 
         static gltfMorphTarget ExportMorphTarget(ExportingGltfData data,
             Mesh mesh, int blendShapeIndex,
+            Vector3[] blendShapeVertices, Vector3[] blendShapeNormals,
             bool useSparseAccessorForMorphTarget,
             bool exportOnlyBlendShapePosition,
             IAxisInverter axisInverter)
         {
-            var blendShapeVertices = mesh.vertices;
             var usePosition = blendShapeVertices != null && blendShapeVertices.Length > 0;
 
-            var blendShapeNormals = mesh.normals;
             var useNormal = usePosition && blendShapeNormals != null && blendShapeNormals.Length == blendShapeVertices.Length;
             // var useNormal = usePosition && blendShapeNormals != null && blendShapeNormals.Length == blendShapeVertices.Length && !exportOnlyBlendShapePosition;
 
@@ -242,18 +244,6 @@ namespace UniGLTF
             for (int i = 0; i < blendShapeNormals.Length; ++i)
             {
                 blendShapeNormals[i] = axisInverter.InvertVector3(blendShapeNormals[i]);
-            }
-
-            var positions = mesh.vertices;
-            for (int i = 0; i < positions.Length; ++i)
-            {
-                positions[i] = axisInverter.InvertVector3(positions[i]);
-            }
-
-            var normals = mesh.normals;
-            for (int i = 0; i < normals.Length; ++i)
-            {
-                normals[i] = axisInverter.InvertVector3(normals[i]);
             }
 
             return BlendShapeExporter.Export(data,


### PR DESCRIPTION
- Boundsの計算にAggregate()を使用している箇所を変更 (関連: #1505 )
- mesh.vertices, mesh.normalsへの不要なアクセスの削減
- mesh.GetBlendShapeFrameVertices()に渡す配列を使い回すようにする