### PR TITLE
Use URP as default in development project.

### DIFF
--- a/Assets/Development.meta
+++ b/Assets/Development.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a63f9042ef272324a8f6ebed8be2901b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Editor.meta
+++ b/Assets/Development/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2be9358956a903e47970a43ff72b7d1c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Editor/Development.Editor.asmdef
+++ b/Assets/Development/Editor/Development.Editor.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "Development.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:5f875fdc81c40184c8333b9d63c6ddd5",
+        "GUID:05dd262a0c0a2f841b8252c8c3815582",
+        "GUID:f7b2dd4e5e1e7264089dc065c45db910",
+        "GUID:e47c917724578cc43b5506c17a27e9a0",
+        "GUID:6aae90b2207f6fe4fa38ba53e3ab92ef"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Development/Editor/Development.Editor.asmdef.meta
+++ b/Assets/Development/Editor/Development.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 090ebac71232bfe498e86a0ae669ee4b
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Runtime.meta
+++ b/Assets/Development/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 807644de14d790d438bc435c90f7bce8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Runtime/Development.asmdef
+++ b/Assets/Development/Runtime/Development.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Development",
+    "rootNamespace": "",
+    "references": [
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:05dd262a0c0a2f841b8252c8c3815582",
+        "GUID:e47c917724578cc43b5506c17a27e9a0"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Development/Runtime/Development.asmdef.meta
+++ b/Assets/Development/Runtime/Development.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7529cbe8f8dd48148b0e5ba9a2764b9d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Settings.meta
+++ b/Assets/Development/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7861d56b6e685354fbf01e9b455b448c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Settings/URP.asset
+++ b/Assets/Development/Settings/URP.asset
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf2edee5c58d82540a51f03df9d42094, type: 3}
+  m_Name: URP
+  m_EditorClassIdentifier: 
+  k_AssetVersion: 9
+  k_AssetPreviousVersion: 9
+  m_RendererType: 1
+  m_RendererData: {fileID: 0}
+  m_RendererDataList:
+  - {fileID: 11400000, guid: 480294d90dacafe4194ab2cb312ad15f, type: 2}
+  m_DefaultRendererIndex: 0
+  m_RequireDepthTexture: 0
+  m_RequireOpaqueTexture: 0
+  m_OpaqueDownsampling: 1
+  m_SupportsTerrainHoles: 1
+  m_StoreActionsOptimization: 0
+  m_SupportsHDR: 1
+  m_MSAA: 4
+  m_RenderScale: 1
+  m_UpscalingFilter: 0
+  m_FsrOverrideSharpness: 0
+  m_FsrSharpness: 0.92
+  m_MainLightRenderingMode: 1
+  m_MainLightShadowsSupported: 1
+  m_MainLightShadowmapResolution: 2048
+  m_AdditionalLightsRenderingMode: 1
+  m_AdditionalLightsPerObjectLimit: 4
+  m_AdditionalLightShadowsSupported: 0
+  m_AdditionalLightsShadowmapResolution: 2048
+  m_AdditionalLightsShadowResolutionTierLow: 256
+  m_AdditionalLightsShadowResolutionTierMedium: 512
+  m_AdditionalLightsShadowResolutionTierHigh: 1024
+  m_ReflectionProbeBlending: 0
+  m_ReflectionProbeBoxProjection: 0
+  m_ShadowDistance: 50
+  m_ShadowCascadeCount: 1
+  m_Cascade2Split: 0.25
+  m_Cascade3Split: {x: 0.1, y: 0.3}
+  m_Cascade4Split: {x: 0.067, y: 0.2, z: 0.467}
+  m_CascadeBorder: 0.2
+  m_ShadowDepthBias: 1
+  m_ShadowNormalBias: 1
+  m_AnyShadowsSupported: 1
+  m_SoftShadowsSupported: 0
+  m_ConservativeEnclosingSphere: 1
+  m_NumIterationsEnclosingSphere: 64
+  m_AdditionalLightsCookieResolution: 2048
+  m_AdditionalLightsCookieFormat: 3
+  m_UseSRPBatcher: 1
+  m_SupportsDynamicBatching: 0
+  m_MixedLightingSupported: 1
+  m_SupportsLightLayers: 0
+  m_DebugLevel: 0
+  m_UseAdaptivePerformance: 1
+  m_ColorGradingMode: 0
+  m_ColorGradingLutSize: 32
+  m_UseFastSRGBLinearConversion: 0
+  m_ShadowType: 1
+  m_LocalShadowsSupported: 0
+  m_LocalShadowsAtlasResolution: 256
+  m_MaxPixelLights: 0
+  m_ShadowAtlasResolution: 256
+  m_ShaderVariantLogLevel: 0
+  m_VolumeFrameworkUpdateMode: 0
+  m_ShadowCascades: 0

