### PR TITLE
Implements glTF default material importer at URP

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/BuiltInGltfMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/BuiltInGltfMaterialDescriptorGenerator.cs
@@ -13,26 +13,15 @@ namespace UniGLTF
         {
             if (BuiltInGltfUnlitMaterialImporter.TryCreateParam(data, i, out var param)) return param;
             if (BuiltInGltfPbrMaterialImporter.TryCreateParam(data, i, out param)) return param;
+
             // fallback
             if (Symbols.VRM_DEVELOP)
             {
                 Debug.LogWarning($"material: {i} out of range. fallback");
             }
-
-            return new MaterialDescriptor(
-                GltfMaterialImportUtils.ImportMaterialName(i, null),
-                BuiltInGltfPbrMaterialImporter.Shader,
-                null,
-                new Dictionary<string, TextureDescriptor>(),
-                new Dictionary<string, float>(),
-                new Dictionary<string, Color>(),
-                new Dictionary<string, Vector4>(),
-                new Action<Material>[]{});
+            return GetGltfDefault(GltfMaterialImportUtils.ImportMaterialName(i, null));
         }
 
-        public MaterialDescriptor GetGltfDefault()
-        {
-            return BuiltInGltfDefaultMaterialImporter.CreateParam();
-        }
+        public MaterialDescriptor GetGltfDefault(string materialName = null) => BuiltInGltfDefaultMaterialImporter.CreateParam(materialName);
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfDefaultMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/BuiltInRP/Import/Materials/BuiltInGltfDefaultMaterialImporter.cs
@@ -9,11 +9,11 @@ namespace UniGLTF
     /// </summary>
     public static class BuiltInGltfDefaultMaterialImporter
     {
-        public static MaterialDescriptor CreateParam()
+        public static MaterialDescriptor CreateParam(string materialName = null)
         {
             // FIXME
             return new MaterialDescriptor(
-                "__default__",
+                string.IsNullOrEmpty(materialName) ? "__default__" : materialName,
                 BuiltInGltfPbrMaterialImporter.Shader,
                 default,
                 new Dictionary<string, TextureDescriptor>(),

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/Import/IMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/Import/IMaterialDescriptorGenerator.cs
@@ -14,6 +14,6 @@
         /// <summary>
         /// Generate the MaterialDescriptor for the non-specified glTF material.
         /// </summary>
-        MaterialDescriptor GetGltfDefault();
+        MaterialDescriptor GetGltfDefault(string materialName = null);
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfDefaultMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfDefaultMaterialImporter.cs
@@ -1,27 +1,65 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace UniGLTF
 {
     /// <summary>
     /// Generate the descriptor of the glTF default material.
+    ///
+    /// https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#default-material
     /// </summary>
-    public static class UrpGltfDefaultMaterialImporter
+    public class UrpGltfDefaultMaterialImporter
     {
-        public static MaterialDescriptor CreateParam()
+        public Shader Shader { get; set; }
+
+        public UrpGltfDefaultMaterialImporter(Shader shader = null)
         {
-            // FIXME
+            Shader = shader != null ? shader : Shader.Find("Universal Render Pipeline/Lit");
+        }
+
+        public MaterialDescriptor CreateParam(string materialName)
+        {
             return new MaterialDescriptor(
-                "__default__",
-                UrpGltfPbrMaterialImporter.Shader,
-                default,
+                string.IsNullOrEmpty(materialName) ? "__default__" : materialName,
+                Shader,
+                null,
                 new Dictionary<string, TextureDescriptor>(),
                 new Dictionary<string, float>(),
                 new Dictionary<string, Color>(),
                 new Dictionary<string, Vector4>(),
-                new List<Action<Material>>()
+                new List<Action<Material>> { GenerateDefaultMaterial }
             );
+        }
+
+        public static void GenerateDefaultMaterial(Material dst)
+        {
+            var context = new UrpLitContext(dst);
+            context.UnsafeEditMode = true;
+
+            context.SurfaceType = UrpLitSurfaceType.Opaque;
+            context.IsAlphaClipEnabled = false;
+            context.CullMode = CullMode.Back;
+
+            context.BaseColorSrgb = new Color(1, 1, 1, 1);
+            context.BaseTexture = null;
+
+            context.WorkflowType = UrpLitWorkflowType.Metallic;
+            context.SmoothnessTextureChannel = UrpLitSmoothnessMapChannel.SpecularMetallicAlpha;
+            context.Metallic = 1f;
+            context.Smoothness = 0f;
+            context.MetallicGlossMap = null;
+
+            context.OcclusionTexture = null;
+
+            context.BumpMap = null;
+
+            context.IsEmissionEnabled = false;
+            context.EmissionColorLinear = new Color(0, 0, 0, 0);
+            context.EmissionTexture = null;
+
+            context.Validate();
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfPbrMaterialImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/Materials/UrpGltfPbrMaterialImporter.cs
@@ -11,13 +11,19 @@ namespace UniGLTF
     /// 
     /// see: https://github.com/Unity-Technologies/Graphics/blob/v7.5.3/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineMaterialUpgrader.cs#L354-L379
     /// </summary>
-    public static class UrpGltfPbrMaterialImporter
+    public class UrpGltfPbrMaterialImporter
     {
-        public const string ShaderName = "Universal Render Pipeline/Lit";
+        /// <summary>
+        /// Universal Render Pipeline/Lit とプロパティやキーワードに互換があるカスタムシェーダに置換可能。
+        /// </summary>
+        public Shader Shader { get; set; }
 
-        public static Shader Shader => Shader.Find(ShaderName);
+        public UrpGltfPbrMaterialImporter(Shader shader = null)
+        {
+            Shader = shader != null ? shader : Shader.Find("Universal Render Pipeline/Lit");
+        }
 
-        public static bool TryCreateParam(GltfData data, int i, out MaterialDescriptor matDesc)
+        public bool TryCreateParam(GltfData data, int i, out MaterialDescriptor matDesc)
         {
             if (i < 0 || i >= data.GLTF.materials.Count)
             {
@@ -44,7 +50,6 @@ namespace UniGLTF
 
         public static async Task GenerateMaterialAsync(GltfData data, glTFMaterial src, Material dst, GetTextureAsyncFunc getTextureAsync, IAwaitCaller awaitCaller)
         {
-            dst.shader = Shader;
             var context = new UrpLitContext(dst);
             context.UnsafeEditMode = true;
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/UrpGltfMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/UrpGltfMaterialDescriptorGenerator.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using UnityEngine;
 
 namespace UniGLTF
@@ -10,30 +7,22 @@ namespace UniGLTF
     /// </summary>
     public sealed class UrpGltfMaterialDescriptorGenerator : IMaterialDescriptorGenerator
     {
+        public UrpGltfPbrMaterialImporter PbrMaterialImporter { get; }
+        public UrpGltfDefaultMaterialImporter DefaultMaterialImporter { get; }
+
         public MaterialDescriptor Get(GltfData data, int i)
         {
             if (BuiltInGltfUnlitMaterialImporter.TryCreateParam(data, i, out var param)) return param;
-            if (UrpGltfPbrMaterialImporter.TryCreateParam(data, i, out param)) return param;
-            // fallback
+            if (PbrMaterialImporter.TryCreateParam(data, i, out param)) return param;
+
+            // NOTE: Fallback to default material
             if (Symbols.VRM_DEVELOP)
             {
                 Debug.LogWarning($"material: {i} out of range. fallback");
             }
-
-            return new MaterialDescriptor(
-                GltfMaterialImportUtils.ImportMaterialName(i, null),
-                UrpGltfPbrMaterialImporter.Shader,
-                null,
-                new Dictionary<string, TextureDescriptor>(),
-                new Dictionary<string, float>(),
-                new Dictionary<string, Color>(),
-                new Dictionary<string, Vector4>(),
-                new Collection<Action<Material>>());
+            return GetGltfDefault(GltfMaterialImportUtils.ImportMaterialName(i, null));
         }
 
-        public MaterialDescriptor GetGltfDefault()
-        {
-            return UrpGltfDefaultMaterialImporter.CreateParam();
-        }
+        public MaterialDescriptor GetGltfDefault(string materialName = null) => DefaultMaterialImporter.CreateParam(materialName);
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/UrpGltfMaterialDescriptorGenerator.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/Import/UrpGltfMaterialDescriptorGenerator.cs
@@ -7,8 +7,8 @@ namespace UniGLTF
     /// </summary>
     public sealed class UrpGltfMaterialDescriptorGenerator : IMaterialDescriptorGenerator
     {
-        public UrpGltfPbrMaterialImporter PbrMaterialImporter { get; }
-        public UrpGltfDefaultMaterialImporter DefaultMaterialImporter { get; }
+        public UrpGltfPbrMaterialImporter PbrMaterialImporter { get; } = new();
+        public UrpGltfDefaultMaterialImporter DefaultMaterialImporter { get; } = new();
 
         public MaterialDescriptor Get(GltfData data, int i)
         {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/ShaderUtil/Lit/UrpLitContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/URP/ShaderUtil/Lit/UrpLitContext.cs
@@ -15,7 +15,7 @@ namespace UniGLTF
     /// - Environment Reflections Toggle
     /// - Sorting Priority
     /// </summary>
-    public sealed class UrpLitContext
+    public class UrpLitContext
     {
         private readonly Material _mat;
 

--- a/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/BuiltInVrmMaterialDescriptorGenerator.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/BuiltInRP/Import/BuiltInVrmMaterialDescriptorGenerator.cs
@@ -41,21 +41,13 @@ namespace VRM
             }
 
             // fallback
-            Debug.LogWarning($"fallback");
-            return new MaterialDescriptor(
-                GltfMaterialImportUtils.ImportMaterialName(i, null),
-                BuiltInGltfPbrMaterialImporter.Shader,
-                null,
-                new Dictionary<string, TextureDescriptor>(),
-                new Dictionary<string, float>(),
-                new Dictionary<string, Color>(),
-                new Dictionary<string, Vector4>(),
-                new Action<Material>[]{});
+            if (Symbols.VRM_DEVELOP)
+            {
+                Debug.LogWarning($"material: {i} out of range. fallback");
+            }
+            return GetGltfDefault(GltfMaterialImportUtils.ImportMaterialName(i, null));
         }
 
-        public MaterialDescriptor GetGltfDefault()
-        {
-            return BuiltInGltfDefaultMaterialImporter.CreateParam();
-        }
+        public MaterialDescriptor GetGltfDefault(string materialName = null) => BuiltInGltfDefaultMaterialImporter.CreateParam(materialName);
     }
 }

--- a/Assets/VRM/Runtime/IO/MaterialIO/URP/Import/UrpVrmMaterialDescriptorGenerator.cs
+++ b/Assets/VRM/Runtime/IO/MaterialIO/URP/Import/UrpVrmMaterialDescriptorGenerator.cs
@@ -9,6 +9,9 @@ namespace VRM
     {
         private readonly glTF_VRM_extensions _vrm;
 
+        public UrpGltfPbrMaterialImporter PbrMaterialImporter { get; }
+        public UrpGltfDefaultMaterialImporter DefaultMaterialImporter { get; }
+
         public UrpVrmMaterialDescriptorGenerator(glTF_VRM_extensions vrm)
         {
             _vrm = vrm;
@@ -20,26 +23,16 @@ namespace VRM
             // unlit "UniUnlit" work in URP
             if (BuiltInGltfUnlitMaterialImporter.TryCreateParam(data, i, out var matDesc)) return matDesc;
             // pbr "Standard" to "Universal Render Pipeline/Lit" 
-            if (UrpGltfPbrMaterialImporter.TryCreateParam(data, i, out matDesc)) return matDesc;
-            // fallback
+            if (PbrMaterialImporter.TryCreateParam(data, i, out matDesc)) return matDesc;
+
+            // NOTE: Fallback to default material
             if (Symbols.VRM_DEVELOP)
             {
                 Debug.LogWarning($"material: {i} out of range. fallback");
             }
-            return new MaterialDescriptor(
-                GltfMaterialImportUtils.ImportMaterialName(i, null),
-                UrpGltfPbrMaterialImporter.Shader,
-                null,
-                new Dictionary<string, TextureDescriptor>(),
-                new Dictionary<string, float>(),
-                new Dictionary<string, Color>(),
-                new Dictionary<string, Vector4>(),
-                new Action<Material>[]{});
+            return GetGltfDefault(GltfMaterialImportUtils.ImportMaterialName(i, null));
         }
 
-        public MaterialDescriptor GetGltfDefault()
-        {
-            return UrpGltfDefaultMaterialImporter.CreateParam();
-        }
+        public MaterialDescriptor GetGltfDefault(string materialName = null) => DefaultMaterialImporter.CreateParam(materialName);
     }
 }

--- a/Assets/VRM10/Runtime/IO/Material/BuiltInRP/Import/BuiltInVrm10MaterialDescriptorGenerator.cs
+++ b/Assets/VRM10/Runtime/IO/Material/BuiltInRP/Import/BuiltInVrm10MaterialDescriptorGenerator.cs
@@ -21,20 +21,9 @@ namespace UniVRM10
             {
                 Debug.LogWarning($"material: {i} out of range. fallback");
             }
-            return new MaterialDescriptor(
-                GltfMaterialImportUtils.ImportMaterialName(i, null),
-                BuiltInGltfPbrMaterialImporter.Shader,
-                null, 
-                new Dictionary<string, TextureDescriptor>(),
-                new Dictionary<string, float>(),
-                new Dictionary<string, Color>(),
-                new Dictionary<string, Vector4>(),
-                new Action<Material>[]{});
+            return GetGltfDefault(GltfMaterialImportUtils.ImportMaterialName(i, null));
         }
 
-        public MaterialDescriptor GetGltfDefault()
-        {
-            return BuiltInGltfDefaultMaterialImporter.CreateParam();
-        }
+        public MaterialDescriptor GetGltfDefault(string materialName = null) => BuiltInGltfDefaultMaterialImporter.CreateParam(materialName);
     }
 }

--- a/Assets/VRM10/Runtime/IO/Material/URP/Import/UrpVrm10MaterialDescriptorGenerator.cs
+++ b/Assets/VRM10/Runtime/IO/Material/URP/Import/UrpVrm10MaterialDescriptorGenerator.cs
@@ -7,6 +7,9 @@ namespace UniVRM10
 {
     public sealed class UrpVrm10MaterialDescriptorGenerator : IMaterialDescriptorGenerator
     {
+        public UrpGltfPbrMaterialImporter PbrMaterialImporter { get; }
+        public UrpGltfDefaultMaterialImporter DefaultMaterialImporter { get; }
+
         public MaterialDescriptor Get(GltfData data, int i)
         {
             // mtoon
@@ -14,24 +17,16 @@ namespace UniVRM10
             // unlit
             if (BuiltInGltfUnlitMaterialImporter.TryCreateParam(data, i, out matDesc)) return matDesc;
             // pbr
-            if (UrpGltfPbrMaterialImporter.TryCreateParam(data, i, out matDesc)) return matDesc;
+            if (PbrMaterialImporter.TryCreateParam(data, i, out matDesc)) return matDesc;
 
-            // fallback
-            Debug.LogWarning($"material: {i} out of range. fallback");
-            return new MaterialDescriptor(
-                GltfMaterialImportUtils.ImportMaterialName(i, null),
-                UrpGltfPbrMaterialImporter.Shader,
-                null,
-                new Dictionary<string, TextureDescriptor>(),
-                new Dictionary<string, float>(),
-                new Dictionary<string, Color>(),
-                new Dictionary<string, Vector4>(),
-                new Action<Material>[]{});
+            // NOTE: Fallback to default material
+            if (Symbols.VRM_DEVELOP)
+            {
+                Debug.LogWarning($"material: {i} out of range. fallback");
+            }
+            return GetGltfDefault(GltfMaterialImportUtils.ImportMaterialName(i, null));
         }
 
-        public MaterialDescriptor GetGltfDefault()
-        {
-            return UrpGltfDefaultMaterialImporter.CreateParam();
-        }
+        public MaterialDescriptor GetGltfDefault(string materialName = null) => DefaultMaterialImporter.CreateParam(materialName);
     }
 }


### PR DESCRIPTION
`UrpGltfDefaultMaterialImporter` を glTF 仕様通りに実装します。

一点、破壊的変更として
`IMaterialDescriptorGenerator` の `GetGltfDefault` 関数に `string materialName = null` 引数を加えました。

カスタムしたシェーダをアプリケーションで使用したい用途を持つような、
`IMaterialDescriptorGeneartor` を独自に実装しているユーザに影響があります。