### PR TITLE
VRM10SpringBoneColliderGroup 改善

### DIFF
--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneCollider.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneCollider.cs
@@ -34,7 +34,12 @@ namespace UniVRM10
 
         public bool IsSelected => GetInstanceID() == SelectedGuid;
 
-        public void OnDrawGizmosSelected()
+        void OnDrawGizmosSelected()
+        {
+            DrawGizmos();
+        }
+
+        public void DrawGizmos()
         {
             Gizmos.matrix = transform.localToWorldMatrix;
             switch (ColliderType)

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneColliderGroup.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneColliderGroup.cs
@@ -25,6 +25,7 @@ namespace UniVRM10
             return Colliders[0].name;
         }
 
+#if UNITY_EDITOR
         [ContextMenu("Create child and move to that")]
         public void Separate()
         {
@@ -80,6 +81,7 @@ namespace UniVRM10
 
             UnityEditor.Undo.CollapseUndoOperations(undo);
         }
+#endif
 
         public void OnDrawGizmosSelected()
         {

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneColliderGroup.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneColliderGroup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace UniVRM10
@@ -14,5 +15,78 @@ namespace UniVRM10
 
         [SerializeField]
         public List<VRM10SpringBoneCollider> Colliders = new List<VRM10SpringBoneCollider>();
+
+        string GetName()
+        {
+            if (!string.IsNullOrEmpty(Name))
+            {
+                return Name;
+            }
+            return Colliders[0].name;
+        }
+
+        [ContextMenu("Create child and move to that")]
+        public void Separate()
+        {
+            var vrm = GetComponentInParent<Vrm10Instance>();
+            if (vrm == null)
+            {
+                return;
+            }
+            if (Colliders == null || Colliders.Count == 0)
+            {
+                return;
+            }
+
+            UnityEditor.Undo.IncrementCurrentGroup();
+            UnityEditor.Undo.SetCurrentGroupName("VRM10SpringBoneColliderGroup.Separate");
+            var undo = UnityEditor.Undo.GetCurrentGroup();
+
+            var child = new GameObject($"group: {GetName()}");
+            UnityEditor.Undo.RegisterCreatedObjectUndo(child, "child");
+            UnityEditor.Undo.SetTransformParent(child.transform, transform, "setParent");
+
+            var group = UnityEditor.Undo.AddComponent<VRM10SpringBoneColliderGroup>(child);
+            group.Name = Name;
+            group.Colliders = Colliders.ToList();
+            for (int i = 0; i < vrm.SpringBone.ColliderGroups.Count; ++i)
+            {
+                if (vrm.SpringBone.ColliderGroups[i] == this)
+                {
+                    vrm.SpringBone.ColliderGroups[i] = group;
+                }
+            }
+            foreach (var spring in vrm.SpringBone.Springs)
+            {
+                for (int i = 0; i < spring.ColliderGroups.Count; ++i)
+                {
+                    if (spring.ColliderGroups[i] == this)
+                    {
+                        spring.ColliderGroups[i] = group;
+                    }
+                }
+            }
+
+            if (Application.isPlaying)
+            {
+                Destroy(this);
+            }
+            else
+            {
+                UnityEditor.Undo.DestroyObjectImmediate(this);
+            }
+
+            UnityEditor.Undo.RegisterFullObjectHierarchyUndo(vrm.gameObject, "VRM10SpringBoneColliderGroup.Separate");
+
+            UnityEditor.Undo.CollapseUndoOperations(undo);
+        }
+
+        public void OnDrawGizmosSelected()
+        {
+            foreach (var collider in Colliders)
+            {
+                collider.DrawGizmos();
+            }
+        }
     }
 }

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneJoint.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneJoint.cs
@@ -23,7 +23,7 @@ namespace UniVRM10
         [SerializeField, Range(0, 1)]
         public float m_dragForce = 0.4f;
 
-        [SerializeField]
+        [SerializeField]        
         public float m_jointRadius = 0.02f;
 
         [SerializeField]

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10InstanceSpringBone.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10InstanceSpringBone.cs
@@ -101,7 +101,7 @@ namespace UniVRM10
                     {
                         foreach (var collider in group.Colliders)
                         {
-                            collider.OnDrawGizmosSelected();
+                            collider.DrawGizmos();
                         }
                     }
                     m_drawCollider = 0;


### PR DESCRIPTION
`OnDrawGizmosSelected` で配下の collider を gizmo 描画する。

context menu で子オブジェクトを作って、そっちに移動する。
これは、ひとつの secondary に複数の VRM10SpringBoneColliderGroup がアタッチされていると作業しづらいことに対する対策です。よさそうであれば、後に import 時に secondry の子オブジェクトを自動で作ってもよいかもしれない。
