### PR TITLE
Refs #2525 - Exporting meshes with quads

### DIFF
--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
@@ -172,7 +172,14 @@ namespace UniGLTF.SpringBoneJobs.InputPorts
                 for (int i = offset; i < end; ++i)
                 {
                     // mark velocity zero
+#if UNITY_2022_2_OR_NEWER
                     currentTails.GetSubArray(offset, Logics.Length).AsSpan().Fill(new Vector3(float.NaN, float.NaN, float.NaN));
+#else
+                    var subArray = currentTails.GetSubArray(offset, Logics.Length);
+                    var value = new Vector3(float.NaN, float.NaN, float.NaN);
+                    for (int a = 0; a < subArray.Length; ++a)
+                        subArray[a] = value;
+#endif
                 }
             }
         }

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/glTFMesh.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/glTFMesh.cs
@@ -75,6 +75,17 @@ namespace UniGLTF
     [Serializable]
     public class glTFPrimitives
     {
+        public enum Mode
+        {
+            POINTS = 0,
+            LINES = 1,
+            LINE_LOOP = 2,
+            LINE_STRIP = 3,
+            TRIANGLES = 4,
+            TRIANGLE_STRIP = 5,
+            TRIANGLE_FAN = 6,
+        }
+
         [JsonSchema(EnumValues = new object[] { 0, 1, 2, 3, 4, 5, 6 })]
         public int mode;
 


### PR DESCRIPTION
Fixes:
* Exporting in general when quads being used in meshes
* Quads being processed and split into two triangles

Added an enum for clarification on gltfPrimitive modes. (optional)