### PR TITLE
Fix collider group name export

### DIFF
--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -381,6 +381,7 @@ namespace UniVRM10
             {
                 springBone.ColliderGroups.Add(new UniGLTF.Extensions.VRMC_springBone.ColliderGroup
                 {
+                    Name = x.Name,
                     Colliders = x.Colliders.Select(y => Array.IndexOf(colliders, y)).ToArray(),
                 });
             }


### PR DESCRIPTION
VRM1.0のモデルエクスポート時に、ColliderGroupに入力したNameが引き継がれないので修正しています。