### PR TITLE
[exporter] renderer の export しない基準 GameObject.active / Renderer.enabled を修正

### DIFF
--- a/Assets/VRM/Runtime/IO/VRMExporter.cs
+++ b/Assets/VRM/Runtime/IO/VRMExporter.cs
@@ -185,11 +185,14 @@ namespace VRM
                 {
                     VRM.firstPerson.firstPersonBone = Nodes.IndexOf(firstPerson.FirstPersonBone);
                     VRM.firstPerson.firstPersonBoneOffset = firstPerson.FirstPersonOffset;
-                    VRM.firstPerson.meshAnnotations = firstPerson.Renderers.Select(x => new glTF_VRM_MeshAnnotation
-                    {
-                        mesh = Meshes.IndexOf(x.SharedMesh),
-                        firstPersonFlag = x.FirstPersonFlag.ToString(),
-                    }).ToList();
+                    VRM.firstPerson.meshAnnotations = firstPerson.Renderers
+                        .Select(x => new glTF_VRM_MeshAnnotation
+                        {
+                            mesh = Meshes.IndexOf(x.SharedMesh),
+                            firstPersonFlag = x.FirstPersonFlag.ToString(),
+                        })
+                        .Where(x => x.mesh != -1)
+                        .ToList();
                 }
 
                 // lookAt

--- a/Assets/VRM/Runtime/IO/VRMImporterContext.cs
+++ b/Assets/VRM/Runtime/IO/VRMImporterContext.cs
@@ -162,7 +162,7 @@ namespace VRM
                     // fallback
                     asset.Preset = CachedEnum.ParseOrDefault<BlendShapePreset>(group.name, true);
                 }
