### PR TITLE
fix blendshape bake.

### DIFF
--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
@@ -168,12 +168,13 @@ namespace UniGLTF.MeshUtility
             src.ClearBlendShapes();
             foreach (var blendshape in blendshapes)
             {
-                // blendshape の normal, tangent はちゃんと動作しなかった。
-                // position とロジックが違うのかもしれない。詳細不明。
-                // 法線に不要な変化が発生し、MToon の outline が乱れたりする。
-                // 変化しないようにする。
                 src.AddBlendShapeFrame(blendshape.Name, blendshape.FrameWeight,
-                    blendshape.Vertices, null, null);
+                    blendshape.Vertices,
+                    // 法線は import / export 対象
+                    blendshape.Normals,
+                    // tangent は import / export の扱いが無い
+                    null
+                    );
             }
         }
     }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
@@ -168,6 +168,10 @@ namespace UniGLTF.MeshUtility
             src.ClearBlendShapes();
             foreach (var blendshape in blendshapes)
             {
+                // blendshape の normal, tangent はちゃんと動作しなかった。
+                // position とロジックが違うのかもしれない。詳細不明。
+                // 法線に不要な変化が発生し、MToon の outline が乱れたりする。
+                // 変化しないようにする。
                 src.AddBlendShapeFrame(blendshape.Name, blendshape.FrameWeight,
                     blendshape.Vertices, null, null);
             }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using UnityEngine;
 using System.Linq;
 using VRMShaders;
+using System;
+using System.Collections.Generic;
 
 
 namespace UniGLTF.MeshUtility
@@ -23,10 +25,10 @@ namespace UniGLTF.MeshUtility
             return null;
         }
 
-        public static Mesh Copy(this Mesh src, bool copyBlendShape)
+        public static Mesh Copy(this Mesh src, bool copyBlendShape, string nameSuffix = "(copy)")
         {
             var dst = new Mesh();
-            dst.name = src.name + "(copy)";
+            dst.name = src.name + nameSuffix;
 #if UNITY_2017_3_OR_NEWER
             dst.indexFormat = src.indexFormat;
 #endif
@@ -106,6 +108,68 @@ namespace UniGLTF.MeshUtility
                     var t = m.MultiplyVector((Vector3)x);
                     return new Vector4(t.x, t.y, t.z, x.w);
                 }).ToArray();
+            }
+        }
+
+        class BlendShape
+        {
+            public readonly string Name;
+            public readonly float FrameWeight;
+            public readonly Vector3[] Vertices;
+            public readonly Vector3[] Normals;
+            public readonly Vector3[] Tangents;
+            public BlendShape(string name, float frameweight,
+                IEnumerable<Vector3> vertices,
+                IEnumerable<Vector3> normals,
+                IEnumerable<Vector3> tangents)
+            {
+                Name = name;
+                FrameWeight = frameweight;
+                Vertices = vertices.ToArray();
+                Normals = normals.ToArray();
+                Tangents = tangents.ToArray();
+            }
+
+            public static BlendShape FromMesh(Mesh mesh, int i, Matrix4x4 m)
+            {
+                var blendShapePositions = new Vector3[mesh.vertexCount];
+                var blendShapeNormals = new Vector3[mesh.vertexCount];
+                var blendShapeTangents = new Vector3[mesh.vertexCount];
+                mesh.GetBlendShapeFrameVertices(i, 0, blendShapePositions, blendShapeNormals, blendShapeTangents);
+                return new BlendShape(
+                    mesh.GetBlendShapeName(i), mesh.GetBlendShapeFrameWeight(i, 0),
+                    blendShapePositions.Select(x => m.MultiplyPoint(x)),
+                    blendShapeNormals.Select(x => m.MultiplyPoint(x)),
+                    blendShapeTangents.Select(x => m.MultiplyPoint(x)));
+            }
+        }
+
+        public static void ApplyMatrixAlsoBlendShapes(this Mesh src, Matrix4x4 m)
+        {
+            src.vertices = src.vertices.Select(x => m.MultiplyPoint(x)).ToArray();
+            if (src.normals != null && src.normals.Length > 0)
+            {
+                src.normals = src.normals.Select(x => m.MultiplyVector(x.normalized)).ToArray();
+            }
+            if (src.tangents != null && src.tangents.Length > 0)
+            {
+                src.tangents = src.tangents.Select(x =>
+                {
+                    var t = m.MultiplyVector((Vector3)x);
+                    return new Vector4(t.x, t.y, t.z, x.w);
+                }).ToArray();
+            }
+
+            var blendshapes = new List<BlendShape>();
+            for (int i = 0; i < src.blendShapeCount; ++i)
+            {
+                blendshapes.Add(BlendShape.FromMesh(src, i, m));
+            }
+            src.ClearBlendShapes();
+            foreach (var blendshape in blendshapes)
+            {
+                src.AddBlendShapeFrame(blendshape.Name, blendshape.FrameWeight,
+                    blendshape.Vertices, null, null);
             }
         }
     }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshFreezer.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshFreezer.cs
@@ -143,10 +143,13 @@ namespace UniGLTF.MeshUtility
             }
 
             // BakeMesh
-            var mesh = src.sharedMesh.Copy(false, ".baked");
-            // TODO: scale に関する第２引数があるが true にすると mesh がつぶれた。どうやって使うのか
+            var mesh = new Mesh
+            {
+                name = src.sharedMesh.name + ".baked"
+            };
+            // memo: BakeMesh(mesh, useScale) という第２引数がある
             src.BakeMesh(mesh);
-            CopyBlendShapes(src, mesh);
+            BakeBlendShapes(src, mesh);
 
             // apply SkinnedMesh.transform rotation
             var m = Matrix4x4.TRS(Vector3.zero, src.transform.rotation, Vector3.one);
