### PR TITLE
Unity6でGraphicsSettings.renderPipelineAssetがObsolete警告を出すのに対応

### DIFF
--- a/Assets/VRM/Editor/BuildClass.cs
+++ b/Assets/VRM/Editor/BuildClass.cs
@@ -28,7 +28,11 @@ namespace VRM.DevOnly
 
         public static void SwitchBuiltinPipeline()
         {
+#if UNITY_6000_0_OR_NEWER
+            UnityEngine.Rendering.GraphicsSettings.defaultRenderPipeline = null;
+#else
             UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset = null;
+#endif
         }
 
         public static void BuildWebGL_SimpleViewer()


### PR DESCRIPTION
Unity6でGraphicsSettings.renderPipelineAssetがObsoleteになり、次のような警告が出ていました。

```
Assets/VRM/Editor/BuildClass.cs(31,13): warning CS0618: 'GraphicsSettings.renderPipelineAsset' is obsolete: 'renderPipelineAsset has been deprecated. Use defaultRenderPipeline instead (UnityUpgradable) -> defaultRenderPipeline'
```

Unity6以降では、代わりとして推奨されるフィールド `defaultRenderPipeline` を使うようにしました。