-                asset.Values = group.binds.Select(x =>
+                asset.Values = group.binds.Where(x => x.mesh >= 0 && x.mesh < Meshes.Count).Select(x =>
                 {
                     var mesh = Meshes[x.mesh].Mesh;
                     var node = transformMeshTable[mesh];

--- a/Assets/VRM10/Runtime/IO/ExpressionExtensions.cs
+++ b/Assets/VRM10/Runtime/IO/ExpressionExtensions.cs
@@ -8,13 +8,23 @@ namespace UniVRM10
 {
     public static class ExpressionExtensions
     {
-        public static UniVRM10.MorphTargetBinding Build10(this MorphTargetBind bind, GameObject root, Vrm10Importer.ModelMap loader, VrmLib.Model model)
+        public static MorphTargetBinding? Build10(this MorphTargetBind bind, GameObject root, Vrm10Importer.ModelMap loader, VrmLib.Model model)
         {
-            var libNode = model.Nodes[bind.Node.Value];
-            var node = loader.Nodes[libNode].transform;
-            var mesh = loader.Meshes[libNode.MeshGroup];
-            var relativePath = node.RelativePathFrom(root.transform);
-            return new UniVRM10.MorphTargetBinding(relativePath, bind.Index.Value, bind.Weight.Value);
+            if (bind.Node.TryGetValidIndex(model.Nodes.Count, out var nodeIndex))
+            {
+                var libNode = model.Nodes[nodeIndex];
+                if (libNode.MeshGroup == null)
+                {
+                    return default;
+                }
+                var node = loader.Nodes[libNode].transform;
+                var relativePath = node.RelativePathFrom(root.transform);
+                return new MorphTargetBinding(relativePath, bind.Index.Value, bind.Weight.Value);
+            }
+            else
+            {
+                return default;
+            }
         }
 
         public static UniVRM10.MaterialColorBinding? Build10(this MaterialColorBind bind, IReadOnlyList<MaterialFactory.MaterialLoadInfo> materials)

--- a/Assets/VRM10/Runtime/IO/Model/ModelExporter.cs
+++ b/Assets/VRM10/Runtime/IO/Model/ModelExporter.cs
@@ -105,7 +105,7 @@ namespace UniVRM10
             }
 
             // material and textures
-            var rendererComponents = root.GetComponentsInChildren<Renderer>();
+            var rendererComponents = root.GetComponentsInChildren<Renderer>().Where(x => x.gameObject.activeInHierarchy && x.enabled).ToArray();
             {
                 foreach (var renderer in rendererComponents)
                 {

--- a/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Exporter.cs
@@ -646,7 +646,13 @@ namespace UniVRM10
             };
             foreach (var f in firstPerson.Renderers)
             {
-                vrm.FirstPerson.MeshAnnotations.Add(ExportMeshAnnotation(f, vrmController.transform, getIndex));
+                var annotation = ExportMeshAnnotation(f, vrmController.transform, getIndex);
+                if (annotation.Node < 0)
+                {
+                    // maybe disabled Rendeer
+                    continue;
+                }
+                vrm.FirstPerson.MeshAnnotations.Add(annotation);
             }
         }
 
@@ -718,6 +724,15 @@ namespace UniVRM10
             Func<string, int> getIndexFromRelativePath = relativePath =>
             {
                 var rendererNode = vrmController.transform.GetFromPath(relativePath);
+                var renderer = rendererNode.GetComponent<Renderer>();
+                if (renderer == null)
+                {
+                    return -1;
+                }
+                if (!renderer.enabled)
+                {
+                    return -1;
+                }
                 var node = converter.Nodes[rendererNode.gameObject];
                 return model.Nodes.IndexOf(node);
             };
@@ -751,7 +766,14 @@ namespace UniVRM10
             {
                 try
                 {
-                    vrmExpression.MorphTargetBinds.Add(ExportMorphTargetBinding(b, getIndexFromRelativePath));
+                    var binding = ExportMorphTargetBinding(b, getIndexFromRelativePath);
+                    if (binding.Node < 0)
+                    {
+                        // node もしくは renderer が存在しない
+                        continue;
+                    }
+
+                    vrmExpression.MorphTargetBinds.Add(binding);
                 }
                 catch (Exception ex)
                 {

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -506,6 +506,7 @@ namespace UniVRM10
                         });
                     }
                 }
+            }
             else
             {
                 // default 値を割り当てる

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -316,7 +316,10 @@ namespace UniVRM10
 
                 if (expression.MorphTargetBinds != null)
                 {
-                    clip.MorphTargetBindings = expression.MorphTargetBinds?.Select(x => x.Build10(Root, m_map, m_model))
+                    clip.MorphTargetBindings = expression.MorphTargetBinds?
+                        .Select(x => x.Build10(Root, m_map, m_model))
+                        .Where(x => x.HasValue)
+                        .Select(x => x.Value)
                         .ToArray();
                 }
                 else
@@ -492,15 +495,17 @@ namespace UniVRM10
                 var fp = vrmExtension.FirstPerson;
                 foreach (var x in fp.MeshAnnotations)
                 {
-                    var node = Nodes[x.Node.Value];
-                    var relative = node.RelativePathFrom(Root.transform);
-                    vrm.FirstPerson.Renderers.Add(new RendererFirstPersonFlags
+                    if (x.Node.TryGetValidIndex(Nodes.Count, out var index))
                     {
-                        FirstPersonFlag = x.Type,
-                        Renderer = relative,
-                    });
+                        var node = Nodes[x.Node.Value];
+                        var relative = node.RelativePathFrom(Root.transform);
+                        vrm.FirstPerson.Renderers.Add(new RendererFirstPersonFlags
+                        {
+                            FirstPersonFlag = x.Type,
+                            Renderer = relative,
+                        });
+                    }
                 }
-            }
             else
             {
                 // default 値を割り当てる


### PR DESCRIPTION
fixed #2434

fixed #1980

export 時の renderer の export 基準を徹底した。

```cs
x.gameObject.activeInHierarchy && x.TryGetComponent<Renderer>(out var renderer) && renderer.enabled
```

関連して firstPerson.annotations と expression.binds の mesh/node が連動するのだけど、
残るバグがあった。

既存のモデルに firstPerson.annotations と expression.binds の無効な参照が残っている場合向けに
importer のチェックを追加した。
