### PR TITLE
Improved selection of VRM10SpringBoneCollider on inspector

### DIFF
--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderDrawer.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderDrawer.cs
@@ -1,4 +1,4 @@
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
 
 namespace UniVRM10
@@ -12,20 +12,24 @@ namespace UniVRM10
             var ButtonSize = GUI.skin.button.CalcSize(new GUIContent(ButtonLabel));
             try
             {
+                // オブジェクトフィールドを表示
                 var collider = property.objectReferenceValue as VRM10SpringBoneCollider;
                 EditorGUI.ObjectField(rect, property, new GUIContent(collider.GetIdentificationName()));
 
+                // 選択中のトランスフォームに複数のコライダが含まれる場合はリセレクトボタンを表示
                 var colliders = collider.transform.GetComponents<VRM10SpringBoneCollider>();
                 if (colliders.Length > 1)
                 {
                     if (GUI.Button(new Rect(rect.x + EditorGUIUtility.labelWidth - ButtonSize.x, rect.y, ButtonSize.x, rect.height), ButtonLabel))
                     {
+                        // リセレクト用ウィンドウの呼び出し
                         VRM10SpringBoneColliderEditorWindow.Show(property);
                     }
                 }
             }
             catch
             {
+                // オブジェクトフィールドを表示
                 EditorGUI.ObjectField(rect, property, new GUIContent());
             }
         }
@@ -38,7 +42,10 @@ namespace UniVRM10
 
         public static void Show(SerializedProperty property)
         {
+            // プロパティを保存
             targetProperty = property;
+
+            // タイトルを設定して補助ウィンドウとして開く
             var window = CreateInstance<VRM10SpringBoneColliderEditorWindow>();
             window.titleContent = new GUIContent("Reselect Collider from \"" + (property.objectReferenceValue as VRM10SpringBoneCollider).transform.name + "\"");
             window.ShowAuxWindow();
@@ -46,12 +53,14 @@ namespace UniVRM10
 
         private void OnGUI()
         {
+            // プロパティが無い場合はウィンドウを閉じる
             if (targetProperty is null)
             {
                 Close();
                 return;
             }
 
+            // コライダが無い場合はウィンドウを閉じる
             var transform = (targetProperty.objectReferenceValue as VRM10SpringBoneCollider).transform;
             var colliders = transform.GetComponents<VRM10SpringBoneCollider>();
             if (colliders.Length == 0)
@@ -60,11 +69,13 @@ namespace UniVRM10
                 return;
             }
 
+            // スクロール可能なウィンドウにコライダの数だけボタンを表示
             scrollPosition = GUILayout.BeginScrollView(scrollPosition);
             foreach (var collider in colliders)
             {
                 if (GUILayout.Button(collider.GetIdentificationName()))
                 {
+                    // プロパティを選択されたコライダに置き換える
                     targetProperty.objectReferenceValue = collider;
                     targetProperty.serializedObject.ApplyModifiedProperties();
                     Close();

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderDrawer.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderDrawer.cs
@@ -8,14 +8,69 @@ namespace UniVRM10
     {
         public override void OnGUI(Rect rect, SerializedProperty property, GUIContent label)
         {
+            const string ButtonLabel = "Reselect";
+            var ButtonSize = GUI.skin.button.CalcSize(new GUIContent(ButtonLabel));
             try
             {
-                EditorGUI.ObjectField(rect, property, new GUIContent(((VRM10SpringBoneCollider)property.objectReferenceValue).GetIdentificationName()));
+                var collider = property.objectReferenceValue as VRM10SpringBoneCollider;
+                EditorGUI.ObjectField(rect, property, new GUIContent(collider.GetIdentificationName()));
+
+                var colliders = collider.transform.GetComponents<VRM10SpringBoneCollider>();
+                if (colliders.Length > 1)
+                {
+                    if (GUI.Button(new Rect(rect.x + EditorGUIUtility.labelWidth - ButtonSize.x, rect.y, ButtonSize.x, rect.height), ButtonLabel))
+                    {
+                        VRM10SpringBoneColliderEditorWindow.Show(property);
+                    }
+                }
             }
             catch
             {
                 EditorGUI.ObjectField(rect, property, new GUIContent());
             }
+        }
+    }
+
+    public class VRM10SpringBoneColliderEditorWindow : EditorWindow
+    {
+        private static SerializedProperty targetProperty;
+        private Vector2 scrollPosition;
+
+        public static void Show(SerializedProperty property)
+        {
+            targetProperty = property;
+            var window = CreateInstance<VRM10SpringBoneColliderEditorWindow>();
+            window.titleContent = new GUIContent("Reselect Collider from \"" + (property.objectReferenceValue as VRM10SpringBoneCollider).transform.name + "\"");
+            window.ShowAuxWindow();
+        }
+
+        private void OnGUI()
+        {
+            if (targetProperty is null)
+            {
+                Close();
+                return;
+            }
+
+            var transform = (targetProperty.objectReferenceValue as VRM10SpringBoneCollider).transform;
+            var colliders = transform.GetComponents<VRM10SpringBoneCollider>();
+            if (colliders.Length == 0)
+            {
+                Close();
+                return;
+            }
+
+            scrollPosition = GUILayout.BeginScrollView(scrollPosition);
+            foreach (var collider in colliders)
+            {
+                if (GUILayout.Button(collider.GetIdentificationName()))
+                {
+                    targetProperty.objectReferenceValue = collider;
+                    targetProperty.serializedObject.ApplyModifiedProperties();
+                    Close();
+                }
+            }
+            GUILayout.EndScrollView();
         }
     }
 }


### PR DESCRIPTION
**概要**
同じボーンに複数のVRM10SpringBoneColliderが存在する場合に、インスペクターから目的のVRM10SpringBoneColliderを探して選択し易くするボタンの追加です。
#2306 の機能強化になります。

**変更前**
Unity標準のオブジェクトピッカーでVRM10SpringBoneColliderを選択しようとした場合、表示されるのはボーンの中で一番上にアタッチされているVRM10SpringBoneColliderだけです。
下記の画像の例では、chestボーンに3つのコライダが存在しますが、オブジェクトピッカーにはchestが1つしか表示されません。このchestを選択した場合、chestボーンの中で一番上に存在するSphereが選択されます。Capsule1やCapsule2を選択するには、ボーンのインスペクタを開いてCapsule1やCapsule2のスクリプトを一番上に移動してから再度選択する必要があり、手間がかかります。
![Unity標準のオブジェクトピッカー](https://github.com/vrm-c/UniVRM/assets/159165605/a77f5622-1d22-4b09-a038-f559dfb4e996)

**変更後**
オブジェクトフィールドに表示されているボーンに複数のコライダが存在する場合、リセレクトボタンを表示します。
ボタンを押下すると下記のようなウィンドウが表示され、ボーンの中の任意のコライダが選択できます。
![リセレクトボタン](https://github.com/vrm-c/UniVRM/assets/159165605/293c569d-2168-4a91-9bd5-4ac77b847369)
