### PR TITLE
Fixes #2521 - Improving runtime GLTF export performance

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/ArrayByteBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/ArrayByteBuffer.cs
@@ -43,22 +43,18 @@ namespace UniGLTF
 
         public glTFBufferView Extend(IntPtr p, int bytesLength, int stride, glBufferTarget target)
         {
-            var tmp = m_bytes;
             // alignment
             var padding = m_used % stride == 0 ? 0 : stride - m_used % stride;
+            var requiredLength = m_used + padding + bytesLength;
 
-            if (m_bytes == null || m_used + padding + bytesLength > m_bytes.Length)
+            if (m_bytes == null || requiredLength > m_bytes.Length)
             {
                 // recreate buffer
-                m_bytes = new Byte[m_used + padding + bytesLength];
+                var newLength = Math.Max(requiredLength, m_bytes?.Length * 2 ?? 256);
+                var newBuffer = new Byte[newLength];
                 if (m_used > 0)
-                {
-                    Buffer.BlockCopy(tmp, 0, m_bytes, 0, m_used);
-                }
-            }
-            if (m_used + padding + bytesLength > m_bytes.Length)
-            {
-                throw new ArgumentOutOfRangeException();
+                    Buffer.BlockCopy(m_bytes, 0, newBuffer, 0, m_used);
+                m_bytes = newBuffer;
             }
 
             Marshal.Copy(p, m_bytes, m_used + padding, bytesLength);
@@ -70,7 +66,7 @@ namespace UniGLTF
                 byteStride = stride,
                 target = target,
             };
-            m_used = m_used + padding + bytesLength;
+            m_used = requiredLength;
             return result;
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
@@ -69,8 +69,8 @@ namespace UniGLTF
         public NativeArray<T> CreateNativeArray<T>(ArraySegment<T> data) where T : struct
         {
             var array = CreateNativeArray<T>(data.Count);
-            // TODO: remove ToArray
-            array.CopyFrom(data.ToArray());
+            for (int i = 0; i < data.Count; i++)
+                array[i] = data.Array[data.Offset + i];
             return array;
         }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
@@ -89,6 +89,8 @@ namespace UniGLTF
                 m_settings = new GltfExportSettings();
             }
 
+            if (progress != null)
+                m_progress = progress;
             m_animationExporter = animationExporter;
             m_materialExporter = materialExporter ?? MaterialExporterUtility.GetValidGltfMaterialExporter();
             m_textureSerializer = textureSerializer ?? new RuntimeTextureSerializer();

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
@@ -89,8 +89,6 @@ namespace UniGLTF
                 m_settings = new GltfExportSettings();
             }
 
-            if (progress != null)
-                m_progress = progress;
             m_animationExporter = animationExporter;
             m_materialExporter = materialExporter ?? MaterialExporterUtility.GetValidGltfMaterialExporter();
             m_textureSerializer = textureSerializer ?? new RuntimeTextureSerializer();


### PR DESCRIPTION
Improved exporting performance drastically by increasing allocated buffer more than needed to be able to skip extending chunk by chunk. 

No difference in export quality