### PR TITLE
TryGetComponent に書き換え

### DIFF
--- a/Assets/UniGLTF/Editor/Animation/AnimationExporter.cs
+++ b/Assets/UniGLTF/Editor/Animation/AnimationExporter.cs
@@ -147,7 +147,7 @@ namespace UniGLTF
                 var elementCount = 0;
                 if (property == glTFAnimationTarget.AnimationProperties.BlendShape)
                 {
-                    var mesh = nodes[nodeIndex].GetComponent<SkinnedMeshRenderer>().sharedMesh;
+                    var mesh = nodes[nodeIndex].GetComponentOrThrow<SkinnedMeshRenderer>().sharedMesh;
                     elementCount = mesh.blendShapeCount;
                 }
                 else
@@ -168,7 +168,7 @@ namespace UniGLTF
                 float valueFactor = 1.0f;
                 if (property == glTFAnimationTarget.AnimationProperties.BlendShape)
                 {
-                    var mesh = nodes[nodeIndex].GetComponent<SkinnedMeshRenderer>().sharedMesh;
+                    var mesh = nodes[nodeIndex].GetComponentOrThrow<SkinnedMeshRenderer>().sharedMesh;
                     var blendShapeName = binding.propertyName.Replace("blendShape.", "");
                     elementOffset = mesh.GetBlendShapeIndex(blendShapeName);
                     valueFactor = 0.01f;

--- a/Assets/UniGLTF/Editor/Animation/AnimationValidator.cs
+++ b/Assets/UniGLTF/Editor/Animation/AnimationValidator.cs
@@ -23,13 +23,11 @@ namespace UniGLTF
             }
 
             var animationClips = new List<AnimationClip>();
-            var animator = root.GetComponent<Animator>();
-            var animation = root.GetComponent<UnityEngine.Animation>();
-            if (animator != null)
+            if (root.TryGetComponent<Animator>(out var animator))
             {
                 animationClips = AnimationExporter.GetAnimationClips(animator);
             }
-            else if (animation != null)
+            if (root.TryGetComponent<Animation>(out var animation))
             {
                 animationClips = AnimationExporter.GetAnimationClips(animation);
             }

