### PR TITLE
[exporter][blendshape][bake] 基準メッシュバグ

### DIFF
--- a/Assets/UniGLTF/Editor/MeshUtility/MeshUtilityDialog.cs
+++ b/Assets/UniGLTF/Editor/MeshUtility/MeshUtilityDialog.cs
@@ -300,7 +300,10 @@ namespace UniGLTF.MeshUtility
 
         bool MeshFreezeGui()
         {
-            return ToggleIsModified("BlendShapeRotationScaling", ref MeshUtility.FreezeBlendShapeRotationAndScaling);
+            var meshFreeze = ToggleIsModified("FreezeMesh", ref MeshUtility.FreezeMesh);
+            var meshFreezeKeepRotation = ToggleIsModified("FreezeMeshKeeprotation", ref MeshUtility.FreezeMeshKeepRotation);
+            var meshFreezeUseCurrentWeight = ToggleIsModified("FreezeMeshCurrentBlendShapeWeight", ref MeshUtility.FreezeMeshCurrentBlendShapeWeight);
+            return meshFreeze || meshFreezeKeepRotation || meshFreezeUseCurrentWeight;
         }
 
         protected virtual bool MeshIntegrateGui()

--- a/Assets/UniGLTF/Runtime/MeshUtility/GltfMeshUtility.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/GltfMeshUtility.cs
@@ -18,12 +18,22 @@ namespace UniGLTF.MeshUtility
     public class GltfMeshUtility
     {
         /// <summary>
-        /// Same as VRM-0 normalization
-        /// - Mesh
-        /// - Node
-        /// - InverseBindMatrices
+        /// v0.127.2
+        /// Mesh の bake。Hierarhcy の改変(scale/rotationの除去)。Binding行列の再作成
         /// </summary>
-        public bool FreezeBlendShapeRotationAndScaling = false;
+        public bool FreezeMesh = false;
+
+        /// <summary>
+        /// v0.127.2
+        /// if false Same as VRM-0 normalization
+        /// </summary>
+        public bool FreezeMeshKeepRotation = false;
+
+        /// <summary>
+        /// v0.127.2
+        /// BlendShape の現状を base にする
+        /// </summary>
+        public bool FreezeMeshCurrentBlendShapeWeight = false;
 
         public List<MeshIntegrationGroup> MeshIntegrationGroups = new List<MeshIntegrationGroup>();
 
@@ -156,15 +166,15 @@ namespace UniGLTF.MeshUtility
         public virtual (List<MeshIntegrationResult>, List<GameObject>) Process(
             GameObject target, IEnumerable<MeshIntegrationGroup> groupCopy)
         {
-            if (FreezeBlendShapeRotationAndScaling)
+            if (FreezeMesh)
             {
                 // MeshをBakeする
-                var meshMap = BoneNormalizer.NormalizeHierarchyFreezeMesh(target);
+                var meshMap = BoneNormalizer.NormalizeHierarchyFreezeMesh(target, FreezeMeshCurrentBlendShapeWeight);
 
                 // - ヒエラルキーから回転・拡縮を除去する
                 // - BakeされたMeshで置き換える
                 // - bindPoses を再計算する
-                BoneNormalizer.Replace(target, meshMap, true, true);
+                BoneNormalizer.Replace(target, meshMap, FreezeMeshKeepRotation);
             }
 
             var newList = new List<GameObject>();

--- a/Assets/UniGLTF/Runtime/MeshUtility/MeshFreezer.cs
+++ b/Assets/UniGLTF/Runtime/MeshUtility/MeshFreezer.cs
@@ -194,7 +194,6 @@ namespace UniGLTF.MeshUtility
             for (int i = 0; i < srcMesh.blendShapeCount; ++i)
             {
                 backcup.Add(src.GetBlendShapeWeight(i));
-                src.SetBlendShapeWeight(i, 0);
             }
 
             var meshVertices = mesh.vertices;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfExportSettings.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfExportSettings.cs
@@ -54,10 +54,16 @@ namespace UniGLTF
         /// </summary>
         public bool ExportUvSecondary;
 
+        [Tooltip("freeze mesh")]
+        public bool FreezeMesh = false;
+
+        [Tooltip("when freeze mesh, keep rotation")]
+        public bool FreezeMeshKeepRotation = false;
+
         /// <summary>
         /// FreezeBlendShape
         /// </summary>
-        [Tooltip("freeze rotation and scale and blendshape")]
-        public bool FreezeMesh = false;
+        [Tooltip("when freeze mesh, blendShpae base use current weight")]
+        public bool FreezeMeshUseCurrentBlendShapeWeight = false;
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
@@ -237,10 +237,10 @@ namespace UniGLTF
                 // - BlendShape は現状がbakeされます
                 // - 回転とスケールが反映された新しい Mesh が作成されます
                 // - Transform の回転とスケールはクリアされます。world position を維持します
-                var newMeshMap = BoneNormalizer.NormalizeHierarchyFreezeMesh(Copy);
+                var newMeshMap = BoneNormalizer.NormalizeHierarchyFreezeMesh(Copy, m_settings.FreezeMeshUseCurrentBlendShapeWeight);
 
                 // SkinnedMeshRenderer.sharedMesh と MeshFilter.sharedMesh を新しいMeshで置き換える
-                BoneNormalizer.Replace(Copy, newMeshMap, true, true);
+                BoneNormalizer.Replace(Copy, newMeshMap, m_settings.FreezeMeshKeepRotation);
             }
 
             Nodes = Copy.transform.Traverse()

--- a/Assets/VRM/Editor/Format/VRMEditorExporter.cs
+++ b/Assets/VRM/Editor/Format/VRMEditorExporter.cs
@@ -209,7 +209,7 @@ namespace VRM
             if (settings.PoseFreeze)
             {
                 // 正規化
-                VRMBoneNormalizer.Execute(target, settings.ForceTPose);
+                VRMBoneNormalizer.Execute(target, settings.ForceTPose, settings.FreezeMeshUseCurrentBlendShapeWeight);
             }
 
             // 元のBlendShapeClipに変更を加えないように複製

--- a/Assets/VRM/Editor/Format/VRMExportSettings.cs
+++ b/Assets/VRM/Editor/Format/VRMExportSettings.cs
@@ -20,6 +20,12 @@ namespace VRM
         public bool PoseFreeze = true;
 
         /// <summary>
+        /// FreezeBlendShape
+        /// </summary>
+        [Tooltip("when freeze mesh, blendShpae base use current weight")]
+        public bool FreezeMeshUseCurrentBlendShapeWeight = false;
+
+        /// <summary>
         /// BlendShapeのシリアライズにSparseAccessorを使う
         /// </summary>
         [Tooltip("Use sparse accessor for blendshape. This may reduce vrm size")]

--- a/Assets/VRM/Editor/Format/VRMHumanoidNormalizerMenu.cs
+++ b/Assets/VRM/Editor/Format/VRMHumanoidNormalizerMenu.cs
@@ -43,11 +43,11 @@ namespace VRM
             }
         }
 
