### PR TITLE
[WIP][1.0] SpringBone gizmo 改修

### DIFF
--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/Blittables/BlittableCollider.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/Blittables/BlittableCollider.cs
@@ -15,5 +15,12 @@ namespace UniGLTF.SpringBoneJobs.Blittables
         // capsule tail or plane normal
         public Vector3 tailOrNormal;
         public int transformIndex;
+
+        public void DrawGizmo(BlittableTransform t)
+        {
+            Gizmos.matrix = t.localToWorldMatrix;
+            Gizmos.color = Color.blue;
+            Gizmos.DrawWireSphere(offset, radius);
+        }
     }
 }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/Blittables/BlittableJointImmutable.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/Blittables/BlittableJointImmutable.cs
@@ -17,5 +17,12 @@ namespace UniGLTF.SpringBoneJobs.Blittables
         public float length;
         public Quaternion localRotation;
         public Vector3 boneAxis;
+
+        public void DrawGizmo(BlittableTransform t, BlittableJointMutable m)
+        {
+            Gizmos.matrix = t.localToWorldMatrix;
+            Gizmos.color = Color.green;
+            Gizmos.DrawWireSphere(Vector3.zero, m.radius);
+        }
     }
 }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/Blittables/BlittableSpan.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/Blittables/BlittableSpan.cs
@@ -7,5 +7,7 @@ namespace UniGLTF.SpringBoneJobs.Blittables
     {
         public int startIndex;
         public int count;
+
+        public int EndIndex => startIndex + count;
     }
 }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneBufferCombiner.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneBufferCombiner.cs
@@ -95,5 +95,13 @@ namespace UniGLTF.SpringBoneJobs
                 _combinedBuffer = null;
             }
         }
+
+        public void DrawGizmos()
+        {
+            if (_combinedBuffer is FastSpringBoneCombinedBuffer combined)
+            {
+                combined.DrawGizmos();
+            }
+        }
     }
 }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
@@ -398,5 +398,27 @@ namespace UniGLTF.SpringBoneJobs
                 logicsIndex += length;
             }
         }
+
+        public void DrawGizmos()
+        {
+            foreach (var collider in _colliders)
+            {
+                collider.DrawGizmo(_transforms[collider.transformIndex]);
+            }
+
+            foreach (var spring in _springs)
+            {
+                for (int i = spring.logicSpan.startIndex; i < spring.logicSpan.EndIndex; ++i)
+                {
+                    var joint = _logics[i];
+                    joint.DrawGizmo(_transforms[joint.tailTransformIndex], _joints[i]);
+
+                    Gizmos.matrix = Matrix4x4.identity;
+                    Gizmos.DrawLine(
+                        _transforms[joint.tailTransformIndex].position,
+                        _transforms[joint.headTransformIndex].position);
+                }
+            }
+        }
     }
 }

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneJointEditor.cs
@@ -13,7 +13,6 @@ namespace UniVRM10
         private SerializedProperty m_gravityDirProp;
         private SerializedProperty m_dragForceProp;
         private SerializedProperty m_jointRadiusProp;
-        private SerializedProperty m_drawColliderProp;
 
         private Vrm10Instance m_root;
 
@@ -30,7 +29,6 @@ namespace UniVRM10
             m_gravityDirProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_gravityDir));
             m_dragForceProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_dragForce));
             m_jointRadiusProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_jointRadius));
-            m_drawColliderProp = serializedObject.FindProperty(nameof(VRM10SpringBoneJoint.m_drawCollider));
 
             m_root = m_target.GetComponentInParent<Vrm10Instance>();
         }
@@ -49,7 +47,6 @@ namespace UniVRM10
             EditorGUI.BeginDisabledGroup(true);
             var isLastTail = ShowSpringInfo();
             EditorGUI.EndDisabledGroup();
