### PR TITLE
springbone 初期化の修正。

### DIFF
--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
@@ -103,7 +103,16 @@ namespace UniGLTF.SpringBoneJobs.InputPorts
             Joints = new NativeArray<BlittableJointMutable>(blittableJoints.ToArray(), Allocator.Persistent);
             Colliders = new NativeArray<BlittableCollider>(blittableColliders.ToArray(), Allocator.Persistent);
             Logics = new NativeArray<BlittableJointImmutable>(blittableLogics.ToArray(), Allocator.Persistent);
-            BlittableTransforms = new NativeArray<BlittableTransform>(Transforms.Length, Allocator.Persistent);
+            BlittableTransforms = new NativeArray<BlittableTransform>(Transforms.Select(transform => new BlittableTransform
+            {
+                position = transform.position,
+                rotation = transform.rotation,
+                localPosition = transform.localPosition,
+                localRotation = transform.localRotation,
+                localScale = transform.localScale,
+                localToWorldMatrix = transform.localToWorldMatrix,
+                worldToLocalMatrix = transform.worldToLocalMatrix
+            }).ToArray(), Allocator.Persistent);
             Profiler.EndSample();
         }
 


### PR DESCRIPTION
tail の初期位置が原点から始まって開始時にはねる。
tail の初期化経路が変わったからかもしれない。
#2440 `v0.126` は関係あるかもしれないが、別件かもしれない。
