### PR TITLE
Fixed #2519 - progress being used when given

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/gltfExporter.cs
@@ -89,6 +89,8 @@ namespace UniGLTF
                 m_settings = new GltfExportSettings();
             }
 
+            if (progress != null)
+                m_progress = progress;
             m_animationExporter = animationExporter;
             m_materialExporter = materialExporter ?? MaterialExporterUtility.GetValidGltfMaterialExporter();
             m_textureSerializer = textureSerializer ?? new RuntimeTextureSerializer();


### PR DESCRIPTION
Actually using progress parameter in GLTF Export constructor.
This enables progress callback for exports