@@ -183,7 +186,7 @@ namespace UniGLTF.MeshUtility
             src.sharedMesh = srcMesh;
         }
 
-        private static void CopyBlendShapes(SkinnedMeshRenderer src, Mesh mesh)
+        private static void BakeBlendShapes(SkinnedMeshRenderer src, Mesh mesh)
         {
             var srcMesh = src.sharedMesh;
 
@@ -247,7 +250,7 @@ namespace UniGLTF.MeshUtility
                 Vector3[] normals = blendShapeMesh.normals;
                 for (int j = 0; j < normals.Length; ++j)
                 {
-                    normals[j] = normals[j] - meshNormals[j];
+                    normals[j] = normals[j].normalized - meshNormals[j].normalized;
                 }
 
                 Vector3[] tangents = blendShapeMesh.tangents.Select(x => (Vector3)x).ToArray();
@@ -255,7 +258,7 @@ namespace UniGLTF.MeshUtility
                 {
                     for (int j = 0; j < tangents.Length; ++j)
                     {
-                        tangents[j] = tangents[j] - meshTangents[j];
+                        tangents[j] = tangents[j].normalized - meshTangents[j].normalized;
                     }
                 }
 

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshFreezer.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshFreezer.cs
@@ -122,13 +122,6 @@ namespace UniGLTF.MeshUtility
             return newBoneWeights;
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="src"></param>
-        /// <param name="boneMap">正規化前のボーンから正規化後のボーンを得る</param>
-        /// <returns></returns>
-        /// <exception cref="Exception"></exception>
         public static Mesh NormalizeSkinnedMesh(SkinnedMeshRenderer src)
         {
             if (src == null
@@ -151,21 +144,13 @@ namespace UniGLTF.MeshUtility
 
             // BakeMesh
             var mesh = src.sharedMesh.Copy(false, ".baked");
+            // TODO: scale に関する第２引数があるが true にすると mesh がつぶれた。どうやって使うのか
             src.BakeMesh(mesh);
             CopyBlendShapes(src, mesh);
 
             // apply SkinnedMesh.transform rotation
             var m = Matrix4x4.TRS(Vector3.zero, src.transform.rotation, Vector3.one);
             mesh.ApplyMatrixAlsoBlendShapes(m);
-
-            //
-            // BlendShapes
-            //
-            // {
-            //     var m = src.localToWorldMatrix; // include scaling
-            //     m.SetColumn(3, new Vector4(0, 0, 0, 1)); // no translation
-            //     CopyBlendShapes(src, srcMesh, mesh, m);
-            // }
 
             return mesh;
         }
@@ -201,12 +186,6 @@ namespace UniGLTF.MeshUtility
         private static void CopyBlendShapes(SkinnedMeshRenderer src, Mesh mesh)
         {
             var srcMesh = src.sharedMesh;
-            var blendShapeValues = new Dictionary<int, float>();
-            for (int i = 0; i < srcMesh.blendShapeCount; i++)
-            {
-                var val = src.GetBlendShapeWeight(i);
-                if (val > 0) blendShapeValues.Add(i, val);
-            }
 
             // clear blendShape always
             var backcup = new List<float>();
@@ -256,36 +235,18 @@ namespace UniGLTF.MeshUtility
                     throw new Exception("different vertex count");
                 }
 
-                var value = blendShapeValues.ContainsKey(i) ? blendShapeValues[i] : 0;
-                src.SetBlendShapeWeight(i, value);
+                src.SetBlendShapeWeight(i, backcup[i]);
 
                 Vector3[] vertices = blendShapeMesh.vertices;
 
                 for (int j = 0; j < vertices.Length; ++j)
                 {
-                    // if (originalBlendShapePositions[j] == Vector3.zero)
-                    // {
-                    //     vertices[j] = Vector3.zero;
-                    // }
-                    // else
-                    // {
-                    //     vertices[j] = m.MultiplyPoint(vertices[j] - meshVertices[j]);
-                    // }
                     vertices[j] = vertices[j] - meshVertices[j];
                 }
 
                 Vector3[] normals = blendShapeMesh.normals;
                 for (int j = 0; j < normals.Length; ++j)
                 {
-                    // if (originalBlendShapeNormals[j] == Vector3.zero)
-                    // {
-                    //     normals[j] = Vector3.zero;
-
-                    // }
-                    // else
-                    // {
-                    //     normals[j] = m.MultiplyVector(normals[j].normalized) - meshNormals[j];
-                    // }
                     normals[j] = normals[j] - meshNormals[j];
                 }
 
@@ -294,14 +255,6 @@ namespace UniGLTF.MeshUtility
                 {
                     for (int j = 0; j < tangents.Length; ++j)
                     {
-                        // if (originalBlendShapeTangents[j] == Vector3.zero)
-                        // {
-                        //     tangents[j] = Vector3.zero;
-                        // }
-                        // else
-                        // {
-                        //     tangents[j] = m.MultiplyVector(tangents[j]) - meshTangents[j];
-                        // }
                         tangents[j] = tangents[j] - meshTangents[j];
                     }
                 }


### PR DESCRIPTION
fixed #2327

簡単になるように処理順をみなおし。

```cs
var mesh = src.sharedMesh.Copy(false, ".baked");
src.BakeMesh(mesh);
CopyBlendShapes(src, mesh); // matrix は適用しない

var m = Matrix4x4.TRS(Vector3.zero, src.transform.rotation, Vector3.one);
mesh.ApplyMatrixAlsoBlendShapes(m); // 最後の一回だけまとめて matrix を適用する
```