### PR TITLE
[VRM-1.0][springbone][editor] Collider の offset ドラッグを追加

### DIFF
--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderEditor.cs
@@ -11,6 +11,11 @@ namespace UniVRM10
         Vrm10Instance _vrm;
 
         SerializedProperty _script;
+        SerializedProperty _colliderType;
+        SerializedProperty _offset;
+        SerializedProperty _tail;
+
+        static VRM10SpringBoneCollider s_selected;
 
         private void OnEnable()
         {
@@ -21,6 +26,9 @@ namespace UniVRM10
             }
 
             _script = serializedObject.FindProperty("m_Script");
+            _colliderType = serializedObject.FindProperty(nameof(_target.ColliderType));
+            _offset = serializedObject.FindProperty(nameof(_target.Offset));
+            _tail = serializedObject.FindProperty(nameof(_target.Tail));
         }
 
         public override void OnInspectorGUI()
@@ -30,14 +38,13 @@ namespace UniVRM10
                 EditorGUILayout.PropertyField(_script);
             }
 
-            var component = (VRM10SpringBoneCollider)target;
-            switch (component.ColliderType)
+            switch (_target.ColliderType)
             {
                 case VRM10SpringBoneColliderTypes.Plane:
                     // radius: x
                     // tail: x
                     // normal: o
-                    DrawPropertiesExcluding(serializedObject, "m_Script", nameof(component.Tail), nameof(component.Radius));
+                    DrawPropertiesExcluding(serializedObject, "m_Script", nameof(_target.Tail), nameof(_target.Radius));
                     break;
 
                 case VRM10SpringBoneColliderTypes.Sphere:
@@ -45,7 +52,7 @@ namespace UniVRM10
                     // radius: o
                     // tail: x
                     // normal: x
-                    DrawPropertiesExcluding(serializedObject, nameof(component.Tail), nameof(component.Normal), "m_Script");
+                    DrawPropertiesExcluding(serializedObject, nameof(_target.Tail), nameof(_target.Normal), "m_Script");
                     break;
 
                 case VRM10SpringBoneColliderTypes.Capsule:
@@ -53,9 +60,30 @@ namespace UniVRM10
                     // radius: o
                     // tail: o
                     // normal: x
-                    DrawPropertiesExcluding(serializedObject, nameof(component.Normal), "m_Script");
+                    DrawPropertiesExcluding(serializedObject, nameof(_target.Normal), "m_Script");
                     break;
             }
+
+            EditorGUILayout.BeginHorizontal();
+            {
+                if (GUILayout.Button("Drag handle"))
+                {
+                    s_selected = _target;
+                }
+
+                if (_target.transform.childCount > 0)
+                {
+                    if (GUILayout.Button("Fit head-tail capsule"))
+                    {
+                        _colliderType.enumValueFlag = (int)VRM10SpringBoneColliderTypes.Capsule;
+                        _offset.vector3Value = Vector3.zero;
+                        var tail = _target.transform.GetChild(0);
+                        _tail.vector3Value = _target.transform.worldToLocalMatrix.MultiplyPoint(
+                            tail.position);
+                    }
+                }
+            }
+            EditorGUILayout.EndHorizontal();
 
             if (serializedObject.ApplyModifiedProperties())
             {
@@ -65,6 +93,38 @@ namespace UniVRM10
                     if (_vrm != null)
                     {
                         _vrm.Runtime.SpringBone.ReconstructSpringBone();
+                    }
+                }
+            }
+        }
+
+        public void OnSceneGUI()
+        {
+            HandleUtility.Repaint();
+
+            if (s_selected == _target)
+            {
+                var c = _target;
+                Handles.matrix = c.transform.localToWorldMatrix;
+                if (_target.ColliderType == VRM10SpringBoneColliderTypes.Capsule
+                || _target.ColliderType == VRM10SpringBoneColliderTypes.CapsuleInside)
+                {
+                    EditorGUI.BeginChangeCheck();
+                    var newTargetPosition = Handles.PositionHandle(c.Tail, Quaternion.identity);
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        Undo.RecordObject(c, "collider");
+                        c.Tail = newTargetPosition;
+                    }
+                }
+                else
+                {
+                    EditorGUI.BeginChangeCheck();
+                    var newTargetPosition = Handles.PositionHandle(c.Offset, Quaternion.identity);
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        Undo.RecordObject(c, "collider");
+                        c.Offset = newTargetPosition;
                     }
                 }
             }

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderEditor.cs
@@ -1,6 +1,7 @@
 using UnityEditor;
 using UnityEngine;
 