--- a/Assets/Development/Settings/URP.asset.meta
+++ b/Assets/Development/Settings/URP.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a2530151e324c8a4092b54aec3a17066
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Settings/URP_Renderer.asset
+++ b/Assets/Development/Settings/URP_Renderer.asset
@@ -1,0 +1,73 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-3261744245627292160
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b6d00cd3f0249a2b4ee7dc86f9a8d63, type: 3}
+  m_Name: MToonOutlineRenderFeature
+  m_EditorClassIdentifier: 
+  m_Active: 1
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de640fe3d0db1804a85f9fc8f5cadab6, type: 3}
+  m_Name: URP_Renderer
+  m_EditorClassIdentifier: 
+  debugShaders:
+    debugReplacementPS: {fileID: 4800000, guid: cf852408f2e174538bcd9b7fda1c5ae7,
+      type: 3}
+  m_RendererFeatures:
+  - {fileID: -3261744245627292160}
+  m_RendererFeatureMap: 00f635dbe3f4bbd2
+  m_UseNativeRenderPass: 0
+  postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
+  xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
+  shaders:
+    blitPS: {fileID: 4800000, guid: c17132b1f77d20942aa75f8429c0f8bc, type: 3}
+    copyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
+    screenSpaceShadowPS: {fileID: 0}
+    samplingPS: {fileID: 4800000, guid: 04c410c9937594faa893a11dceb85f7e, type: 3}
+    stencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
+    fallbackErrorPS: {fileID: 4800000, guid: e6e9a19c3678ded42a3bc431ebef7dbd, type: 3}
+    materialErrorPS: {fileID: 4800000, guid: 5fd9a8feb75a4b5894c241777f519d4e, type: 3}
+    coreBlitPS: {fileID: 4800000, guid: 93446b5c5339d4f00b85c159e1159b7c, type: 3}
+    coreBlitColorAndDepthPS: {fileID: 4800000, guid: d104b2fc1ca6445babb8e90b0758136b,
+      type: 3}
+    cameraMotionVector: {fileID: 4800000, guid: c56b7e0d4c7cb484e959caeeedae9bbf,
+      type: 3}
+    objectMotionVector: {fileID: 4800000, guid: 7b3ede40266cd49a395def176e1bc486,
+      type: 3}
+  m_AssetVersion: 2
+  m_OpaqueLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_TransparentLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_DefaultStencilState:
+    overrideStencilState: 0
+    stencilReference: 0
+    stencilCompareFunction: 8
+    passOperation: 2
+    failOperation: 0
+    zFailOperation: 0
+  m_ShadowTransparentReceive: 1
+  m_RenderingMode: 0
+  m_DepthPrimingMode: 0
+  m_CopyDepthMode: 0
+  m_AccurateGbufferNormals: 0
+  m_ClusteredRendering: 0
+  m_TileSize: 32
+  m_IntermediateTextureMode: 1

--- a/Assets/Development/Settings/URP_Renderer.asset.meta
+++ b/Assets/Development/Settings/URP_Renderer.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 480294d90dacafe4194ab2cb312ad15f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ec995e51a6e251468d2a3fd8a686257, type: 3}
+  m_Name: UniversalRenderPipelineGlobalSettings
+  m_EditorClassIdentifier: 
+  k_AssetVersion: 2
+  lightLayerName0: Light Layer default
+  lightLayerName1: Light Layer 1
+  lightLayerName2: Light Layer 2
+  lightLayerName3: Light Layer 3
+  lightLayerName4: Light Layer 4
+  lightLayerName5: Light Layer 5
+  lightLayerName6: Light Layer 6
+  lightLayerName7: Light Layer 7
+  m_StripDebugVariants: 1
+  m_StripUnusedPostProcessingVariants: 0
+  m_StripUnusedVariants: 1
+  supportRuntimeDebugDisplay: 0

--- a/Assets/UniversalRenderPipelineGlobalSettings.asset.meta
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46a76356a8d93364bab3c841a0826a14
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -45,7 +45,8 @@ GraphicsSettings:
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}
-  m_CustomRenderPipeline: {fileID: 0}
+  m_CustomRenderPipeline: {fileID: 11400000, guid: a2530151e324c8a4092b54aec3a17066,
+    type: 2}
   m_TransparencySortMode: 0
   m_TransparencySortAxis: {x: 0, y: 0, z: 1}
   m_DefaultRenderingPath: 1
@@ -69,7 +70,7 @@ GraphicsSettings:
   m_DefaultRenderingLayerMask: 1
   m_LogWhenShaderIsCompiled: 0
   m_SRPDefaultSettings:
-    UnityEngine.Rendering.Universal.UniversalRenderPipeline: {fileID: 11400000, guid: e1da13a6b8c25524d927be386f14513c,
+    UnityEngine.Rendering.Universal.UniversalRenderPipeline: {fileID: 11400000, guid: 46a76356a8d93364bab3c841a0826a14,
       type: 2}
   m_CameraRelativeLightCulling: 0
   m_CameraRelativeShadowCulling: 0


### PR DESCRIPTION
開発プロジェクトのデフォルトを URP に変更します。

ただし現時点ではサンプルシーンなどに変更は入れていないため、URP では利用できず、Built-in 用のままです。

`Assets/Development` パッケージは公開用ではなく、UniVRM 開発プロジェクトの管理用に利用されることが期待されます。
たとえばバージョンインクリメントユーティリティはここにある方が望ましいと考えます。