### PR TITLE
[fastspringbone] InitCurrentTailsJob use spring.transformIndexOffset

### DIFF
--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneBufferCombiner.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneBufferCombiner.cs
@@ -60,10 +60,6 @@ namespace UniGLTF.SpringBoneJobs
             Profiler.BeginSample("FastSpringBone.ReconstructBuffers.DisposeBuffers");
             if (_combinedBuffer is FastSpringBoneCombinedBuffer combined)
             {
-                Profiler.BeginSample("FastSpringBone.ReconstructBuffers.SaveToSourceBuffer");
-                combined.SaveToSourceBuffer();
-                Profiler.EndSample();
-
                 // TODO: Dispose せずに再利用？
                 combined.Dispose();
             }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneBufferCombiner.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneBufferCombiner.cs
@@ -5,6 +5,7 @@ using UnityEngine.Profiling;
 using UniGLTF.SpringBoneJobs.InputPorts;
 using UnityEngine;
 using Unity.Collections;
+using System.Linq;
 
 namespace UniGLTF.SpringBoneJobs
 {
@@ -21,37 +22,17 @@ namespace UniGLTF.SpringBoneJobs
         private FastSpringBoneCombinedBuffer _combinedBuffer;
         public FastSpringBoneCombinedBuffer Combined => _combinedBuffer;
         private readonly LinkedList<FastSpringBoneBuffer> _buffers = new LinkedList<FastSpringBoneBuffer>();
-        private bool _isDirty;
+        private Queue<(bool isAdd, FastSpringBoneBuffer buffer)> _request = new();
         public bool HasBuffer => _buffers.Count > 0 && _combinedBuffer != null;
 
         public void Register(FastSpringBoneBuffer buffer)
         {
-            _buffers.AddLast(buffer);
-            _isDirty = true;
+            _request.Enqueue((true, buffer));
         }
 
-        public void Unregister(FastSpringBoneBuffer remove)
+        public void Unregister(FastSpringBoneBuffer buffer)
         {
-            // index が変わる前に シミュレーションの状態を保存する。
-            // 状態の保存場所が BlittableJoint から CurrentTails に移動しているのでここでやる。
-            if (_combinedBuffer is FastSpringBoneCombinedBuffer combined)
-            {
-                var logicsIndex = 0;
-                foreach (var buffer in _buffers)
-                {
-                    if (buffer == remove)
-                    {
-                        // 削除するので skip
-                        // joint の位置が変わる可能性があるので状態を保存せずに速度を0にする方がよい
-                        continue;
-                    }
-                    buffer.BackupCurrentTails(combined.CurrentTails, logicsIndex);
-                    logicsIndex += buffer.Logics.Length;
-                }
-            }
-
-            _buffers.Remove(remove);
-            _isDirty = true;
+            _request.Enqueue((false, buffer));
         }
 
         /// <summary>
@@ -59,14 +40,45 @@ namespace UniGLTF.SpringBoneJobs
         /// </summary>
         public JobHandle ReconstructIfDirty(JobHandle handle)
         {
-            if (_isDirty)
+            if (_request.Count == 0)
             {
-                var result = ReconstructBuffers(handle);
-                _isDirty = false;
-                return result;
+                return handle;
             }
 
-            return handle;
+            if (_combinedBuffer is FastSpringBoneCombinedBuffer combined)
+            {
+                // index が変わる前に シミュレーションの状態を保存する。
+                // 状態の保存場所が BlittableJoint から CurrentTails に移動しているのでここでやる。
+                var logicsIndex = 0;
+                foreach (var buffer in _buffers)
+                {
+                    if (_request.Any(x => !x.isAdd && x.buffer == buffer))
+                    {
+                        // 削除するので skip
+                        continue;
+                    }
+                    buffer.BackupCurrentTails(combined.CurrentTails, logicsIndex);
+                    logicsIndex += buffer.Logics.Length;
+                }
+            }
+
+            // buffer 増減
+            while (_request.Count > 0)
+            {
+                var (isAdd, buffer) = _request.Dequeue();
+                if (isAdd)
+                {
+                    // 速度 0 にする
+                    _buffers.AddLast(buffer);
+                }
+                else
+                {
+                    _buffers.Remove(buffer);
+                }
+            }
+
+            // 再構築
+            return ReconstructBuffers(handle);
         }
 
         /// <summary>

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
@@ -338,23 +338,21 @@ namespace UniGLTF.SpringBoneJobs
                 var spring = Springs[springIndex];
                 for (int jointIndex = spring.logicSpan.startIndex; jointIndex < spring.logicSpan.EndIndex; ++jointIndex)
                 {
-                    var tailIndex = Logics[jointIndex].tailTransformIndex;
-                    if (tailIndex == -1)
+                    int tailIndex;
+                    if (Logics[jointIndex].tailTransformIndex == -1)
                     {
                         // tail 無い
-                        var index = springIndex + Logics[jointIndex].headTransformIndex;
-                        var tail = Transforms[index];
-                        CurrentTails[jointIndex] = tail.position;
-                        PrevTails[jointIndex] = tail.position;
-                        NextTails[jointIndex] = tail.position;
+                        tailIndex = spring.transformIndexOffset + Logics[jointIndex].headTransformIndex;
                     }
                     else
                     {
-                        var tail = Transforms[spring.transformIndexOffset + tailIndex];
-                        CurrentTails[jointIndex] = tail.position;
-                        PrevTails[jointIndex] = tail.position;
-                        NextTails[jointIndex] = tail.position;
+                        tailIndex= spring.transformIndexOffset + Logics[jointIndex].tailTransformIndex;
                     }
+
+                    var tail = Transforms[tailIndex];
+                    CurrentTails[jointIndex] = tail.position;
+                    PrevTails[jointIndex] = tail.position;
+                    NextTails[jointIndex] = tail.position;
                 }
             }
         }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
