### PR TITLE
add version defines so that UniGLTF, UnityGLTF and glTFast can co-exist

### DIFF
--- a/Assets/UniGLTF/Editor/UniGLTF.Editor.asmdef
+++ b/Assets/UniGLTF/Editor/UniGLTF.Editor.asmdef
@@ -17,6 +17,27 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "org.khronos.unitygltf",
+            "expression": "",
+            "define": "UNIGLTF_DISABLE_DEFAULT_GLB_IMPORTER"
+        },
+        {
+            "name": "org.khronos.unitygltf",
+            "expression": "",
+            "define": "UNIGLTF_DISABLE_DEFAULT_GLTF_IMPORTER"
+        },
+        {
+            "name": "com.atteneder.gltfast",
+            "expression": "",
+            "define": "UNIGLTF_DISABLE_DEFAULT_GLB_IMPORTER"
+        },
+        {
+            "name": "com.atteneder.gltfast",
+            "expression": "",
+            "define": "UNIGLTF_DISABLE_DEFAULT_GLTF_IMPORTER"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Hi, I'm the maintainer of https://github.com/khronosgroup/unitygltf. We've got some reports of incompatibility when both UnityGLTF and UniGLTF are in the same project, leading to users believing that either project is broken while they're not.

This PR builds on
- https://github.com/vrm-c/UniVRM/issues/1576
and makes UniGLTF play nice with UnityGLTF and glTFast in the same project.

With this PR in place, all three can co-exist and will all be available as importer overrides.

Before this PR, users had to manually add `UNIGLTF_DISABLE_DEFAULT_GLB_IMPORTER` and `UNIGLTF_DISABLE_DEFAULT_GLTF_IMPORTER` to their scripting settings which was confusing – with this PR it's automatic. And if neither glTFast nor UnityGLTF are present, there is no change in behaviour either.