### PR TITLE
[vrm1] mesh export 時の byteLength 確認テストを追加

### DIFF
--- a/Assets/UniGLTF/Tests/UniGLTF/UniGLTFTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/UniGLTFTests.cs
@@ -741,6 +741,42 @@ namespace UniGLTF
             }
         }
 
+        //
+        // https://github.com/vrm-c/UniVRM/pull/2413
+        //
+        [Test]
+        public void ExportingMeshByteLengthTest()
+        {
+            var validator = ScriptableObject.CreateInstance<MeshExportValidator>();
+            var root = new GameObject("root");
+            try
+            {
+                {
+                    var child = TestGltf.CreatePrimitiveAsBuiltInRP(PrimitiveType.Cube);
+                    child.transform.SetParent(root.transform);
+                }
+                // export
+                var data = TestGltf.ExportAsBuiltInRP(root);
+                var gltf = data.Gltf;
+                // cube
+                var expected =  
+                // pos
+                (4*3)*24
+                // normal
+                +(4*3)*24
+                // uv
+                +(4*2)*24
+                // indices
+                 + 4 * 36;
+                Assert.AreEqual(expected, gltf.buffers[0].byteLength);
+            }
+            finally
+            {
+                GameObject.DestroyImmediate(root);
+                ScriptableObject.DestroyImmediate(validator);
+            }
+        }
+
         [Serializable]
         class CantConstruct
         {

--- a/Assets/VRM10/Runtime/IO/Material/URP/Export.meta
+++ b/Assets/VRM10/Runtime/IO/Material/URP/Export.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a6506c50290f7fb48984c1c5e83929e4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM10/Runtime/IO/Material/URP/Export/UrpVrm10MaterialExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Material/URP/Export/UrpVrm10MaterialExporter.cs
@@ -1,0 +1,19 @@
+﻿using UniGLTF;
+using UnityEngine;
+
+namespace UniVRM10
+{
+    public class UrpVrm10MaterialExporter : IMaterialExporter
+    {
+        public glTFMaterial ExportMaterial(Material m, ITextureExporter textureExporter, GltfExportSettings settings)
+        {
+            #if UNITY_EDITOR
+            return new glTFMaterial{
+                name = "dummyForTest",
+            };
+            #else
+            throw new System.NotImplementedException();
+            #endif
+        }
+    }
+}

--- a/Assets/VRM10/Runtime/IO/Material/URP/Export/UrpVrm10MaterialExporter.cs.meta
+++ b/Assets/VRM10/Runtime/IO/Material/URP/Export/UrpVrm10MaterialExporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95b7c97505db9d747b04136aa1505204
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM10/Runtime/IO/Material/Vrm10MaterialExporterUtility.cs
+++ b/Assets/VRM10/Runtime/IO/Material/Vrm10MaterialExporterUtility.cs
@@ -8,7 +8,7 @@ namespace UniVRM10
         {
             return RenderPipelineUtility.GetRenderPipelineType() switch
             {
-                RenderPipelineTypes.UniversalRenderPipeline => throw new System.NotImplementedException(),
+                RenderPipelineTypes.UniversalRenderPipeline => new UrpVrm10MaterialExporter(),
                 RenderPipelineTypes.BuiltinRenderPipeline => new BuiltInVrm10MaterialExporter(),
                 _ => new BuiltInVrm10MaterialExporter(),
             };

--- a/Assets/VRM10/Tests/LoadTests.cs
+++ b/Assets/VRM10/Tests/LoadTests.cs
@@ -1,5 +1,8 @@
+using System.IO;
+using System.Linq;
 using NUnit.Framework;
 using UniGLTF;
+using UnityEngine;
 
 namespace UniVRM10.Test
 {
@@ -23,6 +26,110 @@ namespace UniVRM10.Test
                 {
                     loader.LoadAsync(new ImmediateCaller()).Wait();
                 }
+            }
+        }
+
+        static string ModelPath
+        {
+            get
+            {
+                // submodule
+                return Path.GetFullPath(Application.dataPath + "/../vrm-specification/samples/Seed-san/vrm/Seed-san.vrm")
+                    .Replace("\\", "/");
+            }
+        }
+
+        static int getByteLength(glTF gltf, int accessorIndex)
+        {
+            if (accessorIndex < 0) { return 0; }
+            var accessor = gltf.accessors[accessorIndex];
+            return accessor.CalcByteSize();
+        }
+
+        static int getByteLength(glTF gltf, glTFPrimitives prim)
+        {
+            var l = 0;
+            l += getByteLength(gltf, prim.indices);
+            l += getByteLength(gltf, prim.attributes.POSITION);
+            l += getByteLength(gltf, prim.attributes.NORMAL);
+            l += getByteLength(gltf, prim.attributes.TANGENT);
+            l += getByteLength(gltf, prim.attributes.TEXCOORD_0);
+            l += getByteLength(gltf, prim.attributes.JOINTS_0);
+            l += getByteLength(gltf, prim.attributes.WEIGHTS_0);
+            foreach (var morph in prim.targets)
+            {
+                l += getByteLength(gltf, morph.POSITION);
+                l += getByteLength(gltf, morph.NORMAL);
+                l += getByteLength(gltf, morph.TANGENT);
+            }
+            return l;
+        }
+
+        static int getByteLength(glTF gltf, glTFMesh mesh)
+        {
+            var l = 0;
+            foreach (var prim in mesh.primitives)
+            {
+                l += getByteLength(gltf, prim);
+            }
+            return l;
+        }
+
+        [Test]
+        public void NoTexture()
+        {
+            if (!File.Exists(ModelPath))
+            {
+                return;
+            }
+
+            // load model
+            var task = Vrm10.LoadPathAsync(ModelPath, awaitCaller: new ImmediateCaller());
+            var instance = task.Result;
+
+            // remove textures
+            instance.Vrm.Meta.Thumbnail = null;
+            var m = new Material(Shader.Find("Unlit/Color"));
+            foreach (var r in instance.GetComponentsInChildren<Renderer>())
+            {
+                r.sharedMaterials = r.sharedMaterials.Select(x => m).ToArray();
+            }
+
+            // export as vrm1
+            using (var arrayManager = new NativeArrayManager())
+            {
+                var converter = new UniVRM10.ModelExporter();
+                var model = converter.Export(arrayManager, instance.gameObject);
+
+                // 右手系に変換
+                Debug.Log($"convert to right handed coordinate...");
+                model.ConvertCoordinate(VrmLib.Coordinates.Vrm1, ignoreVrm: false);
+
+                // export vrm-1.0
+                var exporter = new Vrm10Exporter(new GltfExportSettings());
+                exporter.Export(instance.gameObject, model, converter, new VrmLib.ExportArgs
+                {
+                    sparse = false,
+                });
+
+                var gltf = exporter.Storage.Gltf;
+
+                var last = gltf.bufferViews.Last();
+                // https://github.com/vrm-c/UniVRM/pull/2413
+                Assert.AreEqual(last.byteOffset + last.byteLength, exporter.Storage.Gltf.buffers[0].byteLength);
+
+                // check byteLength
+                var expected = 0;
+                foreach (var mesh in gltf.meshes)
+                {
+                    expected += getByteLength(gltf, mesh);
+                }
+                foreach (var skin in gltf.skins)
+                {
+                    expected += getByteLength(gltf, skin.inverseBindMatrices);
+                }
+                // alighment ?
+                // Assert.AreEqual(expected, exporter.Storage.Gltf.buffers[0].byteLength);
             }
         }
     }


### PR DESCRIPTION
vrm-1.0 の sparse と bindMatrix をバッファーに追加するときに通る関数で問題が起きていたぽい。
後続に image のバッファー追加があると上書きされて顕在化しない様子。

テストの都合で UrpVrm10MaterialExporter の placeholder だけ追加しました。

#2413 の有無によりテストの成否が変化することを確認できました。

exporter の buffer 周りのインタフェースがよろしくない(間違えやすい)ので、
リファクタリングしたいところ。