@@ -124,6 +124,7 @@ namespace UniGLTF.SpringBoneJobs
             _transformAccessArray = new TransformAccessArray(transforms);
             Profiler.EndSample();
 
+            // Transforms を更新。後続の InitCurrentTails で使う
             handle = new PullTransformJob
             {
                 Transforms = Transforms
@@ -176,6 +177,10 @@ namespace UniGLTF.SpringBoneJobs
                 logicsOffset += buffer.Logics.Length;
                 transformOffset += buffer.Transforms.Length;
             }
+
+            // verlet の current, prev, next のバッファを今の transform の状態にする。
+            // 速度は 0 にクリアする。
+            // TODO: 速度の維持は SaveToSourceBuffer でされていたのだがデータ構造変更で場所が変わった
             handle = InitCurrentTails(handle);
             Profiler.EndSample();
 
@@ -345,7 +350,7 @@ namespace UniGLTF.SpringBoneJobs
                     }
                     else
                     {
-                        var tail = Transforms[spring.transformIndexOffset +  tailIndex];
+                        var tail = Transforms[spring.transformIndexOffset + tailIndex];
                         CurrentTails[jointIndex] = tail.position;
                         PrevTails[jointIndex] = tail.position;
                         NextTails[jointIndex] = tail.position;

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
@@ -354,9 +354,9 @@ namespace UniGLTF.SpringBoneJobs
             for (var i = 0; i < _batchedBuffers.Length; ++i)
             {
                 var length = _batchedBufferLogicSizes[i];
-                Debug.Assert(length == buffer.Logics.Length);
                 if (_batchedBuffers[i] == buffer)
                 {
+                    Debug.Assert(length == buffer.Logics.Length);
                     for (var j = 0; j < length; ++j)
                     {
                         var logic = buffer.Logics[j];
@@ -376,22 +376,23 @@ namespace UniGLTF.SpringBoneJobs
 
         public void DrawGizmos()
         {
-            foreach (var collider in _colliders)
-            {
-                collider.DrawGizmo(_transforms[collider.transformIndex]);
-            }
-
             foreach (var spring in _springs)
             {
+                for (int i = spring.colliderSpan.startIndex; i < spring.colliderSpan.EndIndex; ++i)
+                {
+                    var collider = _colliders[i];
+                    collider.DrawGizmo(_transforms[spring.transformIndexOffset + collider.transformIndex]);
+                }
+
                 for (int i = spring.logicSpan.startIndex; i < spring.logicSpan.EndIndex; ++i)
                 {
                     var joint = _logics[i];
-                    joint.DrawGizmo(_transforms[joint.tailTransformIndex], _joints[i]);
+                    joint.DrawGizmo(_transforms[spring.transformIndexOffset + joint.tailTransformIndex], _joints[i]);
 
                     Gizmos.matrix = Matrix4x4.identity;
                     Gizmos.DrawLine(
-                        _transforms[joint.tailTransformIndex].position,
-                        _transforms[joint.headTransformIndex].position);
+                        _transforms[spring.transformIndexOffset + joint.tailTransformIndex].position,
+                        _transforms[spring.transformIndexOffset + joint.headTransformIndex].position);
                 }
             }
         }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
@@ -181,9 +181,6 @@ namespace UniGLTF.SpringBoneJobs
                 transformOffset += buffer.Transforms.Length;
             }
 
-            // verlet の current, prev, next のバッファを今の transform の状態にする。
-            // 速度は 0 にクリアする。
-            // TODO: 速度の維持は SaveToSourceBuffer でされていたのだがデータ構造変更で場所が変わった
             handle = InitCurrentTails(handle);
             Profiler.EndSample();
 
@@ -328,12 +325,21 @@ namespace UniGLTF.SpringBoneJobs
             }
         }
 
