### PR TITLE
[importer] m_materials の中に m_defaultMaterial が含まれている場合に例外になるのを回避

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/Import/MaterialFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/Import/MaterialFactory.cs
@@ -54,6 +54,10 @@ namespace UniGLTF
                 {
                     // 外部の '.asset' からロードしていない
                     UnityObjectDestroyer.DestroyRuntimeOrEditor(x.Asset);
+                    if (x.Asset == m_defaultMaterial)
+                    {
+                        m_defaultMaterial = null;
+                    }
                 }
             }
 
@@ -82,6 +86,10 @@ namespace UniGLTF
                     // 外部の '.asset' からロードしていない
                     take(x.Key, x.Asset);
                     m_materials.Remove(x);
+                    if (x.Asset == m_defaultMaterial)
+                    {
+                        m_defaultMaterial = null;
+                    }
                 }
             }
 


### PR DESCRIPTION
```
UnityEditor.AssetImporters.AssetImportContext.AddObjectToAsset
```

https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/TriangleWithoutIndices/glTF-Embedded

で再現します。

vrma は 0 material glb
