### PR TITLE
Maintain extension support flags when migrating a vrm0.x model.

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ExtensionSupportFlags.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ExtensionSupportFlags.cs
@@ -15,5 +15,11 @@
         /// https://docs.unity3d.com/Packages/com.unity.cloud.ktx@3.2/manual/creating-textures.html
         /// </summary>
         public bool IsAllTexturesYFlipped { get; set; }
+
+        public void CopyValueFrom(ExtensionSupportFlags src)
+        {
+            ConsiderKhrTextureBasisu = src.ConsiderKhrTextureBasisu;
+            IsAllTexturesYFlipped = src.IsAllTexturesYFlipped;
+        }
     }
 }

--- a/Assets/VRM10/Runtime/IO/Vrm10Data.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Data.cs
@@ -100,6 +100,7 @@ namespace UniVRM10
 
             // マイグレーション結果をパースする
             var migratedData = new GlbLowLevelParser(data.TargetPath, migrated).Parse();
+            migratedData.ExtensionSupportFlags.CopyValueFrom(data.ExtensionSupportFlags);
             try
             {
                 if (!UniGLTF.Extensions.VRMC_vrm.GltfDeserializer.TryGet(migratedData.GLTF.extensions, out VRMC_vrm vrm))


### PR DESCRIPTION
VRM 0.X モデルを VRM 1.0 モデルにマイグレーションするとき、もともとの `GltfData` に与えられていた `ExtensionSupportFlags` が初期値に戻ってしまう問題を解決します