### PR TITLE
VRM0のMToonエクスポート時にノーマルマップテクスチャをglTFのマテリアルにもエクスポートするようにした

### DIFF
--- a/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Export/Materials/BuiltInVrmMToonMaterialExporter.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Export/Materials/BuiltInVrmMToonMaterialExporter.cs
@@ -32,6 +32,7 @@ namespace VRM
             ExportRenderingSettings(srcProps, dst);
             ExportBaseColor(src, srcProps, textureExporter, dst);
             ExportEmission(src, srcProps, textureExporter, dst);
+            ExportNormal(src, srcProps, textureExporter, dst);
 
             return true;
         }
@@ -112,6 +113,23 @@ namespace VRM
                         index = index,
                     };
                     ExportMainTextureTransform(srcMaterial, dst.emissiveTexture);
+                }
+            }
+        }
+
+        private static void ExportNormal(Material srcMaterial, MToonDefinition src, ITextureExporter textureExporter, glTFMaterial dst)
+        {
+            if (src.Lighting.Normal.NormalTexture != null)
+            {
+                var index = textureExporter.RegisterExportingAsNormal(src.Lighting.Normal.NormalTexture);
+                if (index != -1)
+                {
+                    dst.normalTexture = new glTFMaterialNormalTextureInfo()
+                    {
+                        index = index,
+                        scale = src.Lighting.Normal.NormalScaleValue,
+                    };
+                    ExportMainTextureTransform(srcMaterial, dst.normalTexture);
                 }
             }
         }


### PR DESCRIPTION
UniVRM 0.6系や0.5系ではMToon0のノーマルマップテクスチャはglTF側にも出力されていました。最新版ではそうなっていなかったので、同様に出力する機能を追加しました

glTFへのフォールバックした際の見た目が改善されるため、良ければ是非マージお願いしたいです