### PR TITLE
glTF/VRM1.0 ScriptedImporters can detect the project's RenderPipeline. or a user can select manually.

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterBase.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterBase.cs
@@ -20,34 +20,7 @@ namespace UniGLTF
 
         [SerializeField]
         [Header("Experimental")]
-        public RenderPipelineTypes m_renderPipeline;
-
-        void OnValidate()
-        {
-            if (m_renderPipeline == UniGLTF.RenderPipelineTypes.UniversalRenderPipeline)
-            {
-                if (Shader.Find(UniGLTF.UrpGltfPbrMaterialImporter.ShaderName) == null)
-                {
-                    Debug.LogWarning("URP is not installed. Force to BuiltinRenderPipeline");
-                    m_renderPipeline = UniGLTF.RenderPipelineTypes.BuiltinRenderPipeline;
-                }
-            }
-        }
-
-        static IMaterialDescriptorGenerator GetMaterialGenerator(RenderPipelineTypes renderPipeline)
-        {
-            switch (renderPipeline)
-            {
-                case RenderPipelineTypes.BuiltinRenderPipeline:
-                    return new BuiltInGltfMaterialDescriptorGenerator();
-
-                case RenderPipelineTypes.UniversalRenderPipeline:
-                    return new UrpGltfMaterialDescriptorGenerator();
-
-                default:
-                    throw new System.NotImplementedException();
-            }
-        }
+        public ImporterRenderPipelineTypes m_renderPipeline;
 
         /// <summary>
         /// glb をパースして、UnityObject化、さらにAsset化する
@@ -55,7 +28,8 @@ namespace UniGLTF
         /// <param name="scriptedImporter"></param>
         /// <param name="context"></param>
         /// <param name="reverseAxis"></param>
-        protected static void Import(ScriptedImporter scriptedImporter, AssetImportContext context, Axes reverseAxis, RenderPipelineTypes renderPipeline)
+        /// <param name="renderPipeline"></param>
+        protected static void Import(ScriptedImporter scriptedImporter, AssetImportContext context, Axes reverseAxis, ImporterRenderPipelineTypes renderPipeline)
         {
             UniGLTFLogger.Log("OnImportAsset to " + scriptedImporter.assetPath);
 
@@ -68,7 +42,7 @@ namespace UniGLTF
                 .Where(x => x.Value != null)
                 .ToDictionary(kv => new SubAssetKey(kv.Value.GetType(), kv.Key.name), kv => kv.Value);
 
-            IMaterialDescriptorGenerator materialGenerator = GetMaterialGenerator(renderPipeline);
+            var materialGenerator = GetMaterialDescriptorGenerator(renderPipeline);
 
             using (var data = new AutoGltfFileParser(scriptedImporter.assetPath).Parse())
             using (var loader = new ImporterContext(data, extractedObjects, materialGenerator: materialGenerator))
@@ -93,6 +67,17 @@ namespace UniGLTF
                 context.AddObjectToAsset(root.name, root);
                 context.SetMainObject(root);
             }
+        }
+
+        private static IMaterialDescriptorGenerator GetMaterialDescriptorGenerator(ImporterRenderPipelineTypes renderPipeline)
+        {
+            return renderPipeline switch
+            {
+                ImporterRenderPipelineTypes.Auto => MaterialDescriptorGeneratorUtility .GetValidGltfMaterialDescriptorGenerator(),
+                ImporterRenderPipelineTypes.BuiltinRenderPipeline => MaterialDescriptorGeneratorUtility .GetGltfMaterialDescriptorGenerator(RenderPipelineTypes.BuiltinRenderPipeline),
+                ImporterRenderPipelineTypes.UniversalRenderPipeline => MaterialDescriptorGeneratorUtility .GetGltfMaterialDescriptorGenerator(RenderPipelineTypes.UniversalRenderPipeline),
+                _ => MaterialDescriptorGeneratorUtility.GetValidGltfMaterialDescriptorGenerator(),
+            };
         }
     }
 }

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterBase.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/GltfScriptedImporterBase.cs
@@ -19,7 +19,6 @@ namespace UniGLTF
         public ScriptedImporterAxes m_reverseAxis = default;
 
         [SerializeField]
