### PR TITLE
fix CurveY range

### DIFF
--- a/Assets/VRM/Runtime/LookAt/CurveMapper.cs
+++ b/Assets/VRM/Runtime/LookAt/CurveMapper.cs
@@ -14,7 +14,7 @@ namespace VRM
         [Range(20.0f, 90.0f)]
         public float CurveXRangeDegree;
 
-        [Range(0, 90.0f)]
+        [Range(0, 1.0f)]
         public float CurveYRangeDegree;
 
         public CurveMapper(float xRange, float yRange)


### PR DESCRIPTION
VRMLookAtBlendShapeApplyerのCurve Y Range Degreeはyaw, pitch が上限の時の blendShape の適用割合なので0～1になっているべきだが実際のRangeは0~90になっているのを修正しました。
https://vrm.dev/univrm/lookat/lookat_blendshape/