### PR TITLE
[vrm10][Importer引数] ScriptedImpoter からの Import で SpringBone の初期化を回避する

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ImporterContext.cs
@@ -12,6 +12,7 @@ namespace UniGLTF
     /// </summary>
     public class ImporterContext : IResponsibilityForDestroyObjects
     {
+        public readonly bool IsAssetImport;
         private readonly ImporterContextSettings _settings;
         
         public ITextureDescriptorGenerator TextureDescriptorGenerator { get; protected set; }
@@ -37,8 +38,10 @@ namespace UniGLTF
             IReadOnlyDictionary<SubAssetKey, UnityEngine.Object> externalObjectMap = null,
             ITextureDeserializer textureDeserializer = null,
             IMaterialDescriptorGenerator materialGenerator = null,
-            ImporterContextSettings settings = null)
+            ImporterContextSettings settings = null,
+            bool isAssetImport = false)
         {
+            IsAssetImport = isAssetImport;
             _settings = settings ?? new ImporterContextSettings();
             Data = data;
             TextureDescriptorGenerator = new GltfTextureDescriptorGenerator(Data);

--- a/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
+++ b/Assets/VRM10/Editor/ScriptedImporter/VrmScriptedImporterImpl.cs
@@ -48,7 +48,10 @@ namespace UniVRM10
 
             var materialGenerator = GetMaterialDescriptorGenerator(renderPipeline);
 
-            using (var loader = new Vrm10Importer(result, externalObjectMap: extractedObjects, materialGenerator: materialGenerator))
+            using (var loader = new Vrm10Importer(result, 
+                externalObjectMap: extractedObjects, 
+                materialGenerator: materialGenerator,
+                isAssetImport: true))
             {
                 // settings TextureImporters
                 foreach (var textureInfo in loader.TextureDescriptorGenerator.Get().GetEnumerable())

--- a/Assets/VRM10/Editor/Vrm10ExportDialog.cs
+++ b/Assets/VRM10/Editor/Vrm10ExportDialog.cs
@@ -290,6 +290,7 @@ namespace UniVRM10
                     {
                         Debug.Log("vrm-1.0 FreezeMesh");
                         var copy = GameObject.Instantiate(root);
+                        copy.GetComponent<Vrm10Instance>().UpdateType = Vrm10Instance.UpdateTypes.None;
                         disposer.Push(copy);
                         root = copy;
 

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10NopSpringboneRuntime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10NopSpringboneRuntime.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using UniGLTF;
+using UniGLTF.SpringBoneJobs.Blittables;
+using UnityEngine;
+
+namespace UniVRM10
+{
+    /// <summary>
+    /// SpcriptedImporter 経由の import 向け。
+    /// NativeArray の確保や DontDestroyOnLoad を回避。
+    /// </summary>
+    public class Vrm10NopSpringboneRuntime : IVrm10SpringBoneRuntime
+    {
+        public void Dispose()
+        {
+        }
+
+        public Task InitializeAsync(Vrm10Instance instance, IAwaitCaller awaitCaller)
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Process()
+        {
+        }
+
+        public bool ReconstructSpringBone()
+        {
+            return false;
+        }
+
+        public void RestoreInitialTransform()
+        {
+        }
+
+        public void SetJointLevel(Transform joint, BlittableJointMutable jointSettings)
+        {
+        }
+
+        public void SetModelLevel(Transform modelRoot, BlittableModelLevel modelSettings)
+        {
+        }
+    }
+}

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10NopSpringboneRuntime.cs.meta
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10NopSpringboneRuntime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b58249c702cd4054480f69562b43b0b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -33,9 +33,10 @@ namespace UniVRM10
             IMaterialDescriptorGenerator materialGenerator = null,
             bool useControlRig = false,
             ImporterContextSettings settings = null,
-            IVrm10SpringBoneRuntime springboneRuntime = null
+            IVrm10SpringBoneRuntime springboneRuntime = null,
+            bool isAssetImport = false
             )
-            : base(vrm.Data, externalObjectMap, textureDeserializer, settings: settings)
+            : base(vrm.Data, externalObjectMap, textureDeserializer, settings: settings, isAssetImport: isAssetImport)
         {
             if (vrm == null)
             {
@@ -288,7 +289,11 @@ namespace UniVRM10
                 await LoadSpringBoneAsync(awaitCaller, controller, springBone);
             }
 
-            if (Application.isPlaying)
+            if (IsAssetImport)
+            {
+                controller.UpdateType = Vrm10Instance.UpdateTypes.None;
+            }
+            else
             {
                 // EditorImport では呼ばない
                 // Vrm10Runtime で初期化していたが、 async にするためこちらに移動 v0.127

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -291,11 +291,13 @@ namespace UniVRM10
 
             if (IsAssetImport)
             {
-                controller.UpdateType = Vrm10Instance.UpdateTypes.None;
+                // ScriptedImpoter から発動された。
+                // SpringBone のリソース確保を回避する。
+                // Application.isPlaying == true がありえる。
             }
             else
             {
-                // EditorImport では呼ばない
+                // ScriptedImpoter 経由でない。
                 // Vrm10Runtime で初期化していたが、 async にするためこちらに移動 v0.127
                 // RuntimeGltfInstance にアクセスしたいのだが OnLoadHierarchy ではまだ attach されてなかった v0.128
                 // VRMC_springBone が無くても初期化する v0.127.2

--- a/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
+++ b/Assets/VRM10/Runtime/IO/Vrm10Importer.cs
@@ -54,7 +54,24 @@ namespace UniVRM10
                 m_externalMap = new Dictionary<SubAssetKey, UnityEngine.Object>();
             }
 
-            m_springboneRuntime = springboneRuntime ?? new Vrm10FastSpringboneRuntime();
+            m_springboneRuntime = MakeDefaultRuntime(springboneRuntime, isAssetImport);
+        }
+
+        static IVrm10SpringBoneRuntime MakeDefaultRuntime(IVrm10SpringBoneRuntime runtime, bool isAssetImport)
+        {
+            if (runtime != null)
+            {
+                return runtime;
+            }
+
+            if (isAssetImport)
+            {
+                // 何もしない dummy
+                return new Vrm10NopSpringboneRuntime();
+            }
+
+            // Vrm10Instance.MakeRuntime に移譲
+            return null;
         }
 
         static void AssignHumanoid(List<VrmLib.Node> nodes, UniGLTF.Extensions.VRMC_vrm.HumanBone humanBone, VrmLib.HumanoidBones key)

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -230,6 +230,7 @@ QualitySettings:
     PSM: 5
     PSP2: 2
     Samsung TV: 2
+    Server: 0
     Standalone: 5
     Switch: 5
     Tizen: 2


### PR DESCRIPTION
```
A Native Collection has not been disposed, resulting in a memory leak. Allocated from:
```

- export 用の copy されたヒエラルキーの springbone が活動してしまう
- play 時に asset import すると、意図しない springbone の初期化が動作してしまう

に対処しました、
主にSpringBone の初期化フェーズを importer 内に移動したことが、影響しています。
