### PR TITLE
fix VRM10SpringBoneJointEditor

### DIFF
--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs
@@ -23,6 +23,7 @@ namespace UniVRM10
             {
                 return;
             }
+            m_target = (VRM10SpringBoneJoint)target;
 
             m_stiffnessForceProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_stiffnessForce));
             m_gravityPowerProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_gravityPower));
@@ -31,10 +32,7 @@ namespace UniVRM10
             m_jointRadiusProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_jointRadius));
             m_drawColliderProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_drawCollider));
 
-            if (m_target != null)
-            {
-                m_root = m_target.GetComponentInParent<Vrm10Instance>();
-            }
+            m_root = m_target.GetComponentInParent<Vrm10Instance>();
         }
 
         static bool m_showJoints;


### PR DESCRIPTION
https://vrm.dev/univrm1/vrm1_tutorial/springbone/#spring-%E3%81%AB-joint-%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%99%E3%82%8B

未登録の孤立Jointの警告。
バグで消えなくなっていた。