### PR TITLE
コライダーエクスポート時の "Unreachable code detected" 警告に対応

### DIFF
--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -381,7 +381,6 @@ namespace UniVRM10
                         };
                         break;
                     }
-                    break;
             }
             return shape;
         }


### PR DESCRIPTION
次の警告が発生していました。

```
UniVRM/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs(384,21): warning CS0162: Unreachable code detected
```

冗長なbreakが存在していたため、削除しました。