-        public static void Normalize()
+        public static void Normalize(bool bakeCurrentBlendShape)
         {
             var go = Selection.activeObject as GameObject;
 
-            VRMBoneNormalizer.Execute(go, true);
+            VRMBoneNormalizer.Execute(go, true, bakeCurrentBlendShape);
         }
     }
 }

--- a/Assets/VRM/Editor/VrmTopMenu.cs
+++ b/Assets/VRM/Editor/VrmTopMenu.cs
@@ -31,7 +31,7 @@ namespace VRM
         [MenuItem(UserMenuPrefix + "/" + VRMHumanoidNormalizerMenu.MENU_NAME, true, 52)]
         private static bool FreezeTPoseValidation() => VRMHumanoidNormalizerMenu.NormalizeValidation();
         [MenuItem(UserMenuPrefix + "/" + VRMHumanoidNormalizerMenu.MENU_NAME, false, 52)]
-        private static void FreezeTPose() => VRMHumanoidNormalizerMenu.Normalize();
+        private static void FreezeTPose() => VRMHumanoidNormalizerMenu.Normalize(bakeCurrentBlendShape: true);
 
 
         [MenuItem(UserMenuPrefix + "/" + VRMSpringBoneUtilityEditor.SAVE_MENU_NAME, true, 53)]