-            EditorGUILayout.PropertyField(m_drawColliderProp, new GUIContent("DrawColliders"));
 
             if (isLastTail)
             {

--- a/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneJoint.cs
+++ b/Assets/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneJoint.cs
@@ -26,9 +26,6 @@ namespace UniVRM10
         [SerializeField]
         public float m_jointRadius = 0.02f;
 
-        [SerializeField]
-        public bool m_drawCollider = false;
-
         public BlittableJointMutable Blittable => new BlittableJointMutable
         {
             stiffnessForce = m_stiffnessForce,
@@ -115,22 +112,31 @@ namespace UniVRM10
 
         private void OnDrawGizmosSelected()
         {
+            Matrix4x4 m = default;
+            m.SetTRS(transform.position, transform.rotation, Vector3.one);
+            Gizmos.matrix = m;
+
             var vrm = GetComponentInParent<Vrm10Instance>();
-            if (vrm != null)
+            if (vrm != null && vrm.TryGetRadiusAsTail(this, out var radius))
             {
-                var found = vrm.SpringBone.FindJoint(this);
-                if (found.HasValue)
+                if (radius.HasValue)
                 {
-                    var (spring, i) = found.Value;
-                    // Spring の房全体を描画する
-                    spring.RequestDrawGizmos(m_drawCollider);
-                    return;
+                    Gizmos.color = Color.yellow;
+                    Gizmos.DrawWireSphere(Vector3.zero, radius.Value);
+                }
+                else
+                {
+                    // root
+                    Gizmos.color = new Color(1, 0.75f, 0f);
+                    Gizmos.DrawSphere(Vector3.zero, 0.01f);
                 }
             }
-
-            // Spring から参照されていない孤立した Joint
-            Gizmos.color = new Color(1, 0.75f, 0f);
-            Gizmos.DrawSphere(transform.position, m_jointRadius);
+            else
+            {
+                // spring を構成しない
+                Gizmos.color = Color.red;
+                Gizmos.DrawSphere(Vector3.zero, m_jointRadius);
+            }
         }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -238,7 +238,7 @@ namespace UniVRM10
             return true;
         }
 
-        private void OnDrawGizmos()
+        private void OnDrawGizmosSelected()
         {
             foreach (var spring in SpringBone.Springs)
             {

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -273,7 +273,7 @@ namespace UniVRM10
                         }
                         else
                         {
-                            radius = 0;
+                            radius = default;
                             return true;
                         }
                     }

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -244,6 +244,11 @@ namespace UniVRM10
             {
                 spring.DrawGizmos();
             }
+
+            if (Application.isPlaying)
+            {
+                Runtime.SpringBone.DrawGizmos();
+            }
         }
 
         #region Obsolete

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10Instance.cs
@@ -256,5 +256,33 @@ namespace UniVRM10
         }
 
         #endregion
+
+        public bool TryGetRadiusAsTail(VRM10SpringBoneJoint target, out float? radius)
+        {
+            foreach (var spring in SpringBone.Springs)
+            {
+                VRM10SpringBoneJoint prev = default;
+                foreach (var joint in spring.Joints)
+                {
+                    if (joint == target)
+                    {
+                        if (prev != null)
+                        {
+                            radius = prev.m_jointRadius;
+                            return true;
+                        }
+                        else
+                        {
+                            radius = 0;
+                            return true;
+                        }
+                    }
+                    prev = joint;
+                }
+            }
+
+            radius = default;
+            return false;
+        }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10InstanceSpringBone.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10InstanceSpringBone.cs
@@ -41,21 +41,6 @@ namespace UniVRM10
                 Name = name;
             }
 
