### PR TITLE
[springbone] SpringBone が無いモデルの NullReferenceException を修正

### DIFF
--- a/Assets/VRM/Runtime/SpringBone/Jobs/Vrm0XFastSpringBoneRuntime.cs
+++ b/Assets/VRM/Runtime/SpringBone/Jobs/Vrm0XFastSpringBoneRuntime.cs
@@ -22,10 +22,14 @@ namespace VRM
         SpringBoneJobs.FastSpringBoneService m_service;
         FastSpringBoneBuffer m_buffer;
 
+        public Vrm0XFastSpringboneRuntime()
+        {
+            m_service = SpringBoneJobs.FastSpringBoneService.Instance;
+        }
+
         public async Task InitializeAsync(GameObject vrm, IAwaitCaller awaitCaller)
         {
             m_vrm = vrm;
-            m_service = SpringBoneJobs.FastSpringBoneService.Instance;
 
             // default update の停止
             foreach (VRMSpringBone sb in vrm.GetComponentsInChildren<VRMSpringBone>())

--- a/Assets/VRM/Runtime/SpringBone/Jobs/Vrm0XFastSpringBoneRuntime.cs
+++ b/Assets/VRM/Runtime/SpringBone/Jobs/Vrm0XFastSpringBoneRuntime.cs
@@ -73,9 +73,8 @@ namespace VRM
 
         public void ReconstructSpringBone()
         {
-            var disposer = m_vrm.gameObject.GetComponent<FastSpringBoneDisposer>();
             Unregister();
-            var task = RegisterAsync(new ImmediateCaller());
+            var _ = RegisterAsync(new ImmediateCaller());
         }
 
         public void RestoreInitialTransform()

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntime.cs
@@ -19,6 +19,11 @@ namespace UniVRM10
         private FastSpringBones.FastSpringBoneService m_fastSpringBoneService;
         private FastSpringBoneBuffer m_fastSpringBoneBuffer;
 
+        public Vrm10FastSpringboneRuntime()
+        {
+            m_fastSpringBoneService = FastSpringBones.FastSpringBoneService.Instance;
+        }
+
         public void SetJointLevel(Transform joint, BlittableJointMutable jointSettings)
         {
             if (m_fastSpringBoneService.BufferCombiner.Combined is FastSpringBoneCombinedBuffer combined)
@@ -37,7 +42,6 @@ namespace UniVRM10
 
         public async Task InitializeAsync(Vrm10Instance instance, IAwaitCaller awaitCaller)
         {
-            m_fastSpringBoneService = FastSpringBones.FastSpringBoneService.Instance;
             m_instance = instance;
 
             // NOTE: FastSpringBoneService は UnitTest などでは動作しない

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntime.cs
@@ -53,8 +53,11 @@ namespace UniVRM10
 
         public void Dispose()
         {
-            m_fastSpringBoneService.BufferCombiner.Unregister(m_fastSpringBoneBuffer);
-            m_fastSpringBoneBuffer.Dispose();
+            if (m_fastSpringBoneBuffer != null)
+            {
+                m_fastSpringBoneService.BufferCombiner.Unregister(m_fastSpringBoneBuffer);
+                m_fastSpringBoneBuffer.Dispose();
+            }
         }
 
         /// <summary>

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -286,14 +286,15 @@ namespace UniVRM10
             if (UniGLTF.Extensions.VRMC_springBone.GltfDeserializer.TryGet(Data.GLTF.extensions, out UniGLTF.Extensions.VRMC_springBone.VRMC_springBone springBone))
             {
                 await LoadSpringBoneAsync(awaitCaller, controller, springBone);
+            }
 
-                if (Application.isPlaying)
-                {
-                    // EditorImport では呼ばない
-                    // Vrm10Runtime で初期化していたが、 async にするためこちらに移動 v0.127
-                    // RuntimeGltfInstance にアクセスしたいのだが OnLoadHierarchy ではまだ attach されてなかった v0.128
-                    await m_springboneRuntime.InitializeAsync(controller, awaitCaller);
-                }
+            if (Application.isPlaying)
+            {
+                // EditorImport では呼ばない
+                // Vrm10Runtime で初期化していたが、 async にするためこちらに移動 v0.127
+                // RuntimeGltfInstance にアクセスしたいのだが OnLoadHierarchy ではまだ attach されてなかった v0.128
+                // VRMC_springBone が無くても初期化する v0.127.2
+                await m_springboneRuntime.InitializeAsync(controller, awaitCaller);
             }
 
             // constraint


### PR DESCRIPTION
多段に NullReferenceException の可能性があるのでちょっと整理する。

|runtime|service|combiner|combined|
|-|-|-|-|
|Vrm0XFastSpringboneRuntime|ok| OnEnable/OnDisable | ReconstructBuffers/Dispose
|Vrm10FastSpringboneRuntime|ok| OnEnable/OnDisable | ReconstructBuffers/Dispose
|Vrm10FastSpringboneRuntimeStandalone|--|new/Dispose| ReconstructBuffers/Dispose

- service と combiner は null でないことを期待してよい
- combined は null かもしれない(null check している)

という API でよさそう。
