### PR TITLE
[Actions] Don't triggered labek checker when codes are synchronized.

### DIFF
--- a/.github/workflows/label_checker.yml
+++ b/.github/workflows/label_checker.yml
@@ -3,7 +3,6 @@ name: Breaking changes label checker
 on:
   pull_request:
     types:
-      - synchronize
       - labeled
       - unlabeled
       - opened


### PR DESCRIPTION
PullRequest のコードが更新されたときに LabelChecker が発火する必要は無い。