### PR TITLE
URP プロジェクトで matcap を含むモデルを Editor import するとエラーになるのを回避(暫定)

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/TextureExtractor.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/TextureExtractor.cs
@@ -59,7 +59,8 @@ namespace UniGLTF
             }
             else
             {
-                throw new Exception($"{key} is not converted.");
+                // throw new Exception($"{key} is not converted.");
+                Debug.LogWarning($"{key} is not converted.");
             }
         }
 


### PR DESCRIPTION
とりえあずエラー回避。

Alicia では以下のメッセージが出ます。
`Exception: UnityEngine.Texture:Sphere is not converted` 

Assets\VRM\Runtime\IO\MaterialIO\URP\Import\UrpVrmMaterialDescriptorGenerator.cs
> mtoon URP "MToon" shader is not ready. import fallback to unlit