### PR TITLE
[export][mesh] 三角形メッシュじゃない場合にスキップする

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportInfo.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshExportInfo.cs
@@ -266,12 +266,6 @@ namespace UniGLTF
             }
         }
 
-        static bool TryGetMeshInfo()
-        {
-
-            return true;
-        }
-
         public void CalcMeshSize(
             GameObject root,
             Renderer renderer,
@@ -423,10 +417,19 @@ namespace UniGLTF
                     }
 
                     var info = new MeshExportInfo(renderer, settings);
-                    if (info.Mesh != null)
+                    if (info.Mesh == null)
                     {
-                        m_list.Add(info);
+                        continue;
                     }
+                    for (int i = 0; i < info.Mesh.subMeshCount; ++i)
+                    {
+                        if (info.Mesh.GetTopology(i) != MeshTopology.Triangles)
+                        {
+                            continue;
+                        }
+                    }
+
+                    m_list.Add(info);
                 }
             }
         }


### PR DESCRIPTION
fixed #2472

現状 triangles のみをサポートしています。

unity

```cs
public enum MeshTopology
{
    //
    // Summary:
    //     Mesh is made from triangles.
    Triangles = 0,
    //
    // Summary:
    //     Mesh is made from quads.
    Quads = 2,
    //
    // Summary:
    //     Mesh is made from lines.
    Lines = 3,
    //
    // Summary:
    //     Mesh is a line strip.
    LineStrip = 4,
    //
    // Summary:
    //     Mesh is made from points.
    Points = 5
}
```

glTF

```json
        "mode": {
            "description": "The topology type of primitives to render.",
            "default": 4, // triangles
            "anyOf": [
                {
                    "const": 0,
                    "description": "POINTS",
                    "type": "integer"
                },
                {
                    "const": 1,
                    "description": "LINES",
                    "type": "integer"
                },
                {
                    "const": 2,
                    "description": "LINE_LOOP",
                    "type": "integer"
                },
                {
                    "const": 3,
                    "description": "LINE_STRIP",
                    "type": "integer"
                },
                {
                    "const": 4,
                    "description": "TRIANGLES",
                    "type": "integer"
                },
                {
                    "const": 5,
                    "description": "TRIANGLE_STRIP",
                    "type": "integer"
                },
                {
                    "const": 6,
                    "description": "TRIANGLE_FAN",
                    "type": "integer"
                },
                {
                    "type": "integer"
                }
            ]
        },
```