### PR TITLE
VRM1.0のエクスポート時に非アクティブのRendererもmeshの出力対象とする

### DIFF
--- a/Assets/VRM10/Runtime/IO/Model/ModelExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/ModelExporter.cs
@@ -105,7 +105,7 @@ namespace UniVRM10
             }
 
             // material and textures
-            var rendererComponents = root.GetComponentsInChildren<Renderer>();
+            var rendererComponents = root.GetComponentsInChildren<Renderer>(true);
             {
                 foreach (var renderer in rendererComponents)
                 {


### PR DESCRIPTION
# 概要
- VRM1.0のエクスポート時に非アクティブのRendererもmeshの出力対象とする
  - 以下の経緯に該当するエラーを解消するため

# 経緯
以下のようにRendererを持つGameObjectが非アクティブの状態でVRM1.0のエクスポートを実施すると、出力されたvrmのJSON部分のnodeに"mesh"が登録されておりませんでした。

![](https://github.com/user-attachments/assets/d1ea86d0-61ec-4469-9a20-00009af31ea1)

```json
  "nodes": [
    ...
    {
      "name": "Face"
    },
    {
      "mesh": 0,
      "name": "Body",
      "skin": 0
    },
    {
    "name": "Hair"
    },
```

一方でFirstPersonのmeshAnnotationやExpressionのmorphTargetでは非アクティブなRendererやそのMeshもエクスポート対象となっていたため、glTFのmeshを持たないnodeに紐づく形で出力されておりました。

以下はエクスポートされたVRM1.0内のFirstPersonのMeshAnnotationsで、103番目のFaceと105番目のHairもmeshがあるものとして出力されています。
```json
      "firstPerson": {
        "meshAnnotations": [
          {
            "node": 103,
            "type": "thirdPersonOnly"
          },
          {
            "node": 104,
            "type": "both"
          },
          {
            "node": 105,
            "type": "firstPersonOnly"
          }
        ]
      },
```

このVRM1.0をUniVRM10でロードすると以下のエラーが発生します。
```
ArgumentNullException: Value cannot be null.
Parameter name: key
System.Collections.Generic.Dictionary`2[TKey, TValue].FindEntry(TKey key)(at < 1c8569827291471e9db0dcd976e97952 >:0)
System.Collections.Generic.Dictionary`2[TKey, TValue].get_Item(TKey key)(at < 1c8569827291471e9db0dcd976e97952 >:0)
UniVRM10.ExpressionExtensions.Build10(UniGLTF.Extensions.VRMC_vrm.MorphTargetBind bind, UnityEngine.GameObject root, UniVRM10.Vrm10Importer + ModelMap loader, VrmLib.Model model)(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / ExpressionExtensions.cs:15)
UniVRM10.Vrm10Importer.< GetOrLoadExpression > b__13_0(UniGLTF.Extensions.VRMC_vrm.MorphTargetBind x)(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10Importer.cs:308)
System.Linq.Enumerable + SelectListIterator`2[TSource, TResult].ToArray()(at < 39d6421ea91449339eee7ef41a176a38 >:0)
System.Linq.Enumerable.ToArray[TSource](System.Collections.Generic.IEnumerable`1[T] source)(at < 39d6421ea91449339eee7ef41a176a38 >:0)
UniVRM10.Vrm10Importer.GetOrLoadExpression(UniGLTF.SubAssetKey & key, UniVRM10.ExpressionPreset preset, UniGLTF.Extensions.VRMC_vrm.Expression expression)(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10Importer.cs:308)
UniVRM10.Vrm10Importer.LoadVrmAsync(UniGLTF.IAwaitCaller awaitCaller, UniGLTF.Extensions.VRMC_vrm.VRMC_vrm vrmExtension)(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10Importer.cs:418)
UniVRM10.Vrm10Importer.OnLoadHierarchy(UniGLTF.IAwaitCaller awaitCaller, System.Func`2[T, TResult] MeasureTime)(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10Importer.cs:265)
UniGLTF.ImporterContext.LoadAsync(UniGLTF.IAwaitCaller awaitCaller, System.Func`2[T, TResult] MeasureTime)(at Library / PackageCache / com.vrmc.gltf@14f3add22f / Runtime / UniGLTF / IO / ImporterContext.cs:132)
UniVRM10.Vrm10Importer.LoadAsync(UniGLTF.IAwaitCaller awaitCaller, System.Func`2[T, TResult] MeasureTime)(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10Importer.cs:149)
UniVRM10.Vrm10.LoadVrm10DataAsync(UniVRM10.Vrm10Data vrm10Data, UniVRM10.MigrationData migrationData, UniVRM10.ControlRigGenerationOption controlRigGenerationOption, System.Boolean showMeshes, UniGLTF.IAwaitCaller awaitCaller, UniGLTF.ITextureDeserializer textureDeserializer, UniGLTF.IMaterialDescriptorGenerator materialGenerator, UniVRM10.Vrm10 + VrmMetaInformationCallback vrmMetaInformationCallback, System.Threading.CancellationToken ct, UniGLTF.ImporterContextSettings importerContextSettings)(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10.cs:366)
UniVRM10.Vrm10.TryLoadingAsVrm10Async(UniGLTF.GltfData gltfData, UniVRM10.ControlRigGenerationOption controlRigGenerationOption, System.Boolean showMeshes, UniGLTF.IAwaitCaller awaitCaller, UniGLTF.ITextureDeserializer textureDeserializer, UniGLTF.IMaterialDescriptorGenerator materialGenerator, UniVRM10.Vrm10 + VrmMetaInformationCallback vrmMetaInformationCallback, System.Threading.CancellationToken ct, UniGLTF.ImporterContextSettings importerContextSettings)(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10.cs:262)
UniVRM10.Vrm10.LoadAsync(UniGLTF.GltfData gltfData, System.Boolean canLoadVrm0X, UniVRM10.ControlRigGenerationOption controlRigGenerationOption, System.Boolean showMeshes, UniGLTF.IAwaitCaller awaitCaller, UniGLTF.ITextureDeserializer textureDeserializer, UniGLTF.IMaterialDescriptorGenerator materialGenerator, UniVRM10.Vrm10 + VrmMetaInformationCallback vrmMetaInformationCallback, System.Threading.CancellationToken ct, UniGLTF.ImporterContextSettings importerContextSettings)(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10.cs:186)
UniVRM10.Vrm10.LoadPathAsync(System.String path, System.Boolean canLoadVrm0X, UniVRM10.ControlRigGenerationOption controlRigGenerationOption, System.Boolean showMeshes, UniGLTF.IAwaitCaller awaitCaller, UniGLTF.ITextureDeserializer textureDeserializer, UniGLTF.IMaterialDescriptorGenerator materialGenerator, UniVRM10.Vrm10 + VrmMetaInformationCallback vrmMetaInformationCallback, System.Threading.CancellationToken ct, UniGLTF.ImporterContextSettings importerContextSettings)(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10.cs:60)
UniVRM10.VRM10Viewer.VRM10ViewerUI.LoadModel(System.String path)(at Assets / Samples / VRM - 1.0 / 0.125.0 / VRM10Viewer / VRM10ViewerUI.cs:540)
UnityEngine.Debug:LogException(Exception)
UniVRM10.VRM10Viewer.< LoadModel > d__36:MoveNext()(at Assets / Samples / VRM - 1.0 / 0.125.0 / VRM10Viewer / VRM10ViewerUI.cs:573)
System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1:SetException(Exception)
UniVRM10.< LoadPathAsync > d__1:MoveNext()(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10.cs:60)
System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1:SetException(Exception)
UniVRM10.< LoadAsync > d__4:MoveNext()(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10.cs:233)
System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1:SetException(Exception)
UniVRM10.< TryLoadingAsVrm10Async > d__5:MoveNext()(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10.cs:262)
System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1:SetException(Exception)
UniVRM10.< LoadVrm10DataAsync > d__7:MoveNext()(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10.cs:390)
System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1:SetException(Exception)
UniVRM10.< LoadAsync > d__10:MoveNext()(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10Importer.cs:149)
System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1:SetException(Exception)
UniGLTF.< LoadAsync > d__32:MoveNext()(at Library / PackageCache / com.vrmc.gltf@14f3add22f / Runtime / UniGLTF / IO / ImporterContext.cs:134)
System.Runtime.CompilerServices.AsyncTaskMethodBuilder:SetResult()
UniVRM10.< LoadGeometryAsync > d__11:MoveNext()(at Library / PackageCache / com.vrmc.vrm@14f3add22f / Runtime / IO / Vrm10Importer.cs:245)
System.Threading.Tasks.TaskCompletionSource`1:SetResult(Object)
UniGLTF.<> c__DisplayClass4_0:< NextFrame > b__0()(at Library / PackageCache / com.vrmc.gltf@14f3add22f / Runtime / UniGLTF / IO / AwaitCaller / RuntimeOnlyAwaitCaller.cs:31)
UniGLTF.TinyManagedTaskScheduler:ManagedUpdate()(at Library / PackageCache / com.vrmc.gltf@14f3add22f / Runtime / UniGLTF / IO / AwaitCaller / TinyManagedTaskScheduler.cs:21)
UniGLTF.UnityLoopTaskScheduler:Update()(at Library / PackageCache / com.vrmc.gltf@14f3add22f / Runtime / UniGLTF / IO / AwaitCaller / NextFrameTaskScheduler.cs:50)
```

# 備考
- 変更前後で非アクティブなGameObjectに対するエクスポートの挙動が変わってしまっております。
- もし引き続き非アクティブなGameObjectを出力の対象外とする場合は、FirstPersonおよびExpression側も同様に対象外とする改修が必要になると思われます。