--- a/Assets/UniGLTF/Editor/Animation/EditorAnimationExporter.cs
+++ b/Assets/UniGLTF/Editor/Animation/EditorAnimationExporter.cs
@@ -14,14 +14,12 @@ namespace UniGLTF
         {
             var clips = new List<AnimationClip>();
 
-            var animator = Copy.GetComponent<Animator>();
-            if (animator != null)
+            if (Copy.TryGetComponent<Animator>(out var animator))
             {
                 clips.AddRange(AnimationExporter.GetAnimationClips(animator));
             }
 
-            var animation = Copy.GetComponent<Animation>();
-            if (animation != null)
+            if (Copy.TryGetComponent<Animation>(out var animation))
             {
                 clips.AddRange(AnimationExporter.GetAnimationClips(animation));
             }

--- a/Assets/UniGLTF/Editor/MeshUtility/TabMeshSeparator.cs
+++ b/Assets/UniGLTF/Editor/MeshUtility/TabMeshSeparator.cs
@@ -190,7 +190,7 @@ namespace UniGLTF.MeshUtility
                 var targetObjectForMeshWithoutBS = GameObject.Instantiate(srcGameObject);
                 targetObjectForMeshWithoutBS.name = srcGameObject.name + "_WithoutBlendShape";
                 targetObjectForMeshWithoutBS.transform.SetParent(srcTransform);
-                var skinnedMeshRendererWithoutBS = targetObjectForMeshWithoutBS.GetComponent<SkinnedMeshRenderer>();
+                var skinnedMeshRendererWithoutBS = targetObjectForMeshWithoutBS.GetComponentOrNull<SkinnedMeshRenderer>();
 
                 // build meshes with/without BlendShape
                 var with = BuildNewMesh(skinnedMeshRendererInput, vertexIndexWithBlendShape, submeshesWithBlendShape, BlendShapeLogic.WithBlendShape);

--- a/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/InternalTPose.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/InternalTPose.cs
@@ -149,7 +149,7 @@ namespace UniGLTF
             var modelBones = GetModelBones.Invoke(null, new object[] { go.transform, false, null });
             var existingMappings = new Dictionary<string, string>();
 
-            var animator = go.GetComponent<Animator>();
+            var animator = go.GetComponentOrThrow<Animator>();
             foreach (var bone in CachedEnum.GetValues<HumanBodyBones>())
             {
                 if (bone == HumanBodyBones.LastBone)

--- a/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/MeshExportValidator.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ExportDialog/MeshExportValidator.cs
@@ -18,8 +18,7 @@ namespace UniGLTF
             }
             if (r is MeshRenderer)
             {
-                MeshFilter f = r.GetComponent<MeshFilter>();
-                if (f != null)
+                if (r.TryGetComponent<MeshFilter>(out var f))
                 {
                     return f.sharedMesh;
                 }

--- a/Assets/UniGLTF/Editor/UniGLTF/Gizmo/BoneInfoDrawer.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/Gizmo/BoneInfoDrawer.cs
@@ -29,7 +29,10 @@ namespace UniGLTF
             {
                 if (_boneMesh == null)
                 {
-                    _boneMesh = BonePrefab.GetComponent<MeshFilter>().sharedMesh;
+                    if (BonePrefab.TryGetComponent<MeshFilter>(out var f))
+                    {
+                        _boneMesh = f.sharedMesh;
+                    }
                 }
                 return _boneMesh;
             }
@@ -42,8 +45,11 @@ namespace UniGLTF
             {
                 if (_boneMaterial == null)
                 {
-                    _boneMaterial = BonePrefab.GetComponent<MeshRenderer>().sharedMaterial;
-                    _boneMaterial.enableInstancing = true;
+                    if (BonePrefab.TryGetComponent<MeshRenderer>(out var mr))
+                    {
+                        _boneMaterial = mr.sharedMaterial;
+                        _boneMaterial.enableInstancing = true;
+                    };
                 }
                 return _boneMaterial;
             }
@@ -76,7 +82,10 @@ namespace UniGLTF
             {
                 if (_selectedBoneMesh == null)
                 {
-                    _selectedBoneMesh = SelectedPrefab.GetComponent<MeshFilter>().sharedMesh;
+                    if (SelectedPrefab.TryGetComponent<MeshFilter>(out var mf))
+                    {
+                        _selectedBoneMesh = mf.sharedMesh;
+                    };
                 }
                 return _selectedBoneMesh;
             }
@@ -89,8 +98,11 @@ namespace UniGLTF
             {
                 if (_selectedMaterial == null)
                 {
-                    _selectedMaterial = SelectedPrefab.GetComponent<MeshRenderer>().sharedMaterial;
-                    _selectedMaterial.enableInstancing = true;
+                    if (SelectedPrefab.TryGetComponent<MeshRenderer>(out var mr))
+                    {
+                        _selectedMaterial = mr.sharedMaterial;
+                        _selectedMaterial.enableInstancing = true;
+                    }
                 }
                 return _selectedMaterial;
             }
@@ -123,7 +135,10 @@ namespace UniGLTF
             {
                 if (_hoverBoneMesh == null)
                 {
-                    _hoverBoneMesh = HoverPrefab.GetComponent<MeshFilter>().sharedMesh;
+                    if (HoverPrefab.TryGetComponent<MeshFilter>(out var mf))
+                    {
+                        _hoverBoneMesh = mf.sharedMesh;
+                    }
                 }
                 return _hoverBoneMesh;
             }
@@ -136,8 +151,11 @@ namespace UniGLTF
             {
                 if (_hoverMaterial == null)
                 {
-                    _hoverMaterial = HoverPrefab.GetComponent<MeshRenderer>().sharedMaterial;
-                    _hoverMaterial.enableInstancing = true;
+                    if (HoverPrefab.TryGetComponent<MeshRenderer>(out var mr))
+                    {
+                        _hoverMaterial = mr.sharedMaterial;
+                        _hoverMaterial.enableInstancing = true;
+                    }
                 }
                 return _hoverMaterial;
             }

--- a/Assets/UniGLTF/Editor/UniGLTF/Validation/HumanoidValidator.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/Validation/HumanoidValidator.cs
@@ -137,7 +137,7 @@ namespace UniGLTF
             {
                 getBoneTransform = humanoid.GetBoneTransform;
             }
-            else if (ExportRoot.GetComponent<Animator>() is Animator animator)
+            else if (ExportRoot.GetComponent<Animator>() is Animator animator && animator != null)
             {
                 getBoneTransform = animator.GetBoneTransform;
 

--- a/Assets/UniGLTF/Editor/UniGLTF/Validation/HumanoidValidator.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/Validation/HumanoidValidator.cs
@@ -133,11 +133,11 @@ namespace UniGLTF
             //
             Func<HumanBodyBones, Transform> getBoneTransform = null;
 
-            if (ExportRoot.GetComponent<UniHumanoid.Humanoid>() is UniHumanoid.Humanoid humanoid)
+            if (ExportRoot.TryGetComponent<UniHumanoid.Humanoid>(out var humanoid))
             {
                 getBoneTransform = humanoid.GetBoneTransform;
             }
-            else if (ExportRoot.GetComponent<Animator>() is Animator animator && animator != null)
+            else if (ExportRoot.TryGetComponent<Animator>(out var animator))
             {
                 getBoneTransform = animator.GetBoneTransform;
 

--- a/Assets/UniGLTF/Editor/UniHumanoid/BoneMappingEditor.cs
+++ b/Assets/UniGLTF/Editor/UniHumanoid/BoneMappingEditor.cs
@@ -17,8 +17,7 @@ namespace UniHumanoid
         {
             m_target = (BoneMapping)target;
 
-            var animator = m_target.GetComponent<Animator>();
-            if (animator != null)
+            if (m_target.TryGetComponent<Animator>(out var animator))
             {
                 m_bones = EachBoneDefs.Select(x => new Bone(
 animator.GetBoneTransform(x.Head), animator.GetBoneTransform(x.Tail)))

--- a/Assets/UniGLTF/Editor/UniHumanoid/HumanoidEditor.cs
+++ b/Assets/UniGLTF/Editor/UniHumanoid/HumanoidEditor.cs
@@ -399,8 +399,7 @@ namespace UniHumanoid
                         AssetDatabase.ImportAsset(unityPath);
 
                         // replace
-                        var animator = m_target.GetComponent<Animator>();
-                        if (animator == null)
+                        if (m_target.TryGetComponent<Animator>(out var animator))
                         {
                             animator = m_target.gameObject.AddComponent<Animator>();
                         }

--- a/Assets/UniGLTF/Editor/UniHumanoid/MuscleInspectorEditor.cs
+++ b/Assets/UniGLTF/Editor/UniHumanoid/MuscleInspectorEditor.cs
@@ -312,8 +312,7 @@ namespace UniHumanoid
         void OnEnable()
         {
             var mi = this.target as MuscleInspector;
-            var animator = mi.GetComponent<Animator>();
-            if (animator != null
+            if (mi.TryGetComponent<Animator>(out var animator)
             && animator.avatar != null
             && animator.avatar.isValid
             && animator.avatar.isHuman

--- a/Assets/UniGLTF/Runtime/Extensions/UnityExtensions.cs
+++ b/Assets/UniGLTF/Runtime/Extensions/UnityExtensions.cs
@@ -399,14 +399,12 @@ namespace UniGLTF
 
         public static Mesh GetSharedMesh(this Transform t)
         {
-            var meshFilter = t.GetComponent<MeshFilter>();
-            if (meshFilter != null)
+            if (t.TryGetComponent<MeshFilter>(out var meshFilter))
             {
                 return meshFilter.sharedMesh;
             }
 
-            var skinnedMeshRenderer = t.GetComponent<SkinnedMeshRenderer>();
-            if (skinnedMeshRenderer != null)
+            if (t.TryGetComponent<SkinnedMeshRenderer>(out var skinnedMeshRenderer))
             {
                 return skinnedMeshRenderer.sharedMesh;
             }
@@ -414,30 +412,72 @@ namespace UniGLTF
             return null;
         }
 
-        public static Material[] GetSharedMaterials(this Transform t)
-        {
-            var renderer = t.GetComponent<Renderer>();
-            if (renderer != null)
-            {
-                return renderer.sharedMaterials;
-            }
-
-            return new Material[] { };
-        }
-
         public static bool Has<T>(this Transform transform, T t) where T : Component
         {
-            return transform.GetComponent<T>() == t;
+            if (transform.TryGetComponent<T>(out var c))
+            {
+                return c == t;
+            }
+            return false; ;
         }
 
         public static T GetOrAddComponent<T>(this GameObject go) where T : Component
         {
-            var c = go.GetComponent<T>();
-            if (c != null)
+            if (go.TryGetComponent<T>(out var t))
             {
-                return c;
+                return t;
             }
             return go.AddComponent<T>();
+        }
+
+        public static T GetComponentOrThrow<T>(this GameObject go) where T : Component
+        {
+            if (go.TryGetComponent<T>(out var t))
+            {
+                return t;
+            }
+            else
+            {
+                throw new ArgumentException($"no {nameof(T)}");
+            }
+        }
+
+        public static T GetComponentOrThrow<T>(this Component c) where T : Component
+        {
+            if (c.TryGetComponent<T>(out var t))
+            {
+                return t;
+            }
+            else
+            {
+                throw new ArgumentException($"no {nameof(T)}");
+            }
+        }
+
+        public static T GetComponentOrNull<T>(this GameObject go) where T : Component
+        {
+            if (go.TryGetComponent<T>(out var t))
+            {
+                return t;
+            }
+            else
+            {
+                // きれいな null を返す
+                return null;
+            }
+        }
+
+        public static T GetComponentOrNull<T>(this Component c) where T : Component
+        {
+            if (c.TryGetComponent<T>(out var t))
+            {
+                return t;
+            }
+            else
+            {
+                // きれいな null を返す
+                return null;
+            }
         }
 
         public static bool EnableForExport(this Component mono)

--- a/Assets/UniGLTF/Runtime/Extensions/UnityExtensions.cs
+++ b/Assets/UniGLTF/Runtime/Extensions/UnityExtensions.cs
@@ -438,7 +438,7 @@ namespace UniGLTF
             }
             else
             {
-                throw new ArgumentException($"no {nameof(T)}");
+                throw new ArgumentException($"no {typeof(T)}");
             }
         }
 
@@ -450,7 +450,7 @@ namespace UniGLTF
             }
             else
             {
-                throw new ArgumentException($"no {nameof(T)}");
+                throw new ArgumentException($"no {typeof(T)}");
             }
         }
 

--- a/Assets/UniGLTF/Runtime/MeshUtility/BoneNormalizer.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/BoneNormalizer.cs
@@ -12,22 +12,23 @@ namespace UniGLTF.MeshUtility
         private static MeshAttachInfo CreateMeshInfo(Transform src)
         {
             // SkinnedMeshRenderer
-            var smr = src.GetComponent<SkinnedMeshRenderer>();
-            var mesh = MeshFreezer.NormalizeSkinnedMesh(smr);
-            if (mesh != null)
+            if (src.TryGetComponent<SkinnedMeshRenderer>(out var smr))
             {
-                return new MeshAttachInfo
+                var mesh = MeshFreezer.NormalizeSkinnedMesh(smr);
+                if (mesh != null)
                 {
-                    Mesh = mesh,
-                    Materials = smr.sharedMaterials,
-                    Bones = smr.bones,
-                    RootBone = smr.rootBone,
-                };
+                    return new MeshAttachInfo
+                    {
+                        Mesh = mesh,
+                        Materials = smr.sharedMaterials,
+                        Bones = smr.bones,
+                        RootBone = smr.rootBone,
+                    };
+                }
             }
 
             // MeshRenderer
-            var mr = src.GetComponent<MeshRenderer>();
-            if (mr != null)
+            if (src.TryGetComponent<MeshRenderer>(out var mr))
             {
                 var dstMesh = MeshFreezer.NormalizeNoneSkinnedMesh(mr, true);
                 if (dstMesh != null)

--- a/Assets/UniGLTF/Runtime/MeshUtility/GltfMeshUtility.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/GltfMeshUtility.cs
@@ -194,12 +194,18 @@ namespace UniGLTF.MeshUtility
                 {
                     if (Application.isPlaying)
                     {
-                        GameObject.Destroy(r.gameObject.GetComponent<MeshFilter>());
+                        if (r.gameObject.TryGetComponent<MeshFilter>(out var mf))
+                        {
+                            GameObject.Destroy(mf);
+                        }
                         GameObject.Destroy(r);
                     }
                     else
                     {
-                        GameObject.DestroyImmediate(r.gameObject.GetComponent<MeshFilter>());
+                        if (r.gameObject.TryGetComponent<MeshFilter>(out var mf))
+                        {
+                            GameObject.DestroyImmediate(mf);
+                        }
                         GameObject.DestroyImmediate(r);
                     }
                 }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshAttachInfo.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshAttachInfo.cs
@@ -34,7 +34,7 @@ namespace UniGLTF.MeshUtility
                 }
                     ).ToArray();
 
-                if (dst.GetComponent<SkinnedMeshRenderer>() is SkinnedMeshRenderer dstRenderer)
+                if (dst.TryGetComponent<SkinnedMeshRenderer>(out var dstRenderer))
                 {
                     dstRenderer.sharedMesh = Mesh;
                     dstRenderer.sharedMaterials = Materials;
@@ -48,10 +48,10 @@ namespace UniGLTF.MeshUtility
             }
             else
             {
-                if (dst.GetComponent<MeshFilter>() is MeshFilter dstFilter)
+                if (dst.TryGetComponent<MeshFilter>(out var dstFilter))
                 {
                     dstFilter.sharedMesh = Mesh;
-                    if (dst.gameObject.GetComponent<MeshRenderer>() is MeshRenderer dstRenderer)
+                    if (dst.gameObject.TryGetComponent<MeshRenderer>(out var dstRenderer))
                     {
                         dstRenderer.sharedMaterials = Materials;
                     }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshExclude.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshExclude.cs
@@ -39,8 +39,7 @@ namespace UniGLTF.MeshUtility
             {
                 return true;
             }
-            var filter = mr.GetComponent<MeshFilter>();
-            if (filter == null)
+            if (mr.TryGetComponent<MeshFilter>(out var filter))
             {
                 return true;
             }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshExtensions.cs
@@ -15,7 +15,7 @@ namespace UniGLTF.MeshUtility
             }
             if (r is MeshRenderer mr)
             {
-                if (mr.GetComponent<MeshFilter>() is MeshFilter mf)
+                if (mr.TryGetComponent<MeshFilter>(out var mf))
                 {
                     return mf.sharedMesh;
                 }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshFreezer.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshFreezer.cs
@@ -301,10 +301,14 @@ namespace UniGLTF.MeshUtility
                 return default;
             }
 
-            var srcFilter = srcRenderer.GetComponent<MeshFilter>();
-            if (srcFilter == null
-                || srcFilter.sharedMesh == null
-                || srcFilter.sharedMesh.vertexCount == 0)
+            if (srcRenderer.TryGetComponent<MeshFilter>(out var srcFilter))
+            {
+                if (srcFilter.sharedMesh == null || srcFilter.sharedMesh.vertexCount == 0)
+                {
+                    return default;
+                }
+            }
+            else
             {
                 return default;
             }

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrationGroup.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrationGroup.cs
@@ -29,11 +29,11 @@ namespace UniGLTF.MeshUtility
                 var relative = r.transform.RelativePathFrom(go.transform);
                 if (r is SkinnedMeshRenderer smr)
                 {
-                    copy.Renderers.Add(instance.transform.GetFromPath(relative).GetComponent<SkinnedMeshRenderer>());
+                    copy.Renderers.Add(instance.transform.GetFromPath(relative).GetComponentOrNull<SkinnedMeshRenderer>());
                 }
                 else if (r is MeshRenderer mr)
                 {
-                    copy.Renderers.Add(instance.transform.GetFromPath(relative).GetComponent<MeshRenderer>());
+                    copy.Renderers.Add(instance.transform.GetFromPath(relative).GetComponentOrNull<MeshRenderer>());
                 }
             }
             return copy;

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrator.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshIntegrator.cs
@@ -95,12 +95,7 @@ namespace UniGLTF.MeshUtility
 
         void Push(MeshRenderer renderer)
         {
-            var meshFilter = renderer.GetComponent<MeshFilter>();
-            if (meshFilter == null)
-            {
-                Debug.LogWarningFormat("{0} has no mesh filter", renderer.name);
-                return;
-            }
+            var meshFilter = renderer.GetComponentOrThrow<MeshFilter>();
             var mesh = meshFilter.sharedMesh;
             if (mesh == null)
             {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportInfo.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportInfo.cs
@@ -38,8 +38,7 @@ namespace UniGLTF
             }
             else if (r is MeshRenderer mr)
             {
-                var filter = r.GetComponent<MeshFilter>();
-                if (filter == null)
+                if (r.TryGetComponent<MeshFilter>(out var filter))
                 {
                     return false;
                 }
@@ -201,8 +200,7 @@ namespace UniGLTF
             }
             else if (renderer is MeshRenderer mr)
             {
-                var filter = mr.GetComponent<MeshFilter>();
-                if (filter != null && settings.MeshFilterAllowedHideFlags.HasFlag(filter.hideFlags))
+                if (mr.TryGetComponent<MeshFilter>(out var filter) && settings.MeshFilterAllowedHideFlags.HasFlag(filter.hideFlags))
                 {
                     if (filter.sharedMesh != null && filter.sharedMesh.vertexCount > 0)
                     {
@@ -411,23 +409,24 @@ namespace UniGLTF
             m_list.Clear();
             foreach (var node in nodes)
             {
-                var renderer = node.GetComponent<Renderer>();
-                if (renderer == null || !renderer.enabled)
+                if (node.TryGetComponent<Renderer>(out var renderer))
                 {
-                    continue;
-                }
+                    if (!renderer.enabled)
+                    {
+                        continue;
+                    }
+                    var found = m_list.FirstOrDefault(x => x.IsSameMeshAndMaterials(renderer));
+                    if (found != null)
+                    {
+                        found.PushRenderer(renderer);
+                        continue;
+                    }
 
-                var found = m_list.FirstOrDefault(x => x.IsSameMeshAndMaterials(renderer));
-                if (found != null)
-                {
-                    found.PushRenderer(renderer);
-                    continue;
-                }
-
-                var info = new MeshExportInfo(renderer, settings);
-                if (info.Mesh != null)
-                {
-                    m_list.Add(info);
+                    var info = new MeshExportInfo(renderer, settings);
+                    if (info.Mesh != null)
+                    {
+                        m_list.Add(info);
+                    }
                 }
             }
         }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/NodeImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/NodeImporter.cs
@@ -173,8 +173,7 @@ namespace UniGLTF
         public static void SetupSkinning(GltfData data, List<TransformWithSkin> nodes, int i, IAxisInverter inverter)
         {
             var x = nodes[i];
-            var skinnedMeshRenderer = x.Transform.GetComponent<SkinnedMeshRenderer>();
-            if (skinnedMeshRenderer != null)
+            if (x.Transform.TryGetComponent<SkinnedMeshRenderer>(out var skinnedMeshRenderer))
             {
                 var mesh = skinnedMeshRenderer.sharedMesh;
                 if (x.SkinIndex.HasValue)

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
@@ -109,7 +109,7 @@ namespace UniGLTF
                 Copy = m_tmpParent;
             }
 
-            if (Copy.transform.GetComponent<Renderer>() != null)
+            if (Copy.transform.TryGetComponent<Renderer>(out var r))
             {
                 // should throw ?
                 Debug.LogError("root mesh is not exported");
@@ -161,12 +161,9 @@ namespace UniGLTF
 
             if (x.gameObject.activeInHierarchy)
             {
-                var meshRenderer = x.GetComponent<MeshRenderer>();
-
-                if (meshRenderer != null && meshRenderer.enabled)
+                if (x.TryGetComponent<MeshRenderer>(out var meshRenderer) && meshRenderer.enabled)
                 {
-                    var meshFilter = x.GetComponent<MeshFilter>();
-                    if (meshFilter != null)
+                    if (x.TryGetComponent<MeshFilter>(out var meshFilter))
                     {
                         var mesh = meshFilter.sharedMesh;
                         var materials = meshRenderer.sharedMaterials;
@@ -192,8 +189,7 @@ namespace UniGLTF
                     }
                 }
 
-                var skinnedMeshRenderer = x.GetComponent<SkinnedMeshRenderer>();
-                if (skinnedMeshRenderer != null && skinnedMeshRenderer.enabled)
+                if (x.TryGetComponent<SkinnedMeshRenderer>(out var skinnedMeshRenderer) && skinnedMeshRenderer.enabled)
                 {
                     var mesh = skinnedMeshRenderer.sharedMesh;
                     var materials = skinnedMeshRenderer.sharedMaterials;

--- a/Assets/UniGLTF/Runtime/UniHumanoid/AvatarDescription.cs
+++ b/Assets/UniGLTF/Runtime/UniHumanoid/AvatarDescription.cs
@@ -137,8 +137,7 @@ namespace UniHumanoid
             var avatar = CreateAvatar(root);
             avatar.name = name;
 
-            var animator = root.GetComponent<Animator>();
-            if (animator != null)
+            if (root.TryGetComponent<Animator>(out var animator))
             {
                 var positionMap = root.Traverse().ToDictionary(x => x, x => x.position);
                 animator.avatar = avatar;
@@ -148,8 +147,7 @@ namespace UniHumanoid
                 }
             }
 
-            var transfer = root.GetComponent<HumanPoseTransfer>();
-            if (transfer != null)
+            if (root.TryGetComponent<HumanPoseTransfer>(out var transfer))
             {
                 transfer.Avatar = avatar;
             }

--- a/Assets/UniGLTF/Runtime/UniHumanoid/BoneMapping.cs
+++ b/Assets/UniGLTF/Runtime/UniHumanoid/BoneMapping.cs
@@ -21,8 +21,7 @@ namespace UniHumanoid
         {
             Bones = new GameObject[(int)HumanBodyBones.LastBone];
 
-            var animator = GetComponent<Animator>();
-            if (animator != null)
+            if (TryGetComponent<Animator>(out var animator))
             {
                 if (animator.avatar != null)
                 {
@@ -94,7 +93,7 @@ namespace UniHumanoid
         private void Awake()
         {
             if (Bones == null
-                || Bones.All(x => x==null))
+                || Bones.All(x => x == null))
             {
                 GetBones();
             }

--- a/Assets/UniGLTF/Runtime/UniHumanoid/HumanPoseTransfer.cs
+++ b/Assets/UniGLTF/Runtime/UniHumanoid/HumanPoseTransfer.cs
@@ -45,8 +45,7 @@ namespace UniHumanoid
 
         private void Reset()
         {
-            var animator = GetComponent<Animator>();
-            if (animator != null)
+            if (TryGetComponent<Animator>(out var animator))
             {
                 Avatar = animator.avatar;
             }
@@ -68,8 +67,7 @@ namespace UniHumanoid
         HumanPoseHandler m_handler;
         public void OnEnable()
         {
-            var animator = GetComponent<Animator>();
-            if (animator != null)
+            if (TryGetComponent<Animator>(out var animator))
             {
                 Avatar = animator.avatar;
             }

--- a/Assets/UniGLTF/Runtime/UniHumanoid/Humanoid.cs
+++ b/Assets/UniGLTF/Runtime/UniHumanoid/Humanoid.cs
@@ -409,37 +409,38 @@ namespace UniHumanoid
         /// <returns></returns>
         public bool AssignBonesFromAnimator()
         {
-            var animator = GetComponent<Animator>();
-            if (animator == null)
+            if (TryGetComponent<Animator>(out var animator))
             {
-                return false;
-            }
-            var avatar = animator.avatar;
-            if (avatar == null)
-            {
-                return false;
-            }
-            if (!avatar.isValid)
-            {
-                return false;
-            }
-            if (!avatar.isHuman)
-            {
-                return false;
-            }
-
-            var keys = CachedEnum.GetValues<HumanBodyBones>();
-
-            AssignBones(keys.Select(x =>
-            {
-                if (x == HumanBodyBones.LastBone)
+                var avatar = animator.avatar;
+                if (avatar == null)
                 {
-                    return (HumanBodyBones.LastBone, null);
+                    return false;
                 }
-                return ((HumanBodyBones)Enum.Parse(typeof(HumanBodyBones), x.ToString(), true), animator.GetBoneTransform(x));
-            }));
+                if (!avatar.isValid)
+                {
+                    return false;
+                }
+                if (!avatar.isHuman)
+                {
+                    return false;
+                }
 
-            return true;
+                var keys = CachedEnum.GetValues<HumanBodyBones>();
+
+                AssignBones(keys.Select(x =>
+                {
+                    if (x == HumanBodyBones.LastBone)
+                    {
+                        return (HumanBodyBones.LastBone, null);
+                    }
+                    return ((HumanBodyBones)Enum.Parse(typeof(HumanBodyBones), x.ToString(), true), animator.GetBoneTransform(x));
+                }));
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         public bool TryGetBoneForTransform(Transform t, out HumanBodyBones bone)

--- a/Assets/UniGLTF/Runtime/UniHumanoid/Humanoid.cs
+++ b/Assets/UniGLTF/Runtime/UniHumanoid/Humanoid.cs
@@ -456,5 +456,35 @@ namespace UniHumanoid
             bone = default;
             return false;
         }
+
+        public static Func<HumanBodyBones, Transform> Get_GetBoneTransform(GameObject root)
+        {
+            if (root.TryGetComponent<UniHumanoid.Humanoid>(out var humanoid))
+            {
+                return humanoid.GetBoneTransform;
+            }
+            else if (root.TryGetComponent<Animator>(out var animator))
+            {
+                // avatar
+                var avatar = animator.avatar;
+                if (avatar == null)
+                {
+                    throw new ArgumentException("no avatar");
+                }
+                if (!avatar.isValid)
+                {
+                    throw new ArgumentException("invalid avatar");
+                }
+                if (!avatar.isHuman)
+                {
+                    throw new ArgumentException("avatar is not humanoid");
+                }
+                return animator.GetBoneTransform;
+            }
+            else
+            {
+                throw new ArgumentException("no animator nor humanoid");
+            }
+        }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniHumanoid/MuscleDebug.cs
+++ b/Assets/UniGLTF/Runtime/UniHumanoid/MuscleDebug.cs
@@ -12,14 +12,12 @@ namespace UniHumanoid
     {
         Avatar GetAvatar()
         {
-            var animator = GetComponent<Animator>();
-            if (animator != null && animator.avatar != null)
+            if (TryGetComponent<Animator>(out var animator) && animator.avatar != null)
             {
                 return animator.avatar;
             }
 
-            var transfer = GetComponent<HumanPoseTransfer>();
-            if (transfer != null && transfer.Avatar != null)
+            if (TryGetComponent<HumanPoseTransfer>(out var transfer) && transfer.Avatar != null)
             {
                 return transfer.Avatar;
             }

--- a/Assets/UniGLTF/Samples~/UniHumanoid/HumanBuilderTest.cs
+++ b/Assets/UniGLTF/Samples~/UniHumanoid/HumanBuilderTest.cs
@@ -119,7 +119,7 @@ namespace UniHumanoid
                 builder.AddLeg(0.1f, 0.3f, 0.4f, 0.1f, 0.1f);
 
                 var description = AvatarDescription.Create(builder.Skeleton);
-                var animator = GetComponent<Animator>();
+                var animator = GetComponentOrThrow<Animator>();
                 animator.avatar = description.CreateAvatar(root);
 
                 // create SkinnedMesh for bone visualize
@@ -132,8 +132,7 @@ namespace UniHumanoid
                 renderer.sharedMaterial = m_material;
                 //root.gameObject.AddComponent<BoneMapping>();
 
-                var transfer = GetComponent<HumanPoseTransfer>();
-                if (transfer != null)
+                if (TryGetComponent<HumanPoseTransfer>(out var transfer))
                 {
                     transfer.Avatar = animator.avatar;
                     transfer.Setup();

--- a/Assets/UniGLTF/Tests/UniGLTF/EditorTextureSerializerTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/EditorTextureSerializerTests.cs
@@ -115,7 +115,7 @@ namespace UniGLTF
             var root = GameObject.CreatePrimitive(PrimitiveType.Cube);
             var mat = new Material(Shader.Find("Standard"));
             mat.SetTexture(propertyName, srcTex);
-            root.GetComponent<MeshRenderer>().sharedMaterial = mat;
+            root.GetComponentOrThrow<MeshRenderer>().sharedMaterial = mat;
 
             // Export glTF
             var data = new ExportingGltfData();

--- a/Assets/UniGLTF/Tests/UniGLTF/MeshExportValidatorTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/MeshExportValidatorTests.cs
@@ -12,7 +12,7 @@ namespace UniGLTF
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.transform.SetParent(root.transform);
 
-            var renderer = cube.GetComponent<Renderer>();
+            var renderer = cube.GetComponentOrThrow<Renderer>();
             renderer.sharedMaterials = materials;
             return root;
         }
@@ -88,7 +88,10 @@ namespace UniGLTF
                 var child = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 child.transform.SetParent(root.transform);
                 // remove MeshFilter
-                Component.DestroyImmediate(child.GetComponent<MeshFilter>());
+                if (child.TryGetComponent<MeshFilter>(out var mf))
+                {
+                    Component.DestroyImmediate(mf);
+                }
 
                 validator.SetRoot(root, new GltfExportSettings(), new DefualtBlendShapeExportFilter());
                 var vs = validator.Validate(root);
@@ -112,7 +115,7 @@ namespace UniGLTF
                 var child = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 child.transform.SetParent(root.transform);
                 // set null
-                child.GetComponent<MeshFilter>().sharedMesh = null;
+                child.GetComponentOrThrow<MeshFilter>().sharedMesh = null;
 
                 validator.SetRoot(root, new GltfExportSettings(), new DefualtBlendShapeExportFilter());
                 var vs = validator.Validate(root);

--- a/Assets/UniGLTF_Samples/UniHumanoid/HumanBuilderTest.cs
+++ b/Assets/UniGLTF_Samples/UniHumanoid/HumanBuilderTest.cs
@@ -120,6 +120,10 @@ namespace UniHumanoid
 
                 var description = AvatarDescription.Create(builder.Skeleton);
                 var animator = GetComponent<Animator>();
+                if (animator == null)
+                {
+                    throw new System.ArgumentException("no animator");
+                }
                 animator.avatar = description.CreateAvatar(root);
 
                 // create SkinnedMesh for bone visualize

--- a/Assets/VRM/Editor/Format/VRMBlendShapeExportFilter.cs
+++ b/Assets/VRM/Editor/Format/VRMBlendShapeExportFilter.cs
@@ -16,7 +16,7 @@ namespace VRM
                 {
                     continue;
                 }
-                
+
                 if (onlyPreset)
                 {
                     if (c.Preset == BlendShapePreset.Unknown)
@@ -45,8 +45,7 @@ namespace VRM
             Clips = new List<BlendShapeClip>();
             if (exportRoot != null)
             {
-                var proxy = exportRoot.GetComponent<VRMBlendShapeProxy>();
-                if (proxy != null)
+                if (exportRoot.TryGetComponent<VRMBlendShapeProxy>(out var proxy))
                 {
                     if (proxy.BlendShapeAvatar != null)
                     {

--- a/Assets/VRM/Editor/Format/VRMEditorExporter.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorExporter.cs
@@ -153,7 +153,7 @@ namespace VRM
             target = GameObject.Instantiate(target);
             destroy.Add(target);
 
-            var metaBehaviour = target.GetComponent<VRMMeta>();
+            var metaBehaviour = target.GetComponentOrNull<VRMMeta>();
             if (metaBehaviour == null)
             {
                 metaBehaviour = target.AddComponent<VRMMeta>();
@@ -167,7 +167,7 @@ namespace VRM
 
             {
                 // copy元
-                var animator = exportRoot.GetComponent<Animator>();
+                var animator = exportRoot.GetComponentOrNull<Animator>();
                 var beforeTransforms = exportRoot.GetComponentsInChildren<Transform>(true);
                 // copy先
                 var afterTransforms = target.GetComponentsInChildren<Transform>(true);
@@ -204,11 +204,8 @@ namespace VRM
                 VRMBoneNormalizer.Execute(target, settings.ForceTPose);
             }
 
-            var fp = target.GetComponent<VRMFirstPerson>();
-
             // 元のBlendShapeClipに変更を加えないように複製
-            var proxy = target.GetComponent<VRMBlendShapeProxy>();
-            if (proxy != null)
+            if (target.TryGetComponent<VRMBlendShapeProxy>(out var proxy))
             {
                 var copyBlendShapeAvatar = CopyBlendShapeAvatar(proxy.BlendShapeAvatar, settings.ReduceBlendshapeClip);
                 proxy.BlendShapeAvatar = copyBlendShapeAvatar;

--- a/Assets/VRM/Editor/Format/VRMEditorExporter.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorExporter.cs
@@ -167,14 +167,14 @@ namespace VRM
 
             {
                 // copy元
-                var animator = exportRoot.GetComponentOrNull<Animator>();
+                var getBone = UniHumanoid.Humanoid.Get_GetBoneTransform(exportRoot);
                 var beforeTransforms = exportRoot.GetComponentsInChildren<Transform>(true);
                 // copy先
                 var afterTransforms = target.GetComponentsInChildren<Transform>(true);
                 // copy先のhumanoidBoneのリストを得る
                 var humanTransforms = CachedEnum.GetValues<HumanBodyBones>()
                     .Where(x => x != HumanBodyBones.LastBone)
-                    .Select(x => animator.GetBoneTransform(x))
+                    .Select(x => getBone(x))
                     .Where(x => x != null)
                     .Select(x => afterTransforms[Array.IndexOf(beforeTransforms, x)]) // copy 先を得る
                     .ToArray();

--- a/Assets/VRM/Editor/Format/VRMExporterVaildator.cs
+++ b/Assets/VRM/Editor/Format/VRMExporterVaildator.cs
@@ -23,13 +23,12 @@ namespace VRM
                 yield break;
             }
 
-            if (ReduceBlendshape && ExportRoot.GetComponent<VRMBlendShapeProxy>() == null)
+            if (ReduceBlendshape && ExportRoot.GetComponentOrNull<VRMBlendShapeProxy>() == null)
             {
                 yield return Validation.Error(VRMExporterWizardMessages.NEEDS_VRM_BLENDSHAPE_PROXY.Msg());
             }
 
-            var vrmMeta = ExportRoot.GetComponent<VRMMeta>();
-            if (vrmMeta != null && vrmMeta.Meta != null && vrmMeta.Meta.Thumbnail != null)
+            if (ExportRoot.TryGetComponent<VRMMeta>(out var vrmMeta) && vrmMeta.Meta != null && vrmMeta.Meta.Thumbnail != null)
             {
                 var thumbnailName = vrmMeta.Meta.Thumbnail.name;
                 if (NameValidator.IsFileNameLengthTooLong(thumbnailName))

--- a/Assets/VRM/Editor/Format/VRMExporterWizard.cs
+++ b/Assets/VRM/Editor/Format/VRMExporterWizard.cs
@@ -79,8 +79,7 @@ namespace VRM
                 }
                 else
                 {
-                    var meta = root.GetComponent<VRMMeta>();
-                    if (meta != null)
+                    if (root.TryGetComponent<VRMMeta>(out var meta))
                     {
                         Meta = meta.Meta;
                     }
@@ -150,14 +149,12 @@ namespace VRM
 
             yield return VRMSpringBoneValidator.Validate;
 
-            var firstPerson = State.ExportRoot.GetComponent<VRMFirstPerson>();
-            if (firstPerson != null)
+            if (State.ExportRoot.TryGetComponent<VRMFirstPerson>(out var firstPerson))
             {
                 yield return firstPerson.Validate;
             }
 
-            var proxy = State.ExportRoot.GetComponent<VRMBlendShapeProxy>();
-            if (proxy != null)
+            if (State.ExportRoot.TryGetComponent<VRMBlendShapeProxy>(out var proxy))
             {
                 yield return proxy.Validate;
             }
@@ -183,7 +180,7 @@ namespace VRM
             //
             // T-Pose
             //
-            if (State.ExportRoot.GetComponent<Animator>() != null)
+            if (State.ExportRoot.TryGetComponent<Animator>(out var animator))
             {
                 var backup = GUI.enabled;
                 GUI.enabled = State.ExportRoot.scene.IsValid();
@@ -305,7 +302,7 @@ namespace VRM
                 case Tabs.BlendShape:
                     if (State.ExportRoot)
                     {
-                        OnBlendShapeGUI(State.ExportRoot.GetComponent<VRMBlendShapeProxy>());
+                        OnBlendShapeGUI(State.ExportRoot.GetComponentOrNull<VRMBlendShapeProxy>());
                     }
                     break;
 

--- a/Assets/VRM/Editor/Format/VRMHumanoidNormalizerMenu.cs
+++ b/Assets/VRM/Editor/Format/VRMHumanoidNormalizerMenu.cs
@@ -17,29 +17,30 @@ namespace VRM
                 return false;
             }
 
-            var animator = root.GetComponent<Animator>();
-            if (animator == null)
+            if (root.TryGetComponent<Animator>(out var animator))
+            {
+                var avatar = animator.avatar;
+                if (avatar == null)
+                {
+                    return false;
+                }
+
+                if (!avatar.isValid)
+                {
+                    return false;
+                }
+
+                if (!avatar.isHuman)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+            else
             {
                 return false;
             }
-
-            var avatar = animator.avatar;
-            if (avatar == null)
-            {
-                return false;
-            }
-
-            if (!avatar.isValid)
-            {
-                return false;
-            }
-
-            if (!avatar.isHuman)
-            {
-                return false;
-            }
-
-            return true;
         }
 
         public static void Normalize()

--- a/Assets/VRM/Editor/LookAt/VRMLookAtHeadEditor.cs
+++ b/Assets/VRM/Editor/LookAt/VRMLookAtHeadEditor.cs
@@ -39,10 +39,7 @@ namespace VRM
         {
             m_items = m_target.transform.Traverse().Select(x =>
             {
-                var meshFilter = x.GetComponent<MeshFilter>();
-                var meshRenderer = x.GetComponent<MeshRenderer>();
-                var skinnedMeshRenderer = x.GetComponent<SkinnedMeshRenderer>();
-                if (meshFilter != null && meshRenderer != null)
+                if (x.TryGetComponent<MeshFilter>(out var meshFilter) && x.TryGetComponent<MeshRenderer>(out var meshRenderer))
                 {
                     return new Item
                     {
@@ -51,7 +48,7 @@ namespace VRM
                         Materials = meshRenderer.sharedMaterials,
                     };
                 }
-                else if (skinnedMeshRenderer != null)
+                else if (x.TryGetComponent<SkinnedMeshRenderer>(out var skinnedMeshRenderer))
                 {
                     return new Item
                     {
@@ -114,11 +111,11 @@ namespace VRM
                     target.position + new Vector3(0, 0.1f, 0),
                     target.forward
                     );
-                for(int j=0; j<m_items.Length; ++j)
+                for (int j = 0; j < m_items.Length; ++j)
                 {
                     ref var x = ref m_items[j];
                     var mesh = x.Baked();
-                    for(int i=0; i<x.Materials.Length; ++i)
+                    for (int i = 0; i < x.Materials.Length; ++i)
                     {
                         m_previewRenderUtility.DrawMesh(mesh, x.Transform.position, x.Transform.rotation,
                             x.Materials[i], i);

--- a/Assets/VRM/Editor/SkinnedMeshUtility/VrmMeshIntegratorWizard.cs
+++ b/Assets/VRM/Editor/SkinnedMeshUtility/VrmMeshIntegratorWizard.cs
@@ -21,7 +21,7 @@ namespace VRM
         protected override void Validate()
         {
             base.Validate();
-            if (_exportTarget.GetComponent<VRMMeta>() == null)
+            if (_exportTarget.GetComponentOrNull<VRMMeta>() == null)
             {
                 _validations.Add(Validation.Error("target is not vrm1"));
                 return;
@@ -60,7 +60,7 @@ namespace VRM
             base.WriteAssets(assetFolder, instance, results);
 
             // reset firstPerson
-            if (instance.GetComponent<VRMFirstPerson>() is VRMFirstPerson firstPerson)
+            if (instance.TryGetComponent<VRMFirstPerson>(out var firstPerson))
             {
                 // TODO:
                 firstPerson.Reset();

--- a/Assets/VRM/Editor/SpringBone/VRMSpringBoneUtilityEditor.cs
+++ b/Assets/VRM/Editor/SpringBone/VRMSpringBoneUtilityEditor.cs
@@ -19,8 +19,7 @@ namespace VRM
                 return false;
             }
 
-            var animator = root.GetComponent<Animator>();
-            if (animator == null)
+            if (root.TryGetComponent<Animator>(out var animator))
             {
                 return false;
             }
@@ -66,8 +65,7 @@ namespace VRM
                 return false;
             }
 
-            var animator = root.GetComponent<Animator>();
-            if (animator == null)
+            if (root.TryGetComponent<Animator>(out var animator))
             {
                 return false;
             }

--- a/Assets/VRM/Runtime/BlendShape/BlendShapeBindingMerger.cs
+++ b/Assets/VRM/Runtime/BlendShape/BlendShapeBindingMerger.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UniGLTF;
 using UnityEngine;
 
 namespace VRM
@@ -51,7 +52,7 @@ namespace VRM
                         SkinnedMeshRenderer target = null;
                         if (_target != null)
                         {
-                            target = _target.GetComponent<SkinnedMeshRenderer>();
+                            target = _target.GetComponentOrNull<SkinnedMeshRenderer>();
                         }
                         if (target != null)
                         {

--- a/Assets/VRM/Runtime/BlendShape/BlendShapeClipHandler.cs
+++ b/Assets/VRM/Runtime/BlendShape/BlendShapeClipHandler.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using System.Linq;
 using System;
+using UniGLTF;
 
 namespace VRM
 {
@@ -28,7 +29,7 @@ namespace VRM
                 m_renderers = m_clip.Values.Select(x =>
                 {
                     var target = UniGLTF.UnityExtensions.GetFromPath(transform, x.RelativePath);
-                    return target.GetComponent<SkinnedMeshRenderer>();
+                    return target.GetComponentOrNull<SkinnedMeshRenderer>();
                 })
                  .ToArray();
             }

--- a/Assets/VRM/Runtime/BlendShape/Blinker.cs
+++ b/Assets/VRM/Runtime/BlendShape/Blinker.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using UnityEngine;
 using UnityEngine.Serialization;
+using UniGLTF;
 
 namespace VRM
 {
@@ -100,7 +101,7 @@ namespace VRM
 
         private void OnEnable()
         {
-            m_blendShapes = GetComponent<VRM.VRMBlendShapeProxy>();
+            m_blendShapes = this.GetComponentOrNull<VRMBlendShapeProxy>();
             m_coroutine = StartCoroutine(BlinkRoutine());
         }
 

--- a/Assets/VRM/Runtime/BlendShape/MaterialValueBindingMerger.cs
+++ b/Assets/VRM/Runtime/BlendShape/MaterialValueBindingMerger.cs
@@ -52,8 +52,7 @@ namespace VRM
 
             foreach (var x in root.Traverse())
             {
-                var renderer = x.GetComponent<Renderer>();
-                if (renderer != null)
+                if (x.TryGetComponent<Renderer>(out var renderer))
                 {
                     foreach (var y in renderer.sharedMaterials.Where(y => y != null))
                     {
@@ -231,8 +230,8 @@ namespace VRM
             {
                 return new MaterialTarget
                 {
-                    MaterialName=binding.MaterialName,
-                    ValueName=binding.ValueName
+                    MaterialName = binding.MaterialName,
+                    ValueName = binding.ValueName
                 };
             }
         }
@@ -260,7 +259,7 @@ namespace VRM
                         if (valueName.EndsWith("_ST_S"))
                         {
                             valueName = valueName.Substring(0, valueName.Length - 2);
-                            var v=material.GetVector(valueName);
+                            var v = material.GetVector(valueName);
                             value.y = v.y;
                             value.w = v.w;
                         }

--- a/Assets/VRM/Runtime/BlendShape/MeshPreviewItem.cs
+++ b/Assets/VRM/Runtime/BlendShape/MeshPreviewItem.cs
@@ -190,12 +190,7 @@ namespace VRM
         public static MeshPreviewItem Create(Transform t, Transform root,
             Func<Material, Material> getOrCreateMaterial)
         {
-            //Debug.Log("create");
-
-            var meshFilter = t.GetComponent<MeshFilter>();
-            var meshRenderer = t.GetComponent<MeshRenderer>();
-            var skinnedMeshRenderer = t.GetComponent<SkinnedMeshRenderer>();
-            if (meshFilter != null && meshRenderer != null)
+            if (t.TryGetComponent<MeshFilter>(out var meshFilter) && t.TryGetComponent<MeshRenderer>(out var meshRenderer))
             {
                 // copy
                 meshRenderer.sharedMaterials = meshRenderer.sharedMaterials.Select(x => getOrCreateMaterial(x)).ToArray();
@@ -204,7 +199,7 @@ namespace VRM
                     Mesh = meshFilter.sharedMesh
                 };
             }
-            else if (skinnedMeshRenderer != null)
+            else if (t.TryGetComponent<SkinnedMeshRenderer>(out var skinnedMeshRenderer))
             {
                 // copy
                 skinnedMeshRenderer.sharedMaterials = skinnedMeshRenderer.sharedMaterials.Select(x => getOrCreateMaterial(x)).ToArray();

--- a/Assets/VRM/Runtime/BlendShape/PreviewSceneManager.cs
+++ b/Assets/VRM/Runtime/BlendShape/PreviewSceneManager.cs
@@ -122,8 +122,7 @@ namespace VRM
                 .Select(x => x.Path)
                 .ToArray();
 
-            var animator = GetComponent<Animator>();
-            if (animator != null)
+            if (TryGetComponent<Animator>(out var animator))
             {
                 var head = animator.GetBoneTransform(HumanBodyBones.Head);
                 if (head != null)

--- a/Assets/VRM/Runtime/FirstPerson/VRMFirstPerson.cs
+++ b/Assets/VRM/Runtime/FirstPerson/VRMFirstPerson.cs
@@ -38,8 +38,7 @@ namespace VRM
                         return renderer.sharedMesh;
                     }
 
-                    var filter = Renderer.GetComponent<MeshFilter>();
-                    if (filter != null)
+                    if (Renderer.TryGetComponent<MeshFilter>(out var filter))
                     {
                         return filter.sharedMesh;
                     }
@@ -75,7 +74,7 @@ namespace VRM
             .Select(x =>
             {
                 var mapped = map[x.Renderer.transform];
-                var renderer = mapped.GetComponent<Renderer>();
+                var renderer = mapped.GetComponentOrNull<Renderer>();
                 return new VRMFirstPerson.RendererFirstPersonFlags
                 {
                     Renderer = renderer,
@@ -87,8 +86,7 @@ namespace VRM
         public void SetDefault()
         {
             FirstPersonOffset = new Vector3(0, 0.06f, 0);
-            var animator = GetComponent<Animator>();
-            if (animator != null)
+            if (TryGetComponent<Animator>(out var animator))
             {
                 FirstPersonBone = animator.GetBoneTransform(HumanBodyBones.Head);
             }

--- a/Assets/VRM/Runtime/Humanoid/VRMHumanoidDescription.cs
+++ b/Assets/VRM/Runtime/Humanoid/VRMHumanoidDescription.cs
@@ -32,7 +32,7 @@ namespace VRM
 
         private void OnValidate()
         {
-            if(Avatar!=null && (!Avatar.isValid || !Avatar.isHuman))
+            if (Avatar != null && (!Avatar.isValid || !Avatar.isHuman))
             {
                 Avatar = null;
             }
@@ -40,16 +40,13 @@ namespace VRM
 
         void Reset()
         {
-            var animator = GetComponent<Animator>();
-            if (animator == null)
+            if (TryGetComponent<Animator>(out var animator))
             {
-                return;
-            }
-
-            Avatar = animator.avatar;
-            if (Avatar == null)
-            {
-                return;
+                Avatar = animator.avatar;
+                if (Avatar == null)
+                {
+                    return;
+                }
             }
         }
     }

--- a/Assets/VRM/Runtime/IO/VRMExporter.cs
+++ b/Assets/VRM/Runtime/IO/VRMExporter.cs
@@ -47,55 +47,51 @@ namespace VRM
 
         public override void ExportExtensions(ITextureSerializer textureSerializer)
         {
-            // avatar
-            if (Copy.TryGetComponent<Animator>(out var animator))
+            var getBone = UniHumanoid.Humanoid.Get_GetBoneTransform(Copy);
+
+            UniHumanoid.AvatarDescription description = null;
+            var isCreated = false;
+            if (Copy.TryGetComponent<VRMHumanoidDescription>(out var humanoid))
             {
-                UniHumanoid.AvatarDescription description = null;
-                var isCreated = false;
-                if (Copy.TryGetComponent<VRMHumanoidDescription>(out var humanoid))
+                if (humanoid != null)
                 {
-                    if (humanoid != null)
-                    {
-                        description = humanoid.GetDescription(out isCreated);
-                    }
+                    description = humanoid.GetDescription(out isCreated);
                 }
-                var nodes = Copy.transform.Traverse().Skip(1).ToList();
+            }
+            var nodes = Copy.transform.Traverse().Skip(1).ToList();
+            {
+                if (description != null)
                 {
-                    if (description != null)
-                    {
-                        // use description
-                        VRM.humanoid.Apply(description, nodes);
-                    }
-
-                    if (isCreated)
-                    {
-                        GameObject.DestroyImmediate(description);
-                    }
+                    // use description
+                    VRM.humanoid.Apply(description, nodes);
                 }
 
+                if (isCreated)
                 {
-                    // set humanoid bone mapping
-                    var avatar = animator.avatar;
-                    foreach (HumanBodyBones key in CachedEnum.GetValues<HumanBodyBones>())
-                    {
-                        if (key == HumanBodyBones.LastBone)
-                        {
-                            break;
-                        }
+                    GameObject.DestroyImmediate(description);
+                }
+            }
 
-                        var transform = animator.GetBoneTransform(key);
-                        if (transform != null)
-                        {
-                            var nodeIndex = nodes.IndexOf(transform);
-                            if (nodeIndex < 0)
-                            {
-                                Debug.LogError($"ヒューマンボーンが export 対象に含まれていない？", transform);
-                            }
-                            else
-                            {
-                                VRM.humanoid.SetNodeIndex(key, nodeIndex);
-                            }
-                        }
+            // set humanoid bone mapping
+            // var avatar = animator.avatar;
+            foreach (HumanBodyBones key in CachedEnum.GetValues<HumanBodyBones>())
+            {
+                if (key == HumanBodyBones.LastBone)
+                {
+                    break;
+                }
+
+                var transform = getBone(key);
+                if (transform != null)
+                {
+                    var nodeIndex = nodes.IndexOf(transform);
+                    if (nodeIndex < 0)
+                    {
+                        Debug.LogError($"ヒューマンボーンが export 対象に含まれていない？", transform);
+                    }
+                    else
+                    {
+                        VRM.humanoid.SetNodeIndex(key, nodeIndex);
                     }
                 }
             }

--- a/Assets/VRM/Runtime/IO/VRMExporter.cs
+++ b/Assets/VRM/Runtime/IO/VRMExporter.cs
@@ -48,19 +48,19 @@ namespace VRM
         public override void ExportExtensions(ITextureSerializer textureSerializer)
         {
             // avatar
-            var animator = Copy.GetComponent<Animator>();
-            if (animator != null)
+            if (Copy.TryGetComponent<Animator>(out var animator))
             {
-                var humanoid = Copy.GetComponent<VRMHumanoidDescription>();
                 UniHumanoid.AvatarDescription description = null;
-                var nodes = Copy.transform.Traverse().Skip(1).ToList();
+                var isCreated = false;
+                if (Copy.TryGetComponent<VRMHumanoidDescription>(out var humanoid))
                 {
-                    var isCreated = false;
                     if (humanoid != null)
                     {
                         description = humanoid.GetDescription(out isCreated);
                     }
-
+                }
+                var nodes = Copy.transform.Traverse().Skip(1).ToList();
+                {
                     if (description != null)
                     {
                         // use description
@@ -101,8 +101,7 @@ namespace VRM
             }
 
             // morph
-            var master = Copy.GetComponent<VRMBlendShapeProxy>();
-            if (master != null)
+            if (Copy.TryGetComponent<VRMBlendShapeProxy>(out var master))
             {
                 var avatar = master.BlendShapeAvatar;
                 if (avatar != null)
@@ -127,8 +126,7 @@ namespace VRM
 #pragma warning disable 0618
             // meta(obsolete)
             {
-                var meta = Copy.GetComponent<VRMMetaInformation>();
-                if (meta != null)
+                if (Copy.TryGetComponent<VRMMetaInformation>(out var meta))
                 {
                     VRM.meta.author = meta.Author;
                     VRM.meta.contactInformation = meta.ContactInformation;
@@ -147,8 +145,7 @@ namespace VRM
 
             // meta
             {
-                var _meta = Copy.GetComponent<VRMMeta>();
-                if (_meta != null && _meta.Meta != null)
+                if (Copy.TryGetComponent<VRMMeta>(out var _meta) && _meta.Meta != null)
                 {
                     var meta = _meta.Meta;
 
@@ -180,8 +177,7 @@ namespace VRM
             }
 
             // firstPerson
-            var firstPerson = Copy.GetComponent<VRMFirstPerson>();
-            if (firstPerson != null)
+            if (Copy.TryGetComponent<VRMFirstPerson>(out var firstPerson))
             {
                 if (firstPerson.FirstPersonBone != null)
                 {
@@ -195,27 +191,22 @@ namespace VRM
                 }
 
                 // lookAt
+                if (Copy.TryGetComponent<VRMLookAtHead>(out var lookAtHead))
                 {
-                    var lookAtHead = Copy.GetComponent<VRMLookAtHead>();
-                    if (lookAtHead != null)
+                    if (Copy.TryGetComponent<VRMLookAtBoneApplyer>(out var boneApplyer))
                     {
-                        var boneApplyer = Copy.GetComponent<VRMLookAtBoneApplyer>();
-                        var blendShapeApplyer = Copy.GetComponent<VRMLookAtBlendShapeApplyer>();
-                        if (boneApplyer != null)
-                        {
-                            VRM.firstPerson.lookAtType = LookAtType.Bone;
-                            VRM.firstPerson.lookAtHorizontalInner.Apply(boneApplyer.HorizontalInner);
-                            VRM.firstPerson.lookAtHorizontalOuter.Apply(boneApplyer.HorizontalOuter);
-                            VRM.firstPerson.lookAtVerticalDown.Apply(boneApplyer.VerticalDown);
-                            VRM.firstPerson.lookAtVerticalUp.Apply(boneApplyer.VerticalUp);
-                        }
-                        else if (blendShapeApplyer != null)
-                        {
-                            VRM.firstPerson.lookAtType = LookAtType.BlendShape;
-                            VRM.firstPerson.lookAtHorizontalOuter.Apply(blendShapeApplyer.Horizontal);
-                            VRM.firstPerson.lookAtVerticalDown.Apply(blendShapeApplyer.VerticalDown);
-                            VRM.firstPerson.lookAtVerticalUp.Apply(blendShapeApplyer.VerticalUp);
-                        }
+                        VRM.firstPerson.lookAtType = LookAtType.Bone;
+                        VRM.firstPerson.lookAtHorizontalInner.Apply(boneApplyer.HorizontalInner);
+                        VRM.firstPerson.lookAtHorizontalOuter.Apply(boneApplyer.HorizontalOuter);
+                        VRM.firstPerson.lookAtVerticalDown.Apply(boneApplyer.VerticalDown);
+                        VRM.firstPerson.lookAtVerticalUp.Apply(boneApplyer.VerticalUp);
+                    }
+                    else if (Copy.TryGetComponent<VRMLookAtBlendShapeApplyer>(out var blendShapeApplyer))
+                    {
+                        VRM.firstPerson.lookAtType = LookAtType.BlendShape;
+                        VRM.firstPerson.lookAtHorizontalOuter.Apply(blendShapeApplyer.Horizontal);
+                        VRM.firstPerson.lookAtVerticalDown.Apply(blendShapeApplyer.VerticalDown);
+                        VRM.firstPerson.lookAtVerticalUp.Apply(blendShapeApplyer.VerticalUp);
                     }
                 }
             }

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -268,11 +268,7 @@ namespace VRM
             humanoid.Avatar = HumanoidAvatar;
             humanoid.Description = AvatarDescription;
 
-            var animator = Root.GetComponent<Animator>();
-            if (animator == null)
-            {
-                animator = Root.AddComponent<Animator>();
-            }
+            var animator = Root.GetOrAddComponent<Animator>();
             animator.avatar = HumanoidAvatar;
 
             // default としてとりあえず設定する

--- a/Assets/VRM/Runtime/LookAt/VRMLookAt.cs
+++ b/Assets/VRM/Runtime/LookAt/VRMLookAt.cs
@@ -115,8 +115,7 @@ namespace VRM
 
         public void GetBones()
         {
-            var animator = GetComponent<Animator>();
-            if (animator != null)
+            if (TryGetComponent<Animator>(out var animator))
             {
                 LeftEye = OffsetOnTransform.Create(animator.GetBoneTransform(HumanBodyBones.LeftEye));
                 RightEye = OffsetOnTransform.Create(animator.GetBoneTransform(HumanBodyBones.RightEye));

--- a/Assets/VRM/Runtime/LookAt/VRMLookAtBlendShapeApplyer.cs
+++ b/Assets/VRM/Runtime/LookAt/VRMLookAtBlendShapeApplyer.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable 0414, 0649
+using UniGLTF;
 using UnityEngine;
 
 
@@ -46,8 +47,8 @@ namespace VRM
 
         private void Start()
         {
-            m_head = GetComponent<VRMLookAtHead>();
-            m_proxy = GetComponent<VRMBlendShapeProxy>();
+            m_head = this.GetComponentOrNull<VRMLookAtHead>();
+            m_proxy = this.GetComponentOrNull<VRMBlendShapeProxy>();
             if (m_head == null)
             {
                 enabled = false;

--- a/Assets/VRM/Runtime/LookAt/VRMLookAtBoneApplyer.cs
+++ b/Assets/VRM/Runtime/LookAt/VRMLookAtBoneApplyer.cs
@@ -29,8 +29,7 @@ namespace VRM
 
         public void OnImported(VRMImporterContext context)
         {
-            var animator = GetComponent<Animator>();
-            if (animator != null)
+            if (TryGetComponent<Animator>(out var animator))
             {
                 LeftEye = OffsetOnTransform.Create(animator.GetBoneTransform(HumanBodyBones.LeftEye));
                 RightEye = OffsetOnTransform.Create(animator.GetBoneTransform(HumanBodyBones.RightEye));
@@ -55,7 +54,7 @@ namespace VRM
 
         void Start()
         {
-            m_head = GetComponent<VRMLookAtHead>();
+            m_head = this.GetComponentOrNull<VRMLookAtHead>();
             if (m_head == null)
             {
                 enabled = false;

--- a/Assets/VRM/Runtime/LookAt/VRMLookAtHead.cs
+++ b/Assets/VRM/Runtime/LookAt/VRMLookAtHead.cs
@@ -80,7 +80,7 @@ namespace VRM
 
         void Awake()
         {
-            var animator = GetComponent<Animator>();
+            var animator = this.GetComponentOrNull<Animator>();
             if (animator == null)
             {
                 Debug.LogWarning("animator is not found");

--- a/Assets/VRM/Runtime/Meta/VRMMetaInformation.cs
+++ b/Assets/VRM/Runtime/Meta/VRMMetaInformation.cs
@@ -54,8 +54,7 @@ namespace VRM
         [ContextMenu("CreateThumbnail")]
         void CreateThumbnailMenu()
         {
-            var lookAt = GetComponent<VRMLookAt>();
-            if (lookAt != null)
+            if(TryGetComponent<VRMLookAt>(out var lookAt))
             {
                 var texture = lookAt.CreateThumbnail();
 

--- a/Assets/VRM/Runtime/SpringBone/VRMSpringUtility.cs
+++ b/Assets/VRM/Runtime/SpringBone/VRMSpringUtility.cs
@@ -18,7 +18,7 @@ namespace VRM
         {
             var colliders = new List<VRMSpringBoneColliderGroup>();
             foreach (var vrmColliderGroup in root.Traverse()
-                .Select(x => x.GetComponent<VRMSpringBoneColliderGroup>())
+                .Select(x => x.GetComponentOrNull<VRMSpringBoneColliderGroup>())
                 .Where(x => x != null))
             {
                 var index = nodes.IndexOf(vrmColliderGroup.transform);

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneDrawer.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneDrawer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
+using UniGLTF;
 
 namespace UniVRM10
 {
@@ -49,25 +50,18 @@ namespace UniVRM10
             if (parent.transform.childCount > 0)
             {
                 var child = parent.transform.GetChild(0);
-                var joint = child.GetComponent<VRM10SpringBoneJoint>();
-                if (joint == null)
-                {
-                    joint = child.gameObject.AddComponent<VRM10SpringBoneJoint>();
-                }
-                if (joint != null)
-                {
-                    // set params
-                    joint.m_dragForce = parent.m_dragForce;
-                    joint.m_gravityDir = parent.m_gravityDir;
-                    joint.m_gravityPower = parent.m_gravityPower;
-                    joint.m_jointRadius = parent.m_jointRadius;
-                    joint.m_stiffnessForce = parent.m_stiffnessForce;
+                var joint = child.gameObject.GetOrAddComponent<VRM10SpringBoneJoint>();
+                // set params
+                joint.m_dragForce = parent.m_dragForce;
+                joint.m_gravityDir = parent.m_gravityDir;
+                joint.m_gravityPower = parent.m_gravityPower;
+                joint.m_jointRadius = parent.m_jointRadius;
+                joint.m_stiffnessForce = parent.m_stiffnessForce;
 
-                    yield return joint;
-                    foreach (var x in MakeJointsRecursive(joint))
-                    {
-                        yield return x;
-                    }
+                yield return joint;
+                foreach (var x in MakeJointsRecursive(joint))
+                {
+                    yield return x;
                 }
             }
         }

--- a/Assets/VRM10/Editor/Components/VRM10Window.cs
+++ b/Assets/VRM10/Editor/Components/VRM10Window.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
+using UniGLTF;
 
 namespace UniVRM10
 {
@@ -17,7 +18,7 @@ namespace UniVRM10
             var window = (VRM10Window)GetWindow(typeof(VRM10Window));
             window.titleContent = new GUIContent(MENU_NAME);
             window.Show();
-            window.Root = UnityEditor.Selection.activeTransform?.GetComponent<Vrm10Instance>();
+            window.Root = UnityEditor.Selection.activeTransform?.GetComponentOrNull<Vrm10Instance>();
             return window;
         }
 
@@ -89,7 +90,7 @@ namespace UniVRM10
             {
                 if (UnityEditor.Selection.activeTransform != null)
                 {
-                    var root = UnityEditor.Selection.activeTransform.Ancestors().Select(x => x.GetComponent<Vrm10Instance>()).FirstOrDefault(x => x != null);
+                    var root = UnityEditor.Selection.activeTransform.Ancestors().Select(x => x.GetComponentOrNull<Vrm10Instance>()).FirstOrDefault(x => x != null);
                     if (root != null)
                     {
                         Root = root;

--- a/Assets/VRM10/Editor/EditorTool/VRM10BoneSelectorEditorTool.cs
+++ b/Assets/VRM10/Editor/EditorTool/VRM10BoneSelectorEditorTool.cs
@@ -70,7 +70,7 @@ namespace UniVRM10
                 _impl = new BoneSelector(SceneView.lastActiveSceneView.camera);
             }
 
-            var root = Selection.activeGameObject?.GetComponent<Vrm10Instance>();
+            var root = Selection.activeGameObject?.GetComponentOrNull<Vrm10Instance>();
             if (root == null)
             {
                 return;

--- a/Assets/VRM10/Editor/EditorTool/VRM10ExpressionEditorTool.cs
+++ b/Assets/VRM10/Editor/EditorTool/VRM10ExpressionEditorTool.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.EditorTools;
 using UnityEngine;
+using UniGLTF;
 
 #if UNITY_2021_OR_NEWER
 #else
@@ -50,7 +51,7 @@ namespace UniVRM10
             {
                 return;
             }
-            var root = Selection.activeTransform.GetComponent<Vrm10Instance>();
+            var root = Selection.activeTransform.GetComponentOrNull<Vrm10Instance>();
             if (root == null)
             {
                 return;

--- a/Assets/VRM10/Editor/EditorTool/VRM10LookAtEditorTool.cs
+++ b/Assets/VRM10/Editor/EditorTool/VRM10LookAtEditorTool.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.EditorTools;
+using UniGLTF;
 
 #if UNITY_2021_OR_NEWER
 #else
@@ -50,7 +51,7 @@ namespace UniVRM10
             {
                 return;
             }
-            var root = Selection.activeTransform.GetComponent<Vrm10Instance>();
+            var root = Selection.activeTransform.GetComponentOrNull<Vrm10Instance>();
             if (root == null)
             {
                 return;
@@ -59,7 +60,7 @@ namespace UniVRM10
             {
                 return;
             }
-            var humanoid = root.GetComponent<UniHumanoid.Humanoid>();
+            var humanoid = root.GetComponentOrThrow<UniHumanoid.Humanoid>();
             var head = humanoid.Head;
             if (head == null)
             {

--- a/Assets/VRM10/Editor/MeshUtility/Vrm10ExpressionUpdater.cs
+++ b/Assets/VRM10/Editor/MeshUtility/Vrm10ExpressionUpdater.cs
@@ -92,7 +92,7 @@ namespace UniVRM10
         public static Dictionary<VRM10Expression, VRM10Expression> Update(string assetFolder, GameObject instance,
             List<MeshIntegrationResult> results)
         {
-            var vrm = instance.GetComponent<Vrm10Instance>();
+            var vrm = instance.GetComponentOrThrow<Vrm10Instance>();
             var util = new Vrm10ExpressionUpdater(instance, results);
 
             // write Vrm10Expressions

--- a/Assets/VRM10/Editor/MeshUtility/Vrm10MeshUtilityDialog.cs
+++ b/Assets/VRM10/Editor/MeshUtility/Vrm10MeshUtilityDialog.cs
@@ -21,7 +21,7 @@ namespace UniVRM10
         protected override void Validate()
         {
             base.Validate();
-            if (_exportTarget.GetComponent<Vrm10Instance>() == null)
+            if (_exportTarget.GetComponentOrNull<Vrm10Instance>() == null)
             {
                 _validations.Add(Validation.Error("target is not vrm1"));
                 return;

--- a/Assets/VRM10/Editor/Vrm10ExportDialog.cs
+++ b/Assets/VRM10/Editor/Vrm10ExportDialog.cs
@@ -82,8 +82,7 @@ namespace UniVRM10
                 }
                 else
                 {
-                    var controller = root.GetComponent<Vrm10Instance>();
-                    if (controller != null)
+                    if (root.TryGetComponent<Vrm10Instance>(out var controller))
                     {
                         Vrm = controller.Vrm;
                     }
@@ -173,7 +172,7 @@ namespace UniVRM10
                 return false;
             }
 
-            if (State.ExportRoot.GetComponent<Animator>() != null)
+            if (State.ExportRoot.TryGetComponent<Animator>(out var animator))
             {
                 var backup = GUI.enabled;
                 GUI.enabled = State.ExportRoot.scene.IsValid();

--- a/Assets/VRM10/Editor/Vrm10InstanceEditor.cs
+++ b/Assets/VRM10/Editor/Vrm10InstanceEditor.cs
@@ -64,8 +64,7 @@ namespace UniVRM10
 
         static bool CheckHumanoid(GameObject go)
         {
-            var animator = go.GetComponent<Animator>();
-            if (animator != null)
+            if (go.TryGetComponent<Animator>(out var animator))
             {
                 if (animator.avatar == null)
                 {
@@ -87,7 +86,7 @@ namespace UniVRM10
                 return true;
             }
 
-            var humanoid = go.GetComponent<UniHumanoid.Humanoid>();
+            var humanoid = go.GetComponentOrNull<UniHumanoid.Humanoid>();
             if (humanoid == null)
             {
                 EditorGUILayout.HelpBox("vrm-1.0 require Animator or UniHumanoid.Humanoid", MessageType.Error);

--- a/Assets/VRM10/Editor/VrmAnimationMenu.cs
+++ b/Assets/VRM10/Editor/VrmAnimationMenu.cs
@@ -80,7 +80,7 @@ namespace UniVRM10
                 // setup
                 //
                 var map = new Dictionary<HumanBodyBones, Transform>();
-                var animator = bvh.Root.GetComponent<Animator>();
+                var animator = bvh.Root.GetComponentOrThrow<Animator>();
                 foreach (HumanBodyBones bone in Enum.GetValues(typeof(HumanBodyBones)))
                 {
                     if (bone == HumanBodyBones.LastBone)
@@ -107,7 +107,7 @@ namespace UniVRM10
                 //
                 // get data
                 //
-                var animation = bvh.Root.gameObject.GetComponent<Animation>();
+                var animation = bvh.Root.gameObject.GetComponentOrThrow<Animation>();
                 var clip = animation.clip;
                 var state = animation[clip.name];
 

--- a/Assets/VRM10/Runtime/Components/Expression/MorphTargetBindingMerger/MorphTargetIdentifier.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/MorphTargetBindingMerger/MorphTargetIdentifier.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using UniGLTF;
 using UnityEngine;
 
 namespace UniVRM10
@@ -13,7 +14,7 @@ namespace UniVRM10
             var targetGameObject = modelRoot.Find(binding.RelativePath);
             if (targetGameObject == null) return null;
 
-            var targetRenderer = targetGameObject.GetComponent<SkinnedMeshRenderer>();
+            var targetRenderer = targetGameObject.GetComponentOrNull<SkinnedMeshRenderer>();
             if (targetRenderer == null) return null;
             if (targetRenderer.sharedMesh == null) return null;
             if (targetRenderer.sharedMesh.blendShapeCount <= binding.Index) return null;

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMeshItem.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewMeshItem.cs
@@ -97,12 +97,7 @@ namespace UniVRM10
         public static PreviewMeshItem Create(Transform t, Transform root,
             Func<Material, Material> getOrCreateMaterial)
         {
-            //Debug.Log("create");
-
-            var meshFilter = t.GetComponent<MeshFilter>();
-            var meshRenderer = t.GetComponent<MeshRenderer>();
-            var skinnedMeshRenderer = t.GetComponent<SkinnedMeshRenderer>();
-            if (meshFilter != null && meshRenderer != null)
+            if (t.TryGetComponent<MeshFilter>(out var meshFilter) && t.TryGetComponent<MeshRenderer>(out var meshRenderer))
             {
                 // copy
                 meshRenderer.sharedMaterials = meshRenderer.sharedMaterials.Select(x => getOrCreateMaterial(x)).ToArray();
@@ -111,7 +106,7 @@ namespace UniVRM10
                     Mesh = meshFilter.sharedMesh
                 };
             }
-            else if (skinnedMeshRenderer != null)
+            else if (t.TryGetComponent<SkinnedMeshRenderer>(out var skinnedMeshRenderer))
             {
                 // copy
                 skinnedMeshRenderer.sharedMaterials = skinnedMeshRenderer.sharedMaterials.Select(x => getOrCreateMaterial(x)).ToArray();

--- a/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
+++ b/Assets/VRM10/Runtime/Components/Expression/Preview/PreviewSceneManager.cs
@@ -138,8 +138,7 @@ namespace UniVRM10
                 .Select(x => x.Path)
                 .ToArray();
 
-            var animator = GetComponent<Animator>();
-            if (animator != null)
+            if(TryGetComponent<Animator>(out var animator))
             {
                 var head = animator.GetBoneTransform(HumanBodyBones.Head);
                 if (head != null)

--- a/Assets/VRM10/Runtime/Components/FirstPerson/RendererFirstPersonFlags.cs
+++ b/Assets/VRM10/Runtime/Components/FirstPerson/RendererFirstPersonFlags.cs
@@ -1,4 +1,5 @@
 using System;
+using UniGLTF;
 using UnityEngine;
 
 namespace UniVRM10
@@ -27,7 +28,7 @@ namespace UniVRM10
         public Renderer GetRenderer(Transform root)
         {
             var node = root.Find(Renderer);
-            return node?.GetComponent<Renderer>();
+            return node?.GetComponentOrNull<Renderer>();
         }
 
         public Mesh GetSharedMesh(Transform root)
@@ -39,8 +40,7 @@ namespace UniVRM10
                     return smr.sharedMesh;
 
                 case MeshRenderer meshRenderer:
-                    var filter = renderer.GetComponent<MeshFilter>();
-                    if (filter != null)
+                    if (renderer.TryGetComponent<MeshFilter>(out var filter))
                     {
                         return filter.sharedMesh;
                     }

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneJoint.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneJoint.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UniGLTF;
 using UnityEngine;
 
 
@@ -29,12 +30,7 @@ namespace UniVRM10
 
         void AddJointRecursive(Transform t, VRM10SpringBoneJoint src)
         {
-            var joint = t.gameObject.GetComponent<VRM10SpringBoneJoint>();
-            if (joint == null)
-            {
-                joint = t.gameObject.AddComponent<VRM10SpringBoneJoint>();
-                Debug.Log($"{joint} added");
-            }
+            var joint = t.gameObject.GetOrAddComponent<VRM10SpringBoneJoint>();
 
             // copy settings
             joint.m_stiffnessForce = src.m_stiffnessForce;
@@ -52,8 +48,7 @@ namespace UniVRM10
 
         void GetJoints(Transform t, List<VRM10SpringBoneJoint> joints)
         {
-            var joint = t.GetComponent<VRM10SpringBoneJoint>();
-            if (joint != null)
+            if (t.TryGetComponent<VRM10SpringBoneJoint>(out var joint))
             {
                 joints.Add(joint);
             }

--- a/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
+++ b/Assets/VRM10/Runtime/Components/VRM10Object/VRM10ObjectFirstPerson.cs
@@ -176,8 +176,8 @@ namespace UniVRM10
             }
             m_done = true;
 
-            var runtime = go.GetComponent<UniGLTF.RuntimeGltfInstance>();
-            var vrmInstance = go.GetComponent<Vrm10Instance>();
+            var runtime = go.GetComponentOrThrow<RuntimeGltfInstance>();
+            var vrmInstance = go.GetComponentOrThrow<Vrm10Instance>();
             // NOTE: This bone must be referenced by renderers instead of the control rig bone.
             var firstPersonBone = vrmInstance.Humanoid.Head;
 

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using UniGLTF;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -81,7 +82,7 @@ namespace UniVRM10
             {
                 if (m_humanoid == null)
                 {
-                    m_humanoid = GetComponent<UniHumanoid.Humanoid>();
+                    m_humanoid = this.GetComponentOrNull<UniHumanoid.Humanoid>();
                 }
                 return m_humanoid;
             }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/ControlRig/Vrm10RuntimeControlRig.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/ControlRig/Vrm10RuntimeControlRig.cs
@@ -41,8 +41,11 @@ namespace UniVRM10
             _controlRigAvatar = HumanoidLoader.LoadHumanoidAvatar(vrmRoot, transformBonePairs);
             _controlRigAvatar.name = "Runtime Control Rig";
 
-            ControlRigAnimator = vrmRoot.GetComponent<Animator>();
-            ControlRigAnimator.avatar = _controlRigAvatar;
+            if (vrmRoot.TryGetComponent<Animator>(out var animator))
+            {
+                ControlRigAnimator = animator;
+                ControlRigAnimator.avatar = _controlRigAvatar;
+            }
         }
 
         public void Dispose()

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeSpringBone .cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10RuntimeSpringBone .cs
@@ -32,8 +32,7 @@ namespace UniVRM10
         {
             m_instance = instance;
 
-            var gltfInstance = instance.GetComponent<RuntimeGltfInstance>();
-            if (gltfInstance != null)
+            if (instance.TryGetComponent<RuntimeGltfInstance>(out var gltfInstance))
             {
                 // ランタイムインポートならここに到達してゼロコストになる
                 m_defaultTransformStates = gltfInstance.InitialTransformStates;

--- a/Assets/VRM10/Runtime/Components/VrmAnimationInstance/Vrm10AnimationInstance.cs
+++ b/Assets/VRM10/Runtime/Components/VrmAnimationInstance/Vrm10AnimationInstance.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UniGLTF;
 using UniHumanoid;
 using UnityEngine;
 
@@ -180,7 +181,7 @@ namespace UniVRM10
                 ControlRig = (provider, provider);
 
                 // create SkinnedMesh for bone visualize
-                var animator = GetComponent<Animator>();
+                var animator = this.GetComponentOrThrow<Animator>();
                 BoxMan = SkeletonMeshUtility.CreateRenderer(animator);
                 var material = new Material(Shader.Find("Standard"));
                 BoxMan.sharedMaterial = material;

--- a/Assets/VRM10/Runtime/Components/VrmAnimationInstance/Vrm10PoseLoader.cs
+++ b/Assets/VRM10/Runtime/Components/VrmAnimationInstance/Vrm10PoseLoader.cs
@@ -151,7 +151,7 @@ namespace UniVRM10
         {
             var (hips, map) = GetPose(humanoid);
 
-            var animator = instance.GetComponent<Animator>();
+            var animator = instance.GetComponentOrThrow<Animator>();
 
             // update src ControlRig
             animator.GetBoneTransform(HumanBodyBones.Hips).localPosition = hips;
@@ -228,7 +228,7 @@ namespace UniVRM10
             );
             using var loader = new VrmAnimationImporter(data);
             var gltfInstance = await loader.LoadAsync(new ImmediateCaller());
-            var instance = gltfInstance.GetComponent<Vrm10AnimationInstance>();
+            var instance = gltfInstance.GetComponentOrThrow<Vrm10AnimationInstance>();
 
             if (data.GLTF.extensions is UniGLTF.glTFExtensionImport extensions)
             {

--- a/Assets/VRM10/Runtime/IO/Model/ModelExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/ModelExporter.cs
@@ -32,8 +32,8 @@ namespace UniVRM10
 
             // humanoid
             {
-                var humanoid = root.GetComponent<UniHumanoid.Humanoid>();
-                if (humanoid is null)
+                var humanoid = root.GetComponentOrNull<UniHumanoid.Humanoid>();
+                if (humanoid == null)
                 {
                     humanoid = root.AddComponent<UniHumanoid.Humanoid>();
                     humanoid.AssignBonesFromAnimator();
@@ -150,8 +150,7 @@ namespace UniVRM10
                     }
                     else if (renderer is MeshRenderer meshRenderer)
                     {
-                        var filter = meshRenderer.gameObject.GetComponent<MeshFilter>();
-                        if (filter != null && MeshCanExport(filter.sharedMesh))
+                        if (meshRenderer.gameObject.TryGetComponent<MeshFilter>(out var filter) && MeshCanExport(filter.sharedMesh))
                         {
                             var mesh = CreateMesh(arrayManager, filter.sharedMesh, meshRenderer, Materials);
                             Model.MeshGroups.Add(mesh);

--- a/Assets/VRM10/Runtime/IO/Vrm10.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10.cs
@@ -354,7 +354,7 @@ namespace UniVRM10
                     throw new Exception("Failed to load by unknown reason.");
                 }
 
-                var vrm10Instance = gltfInstance.GetComponent<Vrm10Instance>();
+                var vrm10Instance = gltfInstance.GetComponentOrNull<Vrm10Instance>();
                 if (vrm10Instance == null)
                 {
                     gltfInstance.Dispose();

--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -255,7 +255,7 @@ namespace UniVRM10
         int? thumbnailIndex) ExportVrm(GameObject root, Model model, ModelExporter converter,
         VRM10ObjectMeta vrmMeta, List<glTFNode> nodes, ITextureExporter textureExporter)
         {
-            var vrmController = root?.GetComponent<Vrm10Instance>();
+            var vrmController = root?.GetComponentOrThrow<Vrm10Instance>();
 
             if (vrmMeta == null)
             {

--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -255,15 +255,21 @@ namespace UniVRM10
         int? thumbnailIndex) ExportVrm(GameObject root, Model model, ModelExporter converter,
         VRM10ObjectMeta vrmMeta, List<glTFNode> nodes, ITextureExporter textureExporter)
         {
-            var vrmController = root?.GetComponentOrThrow<Vrm10Instance>();
-
-            if (vrmMeta == null)
+            if (root == null)
             {
-                if (vrmController?.Vrm?.Meta == null)
+                throw new System.ArgumentNullException("root");
+            }
+
+            if (root.TryGetComponent<Vrm10Instance>(out var vrmController))
+            {
+                if (vrmMeta == null)
                 {
-                    throw new NullReferenceException("metaObject is null");
+                    if (vrmController.Vrm?.Meta == null)
+                    {
+                        throw new NullReferenceException("metaObject is null");
+                    }
+                    vrmMeta = vrmController.Vrm.Meta;
                 }
-                vrmMeta = vrmController.Vrm.Meta;
             }
 
             var vrm = new UniGLTF.Extensions.VRMC_vrm.VRMC_vrm

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -658,8 +658,7 @@ namespace UniVRM10
 
                             // node is required
                             var go = Nodes[gltfJoint.Node.Value].gameObject;
-                            var joint = go.GetComponent<VRM10SpringBoneJoint>();
-                            if (joint != null)
+                            if (go.TryGetComponent<VRM10SpringBoneJoint>(out var joint))
                             {
                                 // 仕様違反。マイグレーションで発生しうるのと、エクスポーターでの除外などがされていないので、
                                 // エラーにせずに飛ばす

--- a/Assets/VRM10/Runtime/IO/VrmAnimationImporter.cs
+++ b/Assets/VRM10/Runtime/IO/VrmAnimationImporter.cs
@@ -264,7 +264,7 @@ namespace UniVRM10
 
             if (expressions.Length > 0)
             {
-                var animation = instance.GetComponent<Animation>();
+                var animation = instance.GetComponentOrThrow<Animation>();
                 var clip = animation.clip;
 
                 // Expression の float カーブを追加する

--- a/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
+++ b/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
@@ -105,11 +105,7 @@ namespace UniVRM10
         public override (List<UniGLTF.MeshUtility.MeshIntegrationResult>, List<GameObject>) Process(
             GameObject target, IEnumerable<UniGLTF.MeshUtility.MeshIntegrationGroup> groupCopy)
         {
-            _vrmInstance = target.GetComponent<Vrm10Instance>();
-            if (_vrmInstance == null)
-            {
-                throw new ArgumentException();
-            }
+            _vrmInstance = target.GetComponentOrThrow<Vrm10Instance>();
 
             // TODO: update: spring
             // TODO: update: constraint
@@ -118,9 +114,12 @@ namespace UniVRM10
 
             if (FreezeBlendShapeRotationAndScaling)
             {
-                var animator = target.GetComponent<Animator>();
-                var newAvatar = AvatarDescription.RecreateAvatar(animator);
-                GameObject.DestroyImmediate(animator);
+                Avatar newAvatar = default;
+                if (target.TryGetComponent<Animator>(out var animator))
+                {
+                    newAvatar = AvatarDescription.RecreateAvatar(animator);
+                    GameObject.DestroyImmediate(animator);
+                }
                 animator = target.AddComponent<Animator>();
                 animator.avatar = newAvatar;
             }
@@ -135,7 +134,7 @@ namespace UniVRM10
             {
                 return;
             }
-            var vrm1 = root.GetComponent<Vrm10Instance>();
+            var vrm1 = root.GetComponentOrNull<Vrm10Instance>();
             if (vrm1 == null)
             {
                 return;

--- a/Assets/VRM10/Runtime/UnityExtensions.cs
+++ b/Assets/VRM10/Runtime/UnityExtensions.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 
 namespace UniVRM10
@@ -221,14 +217,6 @@ namespace UniVRM10
             return current;
         }
 
-        public static IEnumerable<Transform> GetChildren(this Transform self)
-        {
-            foreach (Transform child in self)
-            {
-                yield return child;
-            }
-        }
-
         public static IEnumerable<Transform> Traverse(this Transform t)
         {
             yield return t;
@@ -241,11 +229,6 @@ namespace UniVRM10
             }
         }
 
-        public static Transform FindDescenedant(this Transform t, string name)
-        {
-            return t.Traverse().First(x => x.name == name);
-        }
-
         public static IEnumerable<Transform> Ancestors(this Transform t)
         {
             yield return t;
@@ -256,75 +239,6 @@ namespace UniVRM10
                     yield return x;
                 }
             }
-        }
-
-        public static float[] ToArray(this Quaternion q)
-        {
-            return new float[] { q.x, q.y, q.z, q.w };
-        }
-
-        public static float[] ToArray(this Vector3 v)
-        {
-            return new float[] { v.x, v.y, v.z };
-        }
-
-        public static float[] ToArray(this Vector4 v)
-        {
-            return new float[] { v.x, v.y, v.z, v.w };
-        }
-
-        public static void ReverseZRecursive(this Transform root)
-        {
-            var globalMap = root.Traverse().ToDictionary(x => x, x => PosRot.FromGlobalTransform(x));
-
-            foreach (var x in root.Traverse())
-            {
-                x.position = globalMap[x].Position.ReverseZ();
-                x.rotation = globalMap[x].Rotation.ReverseZ();
-            }
-        }
-
-        public static Mesh GetSharedMesh(this Transform t)
-        {
-            var meshFilter = t.GetComponent<MeshFilter>();
-            if (meshFilter != null)
-            {
-                return meshFilter.sharedMesh;
-            }
-
-            var skinnedMeshRenderer = t.GetComponent<SkinnedMeshRenderer>();
-            if (skinnedMeshRenderer != null)
-            {
-                return skinnedMeshRenderer.sharedMesh;
-            }
-
-            return null;
-        }
-
-        public static Material[] GetSharedMaterials(this Transform t)
-        {
-            var renderer = t.GetComponent<Renderer>();
-            if (renderer != null)
-            {
-                return renderer.sharedMaterials;
-            }
-
-            return new Material[] { };
-        }
-
-        public static bool Has<T>(this Transform transform, T t) where T : Component
-        {
-            return transform.GetComponent<T>() == t;
-        }
-
-        public static T GetOrAddComponent<T>(this GameObject go) where T : Component
-        {
-            var c = go.GetComponent<T>();
-            if (c != null)
-            {
-                return c;
-            }
-            return go.AddComponent<T>();
         }
     }
 }

--- a/Assets/VRM10/Samples~/SimpleVrma/SimpleVrma.cs
+++ b/Assets/VRM10/Samples~/SimpleVrma/SimpleVrma.cs
@@ -47,7 +47,7 @@ public class SimpleVrma : MonoBehaviour
             showMeshes: false,
             awaitCaller: new ImmediateCaller());
 
-        var instance = Vrm.GetComponent<RuntimeGltfInstance>();
+        var instance = Vrm.GetComponentOrThrow<RuntimeGltfInstance>();
         instance.ShowMeshes();
     }
 
@@ -58,11 +58,11 @@ public class SimpleVrma : MonoBehaviour
         using var loader = new VrmAnimationImporter(data);
         var instance = await loader.LoadAsync(new ImmediateCaller());
 
-        Vrma = instance.GetComponent<Vrm10AnimationInstance>();
+        Vrma = instance.GetComponentOrThrow<Vrm10AnimationInstance>();
         Vrm.Runtime.VrmAnimation = Vrma;
         Debug.Log(Vrma);
 
-        var animation = Vrma.GetComponent<Animation>();
+        var animation = Vrma.GetComponentOrThrow<Animation>();
         animation.Play();
     }
 }

--- a/Assets/VRM10/Samples~/URPSample/Runtime/UrpSampleUI.cs
+++ b/Assets/VRM10/Samples~/URPSample/Runtime/UrpSampleUI.cs
@@ -46,7 +46,7 @@ namespace UniVRM10.URPSample
                     return;
                 }
 
-                var instance = _loadedVrm.GetComponent<RuntimeGltfInstance>();
+                var instance = _loadedVrm.GetComponentOrThrow<RuntimeGltfInstance>();
                 instance.ShowMeshes();
                 instance.EnableUpdateWhenOffscreen();
                 

--- a/Assets/VRM10/Samples~/VRM10FirstPersonSample/VRM10RuntimeLoader.cs
+++ b/Assets/VRM10/Samples~/VRM10FirstPersonSample/VRM10RuntimeLoader.cs
@@ -33,8 +33,7 @@ namespace UniVRM10.FirstPersonSample
             m_target.Source = m_source;
             m_target.SourceType = UniHumanoid.HumanPoseTransfer.HumanPoseTransferSourceType.HumanPoseTransfer;
 
-            var animator = m_target.GetComponent<Animator>();
-            if (animator != null)
+            if (m_target.TryGetComponent<Animator>(out var animator))
             {
                 if (m_faceCamera != null)
                 {
@@ -91,7 +90,7 @@ namespace UniVRM10.FirstPersonSample
             // VR用 FirstPerson 設定
             await instance.Vrm.FirstPerson.SetupAsync(instance.gameObject, awaitCaller);
 
-            instance.GetComponent<RuntimeGltfInstance>().ShowMeshes();
+            instance.GetComponentOrThrow<RuntimeGltfInstance>().ShowMeshes();
 
             return instance;
         }
@@ -127,7 +126,7 @@ namespace UniVRM10.FirstPersonSample
             {
                 GameObject.Destroy(m_source.gameObject);
             }
-            m_source = context.Root.GetComponent<UniHumanoid.HumanPoseTransfer>();
+            m_source = context.Root.GetComponentOrThrow<UniHumanoid.HumanPoseTransfer>();
 
             SetupTarget(m_target);
         }

--- a/Assets/VRM10/Samples~/VRM10RuntimeExporterSample/VRM10RuntimeExporter.cs
+++ b/Assets/VRM10/Samples~/VRM10RuntimeExporterSample/VRM10RuntimeExporter.cs
@@ -47,7 +47,7 @@ namespace UniVRM10.RuntimeExporterSample
             }
 
             var vrm10 = await Vrm10.LoadPathAsync(path);
-            var loaded = vrm10.GetComponent<UniGLTF.RuntimeGltfInstance>();
+            var loaded = vrm10.GetComponentOrThrow<UniGLTF.RuntimeGltfInstance>();
             loaded.ShowMeshes();
             loaded.EnableUpdateWhenOffscreen();
 


### PR DESCRIPTION
# エラー
attach されていない場合でも is 演算子が true になって後続で例外になる

```
MissingComponentException: There is no 'Animator' attached to the "Seed-san" game object, but a script is trying to access it.
You probably need to add a Animator to the game object "Seed-san". Or your script needs to check if the component is attached before using it.
UniGLTF.HumanoidValidator+<Validate_TPose>d__6.MoveNext () (at Assets/UniGLTF/Editor/UniGLTF/Validation/HumanoidValidator.cs:145)
UniGLTF.ExporterDialogState.Validate (System.Collections.Generic.IEnumerable`1[T] validators) (at Assets/UniGLTF/Editor/UniGLTF/ExportDialog/ExportDialogState.cs:105)
UniGLTF.ExportDialogBase.BeginGUI () (at Assets/UniGLTF/Editor/UniGLTF/ExportDialog/ExportDialogBase.cs:104)
```

# 再現手順。
vrm-1.0  の seed-san vrm の拡張子を glb に変える。
glb として import して、prefab をシーンに展開。
VRM-1.0 の export dialog に投入する。

# 備考

[UnityのGetCompornent<T>()でNull条件演算子が使えない](https://qiita.com/up-hash/items/91a4ea63ccfa7a1323c5)
に類似する問題と思われる。

#2319 と現象が似ている。
Validation で繰り返し例外が発生してしまう。