-        /// <summary>
-        /// Transform から currentTail を更新。
-        /// prevTail も同じ内容にする(速度0)。
+        /// <summary>        
+        /// # CurrentTails[i] == NAN
+        /// 
+        /// Transforms から Current, Prev, Next を代入する。
+        /// 速度 0 で初期化することになる。
+        /// 
+        /// # CurrentTails[i] != NAN
+        /// 
+        /// 本処理はスキップされて Current, Next の利用が継続されます。
+        /// 
+        /// # NAN
+        /// 
+        /// Batching 関数内の FastSpringBoneBuffer.RestoreCurrentTails にて backup の Current, Next が無かったときに
+        /// 目印として NAN が代入されます。
         /// </summary>
-        /// <param name="handle"></param>
-        /// <returns></returns>
         public JobHandle InitCurrentTails(JobHandle handle)
         {
             return new InitCurrentTailsJob

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
@@ -22,7 +22,6 @@ namespace UniGLTF.SpringBoneJobs.InputPorts
         public NativeArray<BlittableJointMutable> Joints { get; }
         public NativeArray<BlittableCollider> Colliders { get; }
         public NativeArray<BlittableJointImmutable> Logics { get; }
-        public NativeArray<BlittableTransform> BlittableTransforms { get; }
         public Transform[] Transforms { get; }
         public bool IsDisposed { get; private set; }
 
@@ -103,16 +102,6 @@ namespace UniGLTF.SpringBoneJobs.InputPorts
             Joints = new NativeArray<BlittableJointMutable>(blittableJoints.ToArray(), Allocator.Persistent);
             Colliders = new NativeArray<BlittableCollider>(blittableColliders.ToArray(), Allocator.Persistent);
             Logics = new NativeArray<BlittableJointImmutable>(blittableLogics.ToArray(), Allocator.Persistent);
-            BlittableTransforms = new NativeArray<BlittableTransform>(Transforms.Select(transform => new BlittableTransform
-            {
-                position = transform.position,
-                rotation = transform.rotation,
-                localPosition = transform.localPosition,
-                localRotation = transform.localRotation,
-                localScale = transform.localScale,
-                localToWorldMatrix = transform.localToWorldMatrix,
-                worldToLocalMatrix = transform.worldToLocalMatrix
-            }).ToArray(), Allocator.Persistent);
             Profiler.EndSample();
         }
 
@@ -157,7 +146,6 @@ namespace UniGLTF.SpringBoneJobs.InputPorts
             IsDisposed = true;
             Springs.Dispose();
             Joints.Dispose();
-            BlittableTransforms.Dispose();
             Colliders.Dispose();
             Logics.Dispose();
         }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
@@ -24,7 +24,6 @@ namespace UniGLTF.SpringBoneJobs.InputPorts
         public NativeArray<BlittableJointImmutable> Logics { get; }
         private NativeArray<Vector3> _currentTailsBackup;
         public Transform[] Transforms { get; }
-        public bool IsDisposed { get; private set; }
 
         /// <summary>
         /// Joint, Collider, Center の Transform のリスト
@@ -143,11 +142,7 @@ namespace UniGLTF.SpringBoneJobs.InputPorts
 
         public void BackupCurrentTails(NativeArray<Vector3> currentTails, int offset)
         {
-            if (!IsDisposed)
-            {
-                return;
-            }
-            if (Logics.Length == 0)
+            if (!Logics.IsCreated || Logics.Length == 0)
             {
                 return;
             }
@@ -177,12 +172,11 @@ namespace UniGLTF.SpringBoneJobs.InputPorts
 
         public void Dispose()
         {
-            if (IsDisposed) return;
-            IsDisposed = true;
-            Springs.Dispose();
-            Joints.Dispose();
-            Colliders.Dispose();
-            Logics.Dispose();
+            if (Springs.IsCreated) Springs.Dispose();
+            if (Joints.IsCreated) Joints.Dispose();
+            if (Colliders.IsCreated) Colliders.Dispose();
+            if (Logics.IsCreated) Logics.Dispose();
+            if (_currentTailsBackup.IsCreated) _currentTailsBackup.Dispose();
         }
     }
 }

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/FastSpringBoneBufferFactory.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/FastSpringBoneBufferFactory.cs
@@ -26,6 +26,7 @@ namespace UniVRM10
             if (fastSpringBoneBuffer != null)
             {
                 fastSpringBoneBuffer.Dispose();
+                fastSpringBoneBuffer = null;
             }
 
             Func<Transform, TransformState> GetOrAddDefaultTransformState = (Transform tf) =>
@@ -41,7 +42,7 @@ namespace UniVRM10
 
             // create(Spring情報の再収集。設定変更の反映)
             var springs = vrm.SpringBone.Springs.Select(spring => new FastSpringBoneSpring
-            {                
+            {
                 center = spring.Center,
                 colliders = spring.ColliderGroups
                    .SelectMany(group => group.Colliders)


### PR DESCRIPTION
Vrm10FastSpringboneRuntime かつモデルが複数ある時に ReconstructSpringBone すると問題が再現する。

FastSpringBoneBufferCombiner が理解しきれていなかった。
初期化時の index ずれを修正。


