### PR TITLE
`matcapTexture` should be 0.0 when it doesn't exist.

### DIFF
--- a/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon.shader
+++ b/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon.shader
@@ -29,7 +29,7 @@ Shader "VRM10/MToon10"
         _EmissionMap ("emissiveTexture", 2D) = "white" {} // Unity specified name
 
         // Rim Lighting
-        _MatcapColor ("mtoon.matcapFactor", Color) = (0, 0, 0, 1)
+        _MatcapColor ("mtoon.matcapFactor", Color) = (1, 1, 1, 1)
         _MatcapTex ("mtoon.matcapTexture", 2D) = "black" {}
         _RimColor ("mtoon.parametricRimColorFactor", Color) = (0, 0, 0, 1)
         _RimFresnelPower ("mtoon.parametricRimFresnelPowerFactor", Range(0, 100)) = 5.0

--- a/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_lighting_mtoon.hlsl
+++ b/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_lighting_mtoon.hlsl
@@ -118,7 +118,7 @@ inline half3 GetMToonLighting_Rim_Matcap(const MToonInput input)
         
         return _MatcapColor.rgb * MTOON_SAMPLE_TEXTURE2D(_MatcapTex, matcapUv).rgb;
     }
-    return _MatcapColor.rgb;
+    return 0;
 }
 
 inline half3 GetMToonLighting_Rim(const UnityLighting unityLight, const MToonInput input, const half shadow)

--- a/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_urp.shader
+++ b/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_urp.shader
@@ -29,7 +29,7 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
         _EmissionMap ("emissiveTexture", 2D) = "white" {} // Unity specified name
 
         // Rim Lighting
-        _MatcapColor ("mtoon.matcapFactor", Color) = (0, 0, 0, 1)
+        _MatcapColor ("mtoon.matcapFactor", Color) = (1, 1, 1, 1)
         _MatcapTex ("mtoon.matcapTexture", 2D) = "black" {}
         _RimColor ("mtoon.parametricRimColorFactor", Color) = (0, 0, 0, 1)
         _RimFresnelPower ("mtoon.parametricRimFresnelPowerFactor", Range(0, 100)) = 5.0


### PR DESCRIPTION
Fixed https://github.com/vrm-c/UniVRM/issues/2505

仕様によれば、`matcapTexture` が指定されていないとき `0.0` として評価されるべきです。

> When the texture is not defined, it must be sampled as having 0.0 in RGB components.
https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_mtoon-1.0#matcaptexture

つまり `matcapFactor` の値がなんであれ、`matcapTexture` が指定されていないときは MatCap 項自体が `0.0` となるべきだということです。
しかし現状は `matcapFactor` の値が評価されていました。
これを修正します。


またあわせて `matcapFactor` のデフォルト値も仕様に合わせて変更します。
Material 新規作成時のデフォルト値が変わりますが、新規モデル制作時の話であり、その場合も見た目の挙動は変わりません。

> default: [1, 1, 1]
https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_mtoon-1.0#matcapfactor