+
 namespace UniVRM10
 {
     [CustomEditor(typeof(VRM10SpringBoneCollider))]
@@ -9,25 +10,27 @@ namespace UniVRM10
         VRM10SpringBoneCollider _target;
         Vrm10Instance _vrm;
 
+        SerializedProperty _script;
+
         private void OnEnable()
         {
             _target = (VRM10SpringBoneCollider)target;
-            if(_target!=null)
+            if (_target != null)
             {
                 _vrm = _target.GetComponentInParent<Vrm10Instance>();
             }
+
+            _script = serializedObject.FindProperty("m_Script");
         }
 
         public override void OnInspectorGUI()
         {
-            // if (VRM10Window.Active == target)
-            // {
-            //     GUI.backgroundColor = Color.cyan;
-            //     Repaint();
-            // }
-            var property = serializedObject.FindProperty("m_Script");
+            using (new EditorGUI.DisabledScope(true))
+            {
+                EditorGUILayout.PropertyField(_script);
+            }
+
             var component = (VRM10SpringBoneCollider)target;
-            EditorGUILayout.PropertyField(property, new GUIContent("Script (" + component.GetIdentificationName() + ")"));
             switch (component.ColliderType)
             {
                 case VRM10SpringBoneColliderTypes.Plane:
@@ -59,7 +62,7 @@ namespace UniVRM10
                 if (Application.isPlaying)
                 {
                     // UniGLTF.UniGLTFLogger.Log("invaliate");
-                    if(_vrm!=null)
+                    if (_vrm != null)
                     {
                         _vrm.Runtime.SpringBone.ReconstructSpringBone();
                     }

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderGroupEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderGroupEditor.cs
@@ -68,10 +68,6 @@ namespace UniVRM10
 
             if (s_collider is VRM10SpringBoneCollider c)
             {
-                // var t = p.transform;
-                // Handles.color = Color.green;
-                // Handles.SphereHandleCap(t.GetInstanceID(), t.position, t.rotation, p.Radius * 2, EventType.Repaint);
-
                 EditorGUI.BeginChangeCheck();
                 Handles.matrix = c.transform.localToWorldMatrix;
                 var newTargetPosition = Handles.PositionHandle(c.Offset, Quaternion.identity);

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderGroupEditor.cs
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderGroupEditor.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+
+namespace UniVRM10
+{
+    [CustomEditor(typeof(VRM10SpringBoneColliderGroup))]
+    class VRM10SpringBoneColliderGroupEditor : Editor
+    {
+        ListView m_colliders;
+
+        static VRM10SpringBoneCollider s_collider;
+
+        public override VisualElement CreateInspectorGUI()
+        {
+            var root = new VisualElement();
+
+            // root.TrackSerializedObjectValue(serializedObject, OnValueChanged);
+
+            root.Bind(serializedObject);
+
+            {
+                var s = new PropertyField { bindingPath = "m_Script" };
+                s.SetEnabled(false);
+                root.Add(s);
+            }
+
+
+            root.Add(new PropertyField { bindingPath = nameof(VRM10SpringBoneColliderGroup.Name) });
+
+            {
+                m_colliders = new ListView
+                {
+                    bindingPath = nameof(VRM10SpringBoneColliderGroup.Colliders)
+                };
+                m_colliders.selectionChanged += (e) =>
+                {
+                    var item = (SerializedProperty)e.FirstOrDefault();
+                    if (item == null)
+                    {
+                        s_collider = null;
+                    }
+                    else
+                    {
+                        s_collider = (VRM10SpringBoneCollider)item.objectReferenceValue;
+                    }
+                };
+                m_colliders.showAddRemoveFooter = true;
+                m_colliders.showFoldoutHeader = true;
+                m_colliders.headerTitle = "Colliders";
+                root.Add(m_colliders);
+            }
+
+            return root;
+        }
+
+        public void OnSceneGUI()
+        {
+            HandleUtility.Repaint();
+            if (m_colliders == null)
+            {
+                return;
+            }
+
+            if (s_collider is VRM10SpringBoneCollider c)
+            {
+                // var t = p.transform;
+                // Handles.color = Color.green;
+                // Handles.SphereHandleCap(t.GetInstanceID(), t.position, t.rotation, p.Radius * 2, EventType.Repaint);
+
+                EditorGUI.BeginChangeCheck();
+                Handles.matrix = c.transform.localToWorldMatrix;
+                var newTargetPosition = Handles.PositionHandle(c.Offset, Quaternion.identity);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    Undo.RecordObject(c, "collider");
+                    c.Offset = newTargetPosition;
+                }
+            }
+        }
+    }
+}

--- a/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderGroupEditor.cs.meta
+++ b/Assets/VRM10/Editor/Components/SpringBone/VRM10SpringBoneColliderGroupEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ccae4c83e5d3a6438402cdd307f4ad2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
![drag+jamd;e](https://github.com/user-attachments/assets/2df03ffc-0664-47e1-93a9-a7693076e379)

`Drag Handle` ボタンを押すと移動ハンドルが表示される。

常時表示しないのは VRM10springBoneCollider が複数アタッチできるためです。