### PR TITLE
load KHR_texture_basisu as default (but not implemented now)

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ExtensionSupportFlags.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ExtensionSupportFlags.cs
@@ -5,7 +5,7 @@
         /// <summary>
         /// KHR_texture_basisu 拡張を考慮するかどうか。
         /// </summary>
-        public bool ConsiderKhrTextureBasisu { get; set; }
+        public bool ConsiderKhrTextureBasisu { get; set; } = true;
 
         /// <summary>
         /// ファイルに含まれる "全ての" テクスチャの画像が Y 軸反転しているかどうか。

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -36,7 +36,6 @@ namespace UniGLTF
             ITextureDeserializer textureDeserializer = null,
             IMaterialDescriptorGenerator materialGenerator = null)
         {
-            TryValidateGltfData(data);
             Data = data;
             TextureDescriptorGenerator = new GltfTextureDescriptorGenerator(Data);
             MaterialDescriptorGenerator = materialGenerator ?? MaterialDescriptorGeneratorUtility.GetValidGltfMaterialDescriptorGenerator();
@@ -74,21 +73,6 @@ namespace UniGLTF
             // https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression
             "KHR_draco_mesh_compression",
         };
-
-        /// <summary>
-        /// GltfData をバリデートし、読み込み不可能な問題があれば例外を投げる
-        /// </summary>
-        private static void TryValidateGltfData(GltfData data)
-        {
-            if (data.ExtensionSupportFlags.ConsiderKhrTextureBasisu && !Application.isPlaying)
-            {
-                throw new UniGLTFNotSupportedException("KHR_texture_basisu is only available in play mode.");
-            }
-            if (data.ExtensionSupportFlags.ConsiderKhrTextureBasisu && !data.ExtensionSupportFlags.IsAllTexturesYFlipped)
-            {
-                throw new UniGLTFNotSupportedException("KHR_texture_basisu is only supported with all textures Y-flipped.");
-            }
-        }
 
         #region Load. Build unity objects
         public virtual async Task<RuntimeGltfInstance> LoadAsync(IAwaitCaller awaitCaller, Func<string, IDisposable> MeasureTime = null)


### PR DESCRIPTION
glTF の定義に準じた `KHR_texture_basisu` を含むモデル通常の Runtime Load 関数でデフォルトでロードできるようにします。
ただし現状未実装なので例外が出ます。

Y 軸反転したものは、明示的にフラグを立てて `LoadGltfDataAsync` を用いてロードする必要があります。