### PR TITLE
Universal RP 17以降でScriptableRenderPass.Execute()がObsolete警告を出すのに対応

### DIFF
--- a/Assets/VRMShaders/VRM10/MToon10/Runtime/MToonOutlineRenderPass.cs
+++ b/Assets/VRMShaders/VRM10/MToon10/Runtime/MToonOutlineRenderPass.cs
@@ -1,4 +1,5 @@
 #if MTOON_URP
+using System;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
 
@@ -17,6 +18,9 @@ namespace VRMShaders.VRM10.MToon10.Runtime
             this.renderPassEvent = renderPassEvent;
         }
 
+#if UNITY_6000_0_OR_NEWER
+        [Obsolete]
+#endif
         public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             var cmd = CommandBufferPool.Get();


### PR DESCRIPTION
Universal RPパッケージ 17以降でScriptableRenderPass.Execute()がObsoleteになりました。

https://github.com/Unity-Technologies/Graphics/blob/515c4d9a59b7a669bd7a0a33726d4e8ae8d0c59a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/ScriptableRenderPass.cs#L660-L666

それが原因で、Execute()メソッドをオーバーライドをしている箇所がObsolete警告を出すようになりました。同様に[Obsolete]アトリビュートをつけることで警告を回避するようにしました。

本来なら「Universal RP 17以降が使われている場合[Obsolete]アトリビュートをつける」という方式で警告を回避したいですが、それは不可能なようでした。Universal RP 17はUnity 6000.0.0以降で有効なバージョンなため、代わりにUNITY_6000_0_OR_NEWERで判定するようにしました。

また、Obsoleteになってしまった部分の移行先であるRenderGraph版の実装追加も必要だとは思うのですが、このPull Requestではスコープ外とさせてください。