### PR TITLE
[test] unittest 修正

### DIFF
--- a/Assets/VRM10/Tests/LoadTests.cs
+++ b/Assets/VRM10/Tests/LoadTests.cs
@@ -89,10 +89,14 @@ namespace UniVRM10.Test
 
             // remove textures
             instance.Vrm.Meta.Thumbnail = null;
-            var m = new Material(Shader.Find("Unlit/Color"));
+
             foreach (var r in instance.GetComponentsInChildren<Renderer>())
             {
-                r.sharedMaterials = r.sharedMaterials.Select(x => m).ToArray();
+                r.sharedMaterials = r.sharedMaterials.Select(x =>
+                {
+                    var m = new Material(Shader.Find("UniGLTF/UniUnlit"));
+                    return m;
+                }).ToArray();
             }
 
             var settings = new GltfExportSettings();


### PR DESCRIPTION
Unlit/Color だと
 
   var index = textureExporter.RegisterExportingAsSRgb(src.mainTexture, false); // GetTexture("_MainTex");

が例外を発生させる。
2022.3 に更新して挙動が変わったかもしれない(未確認)。