--- a/Assets/VRM/Runtime/SkinnedMeshUtility/VRMBoneNormalizer.cs
+++ b/Assets/VRM/Runtime/SkinnedMeshUtility/VRMBoneNormalizer.cs
@@ -52,7 +52,8 @@ namespace VRM
         /// </summary>
         /// <param name="go">対象モデルのルート</param>
         /// <param name="forceTPose">強制的にT-Pose化するか</param>
-        public static void Execute(GameObject go, bool forceTPose)
+        /// <param name="useCurrentBlendShapeWeight">BlendShape の現状をbakeするか</param>
+        public static void Execute(GameObject go, bool forceTPose, bool useCurrentBlendShapeWeight)
         {
             if (forceTPose)
             {
@@ -72,13 +73,12 @@ namespace VRM
             }
 
             // Transform の回転とスケールを Mesh に適用します。
-            // - BlendShape は現状がbakeされます
             // - 回転とスケールが反映された新しい Mesh が作成されます
             // - Transform の回転とスケールはクリアされます。world position を維持します
-            var newMeshMap = BoneNormalizer.NormalizeHierarchyFreezeMesh(go);
+            var newMeshMap = BoneNormalizer.NormalizeHierarchyFreezeMesh(go, useCurrentBlendShapeWeight);
 
             // SkinnedMeshRenderer.sharedMesh と MeshFilter.sharedMesh を新しいMeshで置き換える
-            BoneNormalizer.Replace(go, newMeshMap, true, true);
+            BoneNormalizer.Replace(go, newMeshMap, false);
 
             // 回転とスケールが除去された新しいヒエラルキーからAvatarを作る
             Avatar newAvatar = default;

--- a/Assets/VRM/Runtime/SkinnedMeshUtility/VrmMeshUtility.cs
+++ b/Assets/VRM/Runtime/SkinnedMeshUtility/VrmMeshUtility.cs
@@ -105,7 +105,7 @@ namespace VRM
             // TODO: update: firstPerson offset
             var (list, newList) = base.Process(target, copyGroup);
 
-            if (FreezeBlendShapeRotationAndScaling)
+            if (FreezeMesh)
             {
                 Avatar newAvatar = null;
                 if (target.TryGetComponent<Animator>(out var animator))

--- a/Assets/VRM10/Editor/VRM10ExportSettings.cs
+++ b/Assets/VRM10/Editor/VRM10ExportSettings.cs
@@ -30,6 +30,15 @@ namespace UniVRM10
         [Tooltip("freeze rotation and scale and blendshape")]
         public bool FreezeMesh = false;
 
+        [Tooltip("when freeze mesh, keep rotation")]
+        public bool FreezeMeshKeepRotation = false;
+
+        /// <summary>
+        /// FreezeBlendShape
+        /// </summary>
+        [Tooltip("when freeze mesh, blendShpae base use current weight")]
+        public bool FreezeMeshUseCurrentBlendShapeWeight = false;
+
         public GltfExportSettings MeshExportSettings => new GltfExportSettings
         {
             UseSparseAccessorForMorphTarget = MorphTargetUseSparse,

--- a/Assets/VRM10/Editor/Vrm10ExportDialog.cs
+++ b/Assets/VRM10/Editor/Vrm10ExportDialog.cs
@@ -297,10 +297,10 @@ namespace UniVRM10
                         // - BlendShape は現状がbakeされます
                         // - 回転とスケールが反映された新しい Mesh が作成されます
                         // - Transform の回転とスケールはクリアされます。world position を維持します
-                        var newMeshMap = BoneNormalizer.NormalizeHierarchyFreezeMesh(root);
+                        var newMeshMap = BoneNormalizer.NormalizeHierarchyFreezeMesh(root, m_settings.FreezeMeshUseCurrentBlendShapeWeight);
 
                         // SkinnedMeshRenderer.sharedMesh と MeshFilter.sharedMesh を新しいMeshで置き換える
-                        BoneNormalizer.Replace(root, newMeshMap, true, true);
+                        BoneNormalizer.Replace(root, newMeshMap, m_settings.FreezeMeshKeepRotation);
                     }
 
                     var converter = new UniVRM10.ModelExporter();

--- a/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
+++ b/Assets/VRM10/Runtime/MeshUtility/Vrm10MeshUtility.cs
@@ -12,7 +12,9 @@ namespace UniVRM10
     {
         public Vrm10MeshUtility()
         {
-            FreezeBlendShapeRotationAndScaling = true;
+            FreezeMesh = true;
+            FreezeMeshKeepRotation = true;
+            FreezeMeshCurrentBlendShapeWeight = true;
         }
 
         bool _generateFirstPerson = false;
@@ -112,7 +114,7 @@ namespace UniVRM10
             // TODO: update: firstPerson offset
             var (list, newList) = base.Process(target, groupCopy);
 
-            if (FreezeBlendShapeRotationAndScaling)
+            if (FreezeMesh)
             {
                 Avatar newAvatar = default;
                 if (target.TryGetComponent<Animator>(out var animator))

--- a/Assets/VRM_Samples/RuntimeExporterSample/VRMRuntimeExporter.cs
+++ b/Assets/VRM_Samples/RuntimeExporterSample/VRMRuntimeExporter.cs
@@ -10,6 +10,9 @@ namespace VRM.RuntimeExporterSample
         [SerializeField]
         public bool UseNormalize = true;
 
+        [SerializeField]
+        public bool BakeBlendShapes = false;
+
         GameObject m_model;
 
         void OnGUI()
@@ -29,7 +32,7 @@ namespace VRM.RuntimeExporterSample
 
             if (GUILayout.Button("Export"))
             {
-                Export(m_model, UseNormalize);
+                Export(m_model, UseNormalize, BakeBlendShapes);
             }
         }
 
@@ -112,7 +115,7 @@ namespace VRM.RuntimeExporterSample
         }
 
 
-        static void Export(GameObject model, bool useNormalize)
+        static void Export(GameObject model, bool useNormalize, bool bakeBlendShape)
         {
             //#if UNITY_STANDALONE_WIN
 #if false
@@ -125,7 +128,7 @@ namespace VRM.RuntimeExporterSample
                 return;
             }
 
-            var bytes = useNormalize ? ExportCustom(model) : ExportSimple(model);
+            var bytes = useNormalize ? ExportCustom(model, false, bakeBlendShape) : ExportSimple(model);
 
             File.WriteAllBytes(path, bytes);
             Debug.LogFormat("export to {0}", path);
@@ -138,10 +141,10 @@ namespace VRM.RuntimeExporterSample
             return bytes;
         }
 
-        static byte[] ExportCustom(GameObject exportRoot, bool forceTPose = false)
+        static byte[] ExportCustom(GameObject exportRoot, bool forceTPose, bool bakeBlendShape)
         {
             // normalize
-            VRMBoneNormalizer.Execute(exportRoot, forceTPose);
+            VRMBoneNormalizer.Execute(exportRoot, forceTPose, bakeBlendShape);
 
             return ExportSimple(exportRoot);
         }


### PR DESCRIPTION
fixed #2465

blendshapeを変化させた状態で bake したときに、
最初に 0 クリアすることで base mesh が意図したものではなく、
すべて 0 のもになる。
かつ、ループが進むごとに変化状態に復帰する bug。

- `0.x`, `1.0` 
- すべての blendshape が 0 じゃない
- export 時に pose_freeze オプション

で発動
