### PR TITLE
Suppress shader compile errors when URP is not imported.

### DIFF
--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_urp.shader
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_urp.shader
@@ -67,6 +67,12 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
     // Shader Model 3.0
     SubShader
     {
+        PackageRequirements
+        {
+            "unity": "2021.3"
+            "com.unity.render-pipelines.universal": "12.0.0"
+        }
+
         Tags
         {
             "RenderType" = "Opaque"


### PR DESCRIPTION
プロジェクトに URP が未導入の場合に MToon10 の URP 版シェーダがコンパイルエラーを Log に出力するのを抑制。

Unity 2021 からの機能を利用
https://docs.unity3d.com/2021.3/Documentation/Manual/SL-PackageRequirements.html