-        [Header("Experimental")]
         public ImporterRenderPipelineTypes m_renderPipeline;
 
         /// <summary>

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ImporterRenderPipelineTypes.cs
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ImporterRenderPipelineTypes.cs
@@ -1,0 +1,9 @@
+﻿namespace UniGLTF
+{
+    public enum ImporterRenderPipelineTypes
+    {
+        Auto = 0,
+        BuiltinRenderPipeline = 1,
+        UniversalRenderPipeline = 2,
+    }
+}

--- a/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ImporterRenderPipelineTypes.cs.meta
+++ b/Assets/UniGLTF/Editor/UniGLTF/ScriptedImporter/ImporterRenderPipelineTypes.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d4f38213d6e442ef986fd3e633991ba7
+timeCreated: 1722347490

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/Import/MaterialDescriptorGeneratorUtility.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/Import/MaterialDescriptorGeneratorUtility.cs
@@ -4,7 +4,12 @@ namespace UniGLTF
     {
         public static IMaterialDescriptorGenerator GetValidGltfMaterialDescriptorGenerator()
         {
-            return RenderPipelineUtility.GetRenderPipelineType() switch
+            return GetGltfMaterialDescriptorGenerator(RenderPipelineUtility.GetRenderPipelineType());
+        }
+
+        public static IMaterialDescriptorGenerator GetGltfMaterialDescriptorGenerator(RenderPipelineTypes renderPipelineType)
+        {
+            return renderPipelineType switch
             {
                 RenderPipelineTypes.UniversalRenderPipeline => new UrpGltfMaterialDescriptorGenerator(),
                 RenderPipelineTypes.BuiltinRenderPipeline => new BuiltInGltfMaterialDescriptorGenerator(),

--- a/Assets/VRM/Runtime/IO/MaterialIO/VrmMaterialDescriptorGeneratorUtility.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/VrmMaterialDescriptorGeneratorUtility.cs
@@ -6,7 +6,12 @@ namespace VRM
     {
         public static IMaterialDescriptorGenerator GetValidVrmMaterialDescriptorGenerator(glTF_VRM_extensions vrm)
         {
-            return RenderPipelineUtility.GetRenderPipelineType() switch
+            return GetVrmMaterialDescriptorGenerator(vrm, RenderPipelineUtility.GetRenderPipelineType());
+        }
+
+        public static IMaterialDescriptorGenerator GetVrmMaterialDescriptorGenerator(glTF_VRM_extensions vrm, RenderPipelineTypes renderPipelineType)
+        {
+            return renderPipelineType switch
             {
                 RenderPipelineTypes.UniversalRenderPipeline => new UrpVrmMaterialDescriptorGenerator(vrm),
                 RenderPipelineTypes.BuiltinRenderPipeline => new BuiltInVrmMaterialDescriptorGenerator(vrm),

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporter.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporter.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using UniGLTF;
+using UnityEngine;
 #if UNITY_2020_2_OR_NEWER
 using UnityEditor.AssetImporters;
 #else
@@ -15,23 +16,11 @@ namespace UniVRM10
         public bool MigrateToVrm1 = default;
 
         [SerializeField]
-        public UniGLTF.RenderPipelineTypes RenderPipeline = default;
+        public ImporterRenderPipelineTypes RenderPipeline = default;
 
         public override void OnImportAsset(AssetImportContext ctx)
         {
             VrmScriptedImporterImpl.Import(this, ctx, MigrateToVrm1, RenderPipeline);
-        }
-
-        void OnValidate()
-        {
-            if (RenderPipeline == UniGLTF.RenderPipelineTypes.UniversalRenderPipeline)
-            {
-                if (Shader.Find(UniGLTF.UrpGltfPbrMaterialImporter.ShaderName) == null)
-                {
-                    Debug.LogWarning("URP is not installed. Force to BuiltinRenderPipeline");
-                    RenderPipeline = UniGLTF.RenderPipelineTypes.BuiltinRenderPipeline;
-                }
-            }
         }
     }
 }

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
@@ -15,23 +15,7 @@ namespace UniVRM10
 {
     public static class VrmScriptedImporterImpl
     {
-        static IMaterialDescriptorGenerator GetMaterialDescriptorGenerator(RenderPipelineTypes renderPipeline)
-        {
-            var settings = Vrm10ProjectEditorSettings.instance;
-            if (settings.MaterialDescriptorGeneratorFactory != null)
-            {
-                return settings.MaterialDescriptorGeneratorFactory.Create();
-            }
-
-            return renderPipeline switch
-            {
-                RenderPipelineTypes.BuiltinRenderPipeline => new BuiltInVrm10MaterialDescriptorGenerator(),
-                RenderPipelineTypes.UniversalRenderPipeline => new UrpVrm10MaterialDescriptorGenerator(),
-                _ => throw new NotImplementedException()
-            };
-        }
-
-        static void Process(Vrm10Data result, ScriptedImporter scriptedImporter, AssetImportContext context, RenderPipelineTypes renderPipeline)
+        static void Process(Vrm10Data result, ScriptedImporter scriptedImporter, AssetImportContext context, ImporterRenderPipelineTypes renderPipeline)
         {
             //
             // Import(create unity objects)
@@ -73,7 +57,7 @@ namespace UniVRM10
         /// <param name="doMigrate">vrm0 だった場合に vrm1 化する</param>
         /// <param name="renderPipeline"></param>
         /// <param name="doNormalize">normalize する</param>
-        public static void Import(ScriptedImporter scriptedImporter, AssetImportContext context, bool doMigrate, RenderPipelineTypes renderPipeline)
+        public static void Import(ScriptedImporter scriptedImporter, AssetImportContext context, bool doMigrate, ImporterRenderPipelineTypes renderPipeline)
         {
             if (Symbols.VRM_DEVELOP)
             {
@@ -112,6 +96,23 @@ namespace UniVRM10
                 }
                 return;
             }
+        }
+
+        private static IMaterialDescriptorGenerator GetMaterialDescriptorGenerator(ImporterRenderPipelineTypes renderPipeline)
+        {
+            var settings = Vrm10ProjectEditorSettings.instance;
+            if (settings.MaterialDescriptorGeneratorFactory != null)
+            {
+                return settings.MaterialDescriptorGeneratorFactory.Create();
+            }
+
+            return renderPipeline switch
+            {
+                ImporterRenderPipelineTypes.Auto => Vrm10MaterialDescriptorGeneratorUtility.GetValidVrm10MaterialDescriptorGenerator(),
+                ImporterRenderPipelineTypes.BuiltinRenderPipeline => Vrm10MaterialDescriptorGeneratorUtility.GetVrm10MaterialDescriptorGenerator(RenderPipelineTypes.BuiltinRenderPipeline),
+                ImporterRenderPipelineTypes.UniversalRenderPipeline => Vrm10MaterialDescriptorGeneratorUtility.GetVrm10MaterialDescriptorGenerator(RenderPipelineTypes.UniversalRenderPipeline),
+                _ => Vrm10MaterialDescriptorGeneratorUtility.GetValidVrm10MaterialDescriptorGenerator(),
+            };
         }
     }
 }

--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MaterialDescriptorGeneratorUtility.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MaterialDescriptorGeneratorUtility.cs
@@ -6,7 +6,12 @@ namespace UniVRM10
     {
         public static IMaterialDescriptorGenerator GetValidVrm10MaterialDescriptorGenerator()
         {
-            return RenderPipelineUtility.GetRenderPipelineType() switch
+            return GetVrm10MaterialDescriptorGenerator(RenderPipelineUtility.GetRenderPipelineType());
+        }
+
+        public static IMaterialDescriptorGenerator GetVrm10MaterialDescriptorGenerator(RenderPipelineTypes renderPipelineType)
+        {
+            return renderPipelineType switch
             {
                 RenderPipelineTypes.UniversalRenderPipeline => new UrpVrm10MaterialDescriptorGenerator(),
                 RenderPipelineTypes.BuiltinRenderPipeline => new BuiltInVrm10MaterialDescriptorGenerator(),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/81991d05-b17c-4af1-b7d2-22394268c284)

ScriptedImporter に対応する glTF と VRM1.0 の Editor Asset において、RenderPipeline の自動選択を用意し、デフォルトの挙動としました。

VRM 0.X の Editor Asset は ScriptedImporter ではなく AssetPostprocessor であるため、従来挙動通り RenderPipeline は自動選択とします。