### PR TITLE
 Improved display of VRM10SpringBoneCollider on inspector

### DIFF
--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderDrawer.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderDrawer.cs
@@ -1,0 +1,21 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace UniVRM10
+{
+    [CustomPropertyDrawer(typeof(VRM10SpringBoneCollider))]
+    public class VRM10SpringBoneColliderDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect rect, SerializedProperty property, GUIContent label)
+        {
+            try
+            {
+                EditorGUI.ObjectField(rect, property, new GUIContent(((VRM10SpringBoneCollider)property.objectReferenceValue).GetIdentificationName()));
+            }
+            catch
+            {
+                EditorGUI.ObjectField(rect, property, new GUIContent());
+            }
+        }
+    }
+}

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderDrawer.cs.meta
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe667808067766449993409eec01bed5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderEditor.cs
@@ -13,7 +13,11 @@ namespace UniVRM10
                 GUI.backgroundColor = Color.cyan;
                 Repaint();
             }
-            base.OnInspectorGUI();
+            var property = serializedObject.FindProperty("m_Script");
+            var script = (VRM10SpringBoneCollider)target;
+            EditorGUILayout.PropertyField(property, new GUIContent("Script (" + script.GetIdentificationName() + ")"));
+            DrawPropertiesExcluding(serializedObject, "m_Script");
+            serializedObject.ApplyModifiedProperties();
         }
     }
 }

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneCollider.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneCollider.cs
@@ -45,5 +45,33 @@ namespace UniVRM10
                     break;
             }
         }
+
+        public string GetIdentificationName()
+        {
+            var index = 0;
+            var count = 0;
+
+            var colliders = transform.GetComponents<VRM10SpringBoneCollider>();
+            foreach (var collider in colliders)
+            {
+                if (collider.ColliderType == ColliderType)
+                {
+                    count++;
+                }
+                if (collider == this)
+                {
+                    index = count;
+                }
+            }
+
+            if (count > 1)
+            {
+                return ColliderType.ToString() + index.ToString();
+            }
+            else
+            {
+                return ColliderType.ToString();
+            }
+        }
     }
 }


### PR DESCRIPTION
VRM10SpringBoneColliderGroupのCollidersリストに識別名の表示を追加し、
同じボーンに複数のVRM10SpringBoneColliderが存在する場合に識別できるようにします。