### PR TITLE
Ensure `matcapFactor` Compatibility with VRM 1.0 Models in UniVRM v0.128.0 and Earlier

### DIFF
--- a/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon.shader
+++ b/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon.shader
@@ -29,7 +29,7 @@ Shader "VRM10/MToon10"
         _EmissionMap ("emissiveTexture", 2D) = "white" {} // Unity specified name
 
         // Rim Lighting
-        _MatcapColor ("mtoon.matcapFactor", Color) = (0, 0, 0, 1)
+        _MatcapColor ("mtoon.matcapFactor", Color) = (0, 0, 0, 1) // 仕様のデフォルト値は白だが、過去の仕様違反 UniVRM 実装アプリケーションのために黒とする。 https://github.com/vrm-c/UniVRM/pull/2594
         _MatcapTex ("mtoon.matcapTexture", 2D) = "black" {}
         _RimColor ("mtoon.parametricRimColorFactor", Color) = (0, 0, 0, 1)
         _RimFresnelPower ("mtoon.parametricRimFresnelPowerFactor", Range(0, 100)) = 5.0

--- a/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon.shader
+++ b/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon.shader
@@ -29,7 +29,7 @@ Shader "VRM10/MToon10"
         _EmissionMap ("emissiveTexture", 2D) = "white" {} // Unity specified name
 
         // Rim Lighting
-        _MatcapColor ("mtoon.matcapFactor", Color) = (1, 1, 1, 1)
+        _MatcapColor ("mtoon.matcapFactor", Color) = (0, 0, 0, 1)
         _MatcapTex ("mtoon.matcapTexture", 2D) = "black" {}
         _RimColor ("mtoon.parametricRimColorFactor", Color) = (0, 0, 0, 1)
         _RimFresnelPower ("mtoon.parametricRimFresnelPowerFactor", Range(0, 100)) = 5.0

--- a/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_urp.shader
+++ b/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_urp.shader
@@ -29,7 +29,7 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
         _EmissionMap ("emissiveTexture", 2D) = "white" {} // Unity specified name
 
         // Rim Lighting
-        _MatcapColor ("mtoon.matcapFactor", Color) = (0, 0, 0, 1)
+        _MatcapColor ("mtoon.matcapFactor", Color) = (0, 0, 0, 1) // 仕様のデフォルト値は白だが、過去の仕様違反 UniVRM 実装アプリケーションのために黒とする。 https://github.com/vrm-c/UniVRM/pull/2594
         _MatcapTex ("mtoon.matcapTexture", 2D) = "black" {}
         _RimColor ("mtoon.parametricRimColorFactor", Color) = (0, 0, 0, 1)
         _RimFresnelPower ("mtoon.parametricRimFresnelPowerFactor", Range(0, 100)) = 5.0

--- a/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_urp.shader
+++ b/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_urp.shader
@@ -29,7 +29,7 @@ Shader "VRM10/Universal Render Pipeline/MToon10"
         _EmissionMap ("emissiveTexture", 2D) = "white" {} // Unity specified name
 
         // Rim Lighting
-        _MatcapColor ("mtoon.matcapFactor", Color) = (1, 1, 1, 1)
+        _MatcapColor ("mtoon.matcapFactor", Color) = (0, 0, 0, 1)
         _MatcapTex ("mtoon.matcapTexture", 2D) = "black" {}
         _RimColor ("mtoon.parametricRimColorFactor", Color) = (0, 0, 0, 1)
         _RimFresnelPower ("mtoon.parametricRimFresnelPowerFactor", Range(0, 100)) = 5.0


### PR DESCRIPTION
https://github.com/vrm-c/UniVRM/pull/2540 では VRM 1.0 の仕様に準じて変更を行った。

しかし一方で UniVRM v0.128.0 以下のバージョンを利用して VRM 1.0 モデルを扱ったアプリケーションでは
依然、仕様違反の挙動のままである。

したがって v0.128.1 以上のバージョンで仕様として正しい VRM 1.0 モデルを作成したとしても、
過去のバージョンではおかしな見た目（真っ白）のモデルとしてインポートされてしまう。
例 : https://github.com/vrm-c/UniVRM/issues/2592

したがって、仕様違反の UniVRM v0.128.0 以下の環境であっても期待される見た目になるようなデフォルト値を選択する。