-            /// <summary>
-            /// VRM10SpringBoneJoint.OnDrawGizmosSelected から複数の描画 Request が来うる。
-            /// Vrm10Instance.OnDrawGizmos 経由で１回だけ描画する。
-            /// </summary>
-            int m_drawRequest;
-            int m_drawCollider;
-            public void RequestDrawGizmos(bool drawCollider)
-            {
-                m_drawRequest++;
-                if (drawCollider)
-                {
-                    m_drawCollider++;
-                }
-            }
-
             static Color JointColor(VRM10SpringBoneJoint joint)
             {
 #if UNITY_EDITOR
@@ -69,20 +54,14 @@ namespace UniVRM10
 
             public void DrawGizmos()
             {
-                if (m_drawRequest == 0)
-                {
-                    return;
-                }
-                m_drawRequest = 0;
-
                 var backup = Gizmos.matrix;
                 Gizmos.matrix = Matrix4x4.identity;
                 VRM10SpringBoneJoint lastJoint = Joints[0];
-                if (lastJoint != null)
-                {
-                    const float f = 0.005f;
-                    Gizmos.DrawCube(lastJoint.transform.position, new Vector3(f, f, f));
-                }
+                // if (lastJoint != null)
+                // {
+                //     const float f = 0.005f;
+                //     Gizmos.DrawCube(lastJoint.transform.position, new Vector3(f, f, f));
+                // }
                 for (int i = 1; i < Joints.Count; ++i)
                 {
                     var joint = Joints[i];
@@ -90,21 +69,9 @@ namespace UniVRM10
                     if (joint != null && lastJoint != null)
                     {
                         Gizmos.DrawLine(lastJoint.transform.position, joint.transform.position);
-                        Gizmos.DrawWireSphere(joint.transform.position, lastJoint.m_jointRadius);
+                        // Gizmos.DrawWireSphere(joint.transform.position, lastJoint.m_jointRadius);
                     }
                     lastJoint = joint;
-                }
-
-                if (m_drawCollider > 0)
-                {
-                    foreach (var group in ColliderGroups)
-                    {
-                        foreach (var collider in group.Colliders)
-                        {
-                            collider.DrawGizmos();
-                        }
-                    }
-                    m_drawCollider = 0;
                 }
 
                 Gizmos.matrix = backup;

--- a/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10InstanceSpringBone.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Instance/Vrm10InstanceSpringBone.cs
@@ -57,11 +57,6 @@ namespace UniVRM10
                 var backup = Gizmos.matrix;
                 Gizmos.matrix = Matrix4x4.identity;
                 VRM10SpringBoneJoint lastJoint = Joints[0];
-                // if (lastJoint != null)
-                // {
-                //     const float f = 0.005f;
-                //     Gizmos.DrawCube(lastJoint.transform.position, new Vector3(f, f, f));
-                // }
                 for (int i = 1; i < Joints.Count; ++i)
                 {
                     var joint = Joints[i];
@@ -69,7 +64,6 @@ namespace UniVRM10
                     if (joint != null && lastJoint != null)
                     {
                         Gizmos.DrawLine(lastJoint.transform.position, joint.transform.position);
-                        // Gizmos.DrawWireSphere(joint.transform.position, lastJoint.m_jointRadius);
                     }
                     lastJoint = joint;
                 }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntime.cs
@@ -120,5 +120,10 @@ namespace UniVRM10
         {
             // FastSpringBoneService が実行するので何もしない
         }
+
+        public void DrawGizmos()
+        {
+            // FastSpringBoneService が実行するので何もしない
+        }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntimeStandalone.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntimeStandalone.cs
@@ -121,5 +121,10 @@ namespace UniVRM10
         {
             m_fastSpringBoneScheduler.Schedule(Time.deltaTime).Complete();
         }
+
+        public void DrawGizmos()
+        {
+
+        }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntimeStandalone.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntimeStandalone.cs
@@ -124,7 +124,7 @@ namespace UniVRM10
 
         public void DrawGizmos()
         {
-
+            m_bufferCombiner.DrawGizmos();
         }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10NopSpringboneRuntime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10NopSpringboneRuntime.cs
@@ -40,5 +40,7 @@ namespace UniVRM10
         public void SetModelLevel(Transform modelRoot, BlittableModelLevel modelSettings)
         {
         }
+
+        public void DrawGizmos() { }
     }
 }

--- a/Assets/VRM10/Runtime/FastSpringBone/FastSpringBoneService.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/FastSpringBoneService.cs
@@ -102,5 +102,13 @@ namespace UniVRM10.FastSpringBones
             }
             _fastSpringBoneScheduler.Schedule(deltaTime).Complete();
         }
+
+        public void OnDrawGizmosSelected()
+        {
+            if (enabled)
+            {
+                BufferCombiner.DrawGizmos();
+            }
+        }
     }
 }

--- a/Assets/VRM10/Runtime/IO/IVrm10SpringBoneRuntime.cs
+++ b/Assets/VRM10/Runtime/IO/IVrm10SpringBoneRuntime.cs
@@ -44,5 +44,10 @@ namespace UniVRM10
         /// 毎フレーム Vrm10Runtime.Process から呼ばれる。
         /// </summary>
         public void Process();
+
+        /// <summary>
+        /// from Vrm10Instance.OnDrawGizmosSelected
+        /// </summary>
+        public void DrawGizmos();
     }
 }


### PR DESCRIPTION
IVrm10SpringBoneRuntime.DrawGizmos を導入して、関連して整理しました。

原則として  OnDrawGizmosSelected を起点にすることにしました。
また、Joint が Spring の接続線を描画するなど他のオブジェクトを描画することを避けました。

以下のオブジェクトが OnDrawGizmosSelected を実装します。

- VRM10SpringBoneJoint
- VRM10SpringBoneCollider と VRM10SpringBoneColliderGroup
- Vrm10Instance(joint の接続線 と IVrm10SpringBoneRuntime 呼び出し)
- springbone が singleton である場合は、そのサービスオブジェクト

IVrm10SpringBoneRuntime  の描画は play 中のみです。
