### PR TITLE
Fix EPS_COL as half in MToon shaders

### DIFF
--- a/Assets/VRM/MToon/Shaders/MToonCore.cginc
+++ b/Assets/VRM/MToon/Shaders/MToonCore.cginc
@@ -120,7 +120,7 @@ float4 frag_forward(v2f i) : SV_TARGET
     
     // const
     const float PI_2 = 6.28318530718;
-    const float EPS_COL = 0.00001;
+    const half EPS_COL = 0.0009765625;
     
     // uv
     float2 mainUv = TRANSFORM_TEX(i.uv0, _MainTex);

--- a/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_utility.hlsl
+++ b/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_utility.hlsl
@@ -9,7 +9,7 @@
 
 // define
 static const float PI_2 = 6.28318530718;
-static const float EPS_COL = 0.00001;
+static const half EPS_COL = 0.0009765625;
 
 inline half mtoon_linearstep(const half start, const half end, const half t)
 {


### PR DESCRIPTION
# 概要
シェーダー `VRM/MToon` 及び `VRM10/MToon10` で使用される定数 `EPS_COL` をhalf型に変更し、使用するイプシロンもhalfに合わせて修正しました。経緯は後述させていただきます。

半精度浮動小数点のイプシロンとして 2^(1-11) を数値で指定しています。

# 経緯
UnityEditor上でAndroid かつ GraphicsAPIがOpenGL ES3の環境でMToon10のTransparentの描画が正しく実施されない現象を確認しました。
以下はVRoidStudioからVRM1.0で出力したアバターで、目のシェーダーとしてMToon10かつTransparentが使用されています。
![](https://github.com/user-attachments/assets/b27fa674-216e-47b0-87fa-df45ef62702e)

こちらの現象ですが、`EPS_COL` はfloat型で宣言されておりますが実際にはhalf型との演算に使用されてことに起因している様です。
演算時にhalf型へ変換されて処理されますが0.00001は半精度浮動小数点では表現できないため、一部Graphics APIでhalf型の演算に使用された場合におかしな数値として扱われていると思われます。本現象はVulkanやDirect 3D11では確認されませんでした。

# 現象を確認した環境
- OS: Windows10
- Platform: UnityEditorにて、Android(Switch Platform)かつOpenGL ES3
  - Androidアプリ(apk)をAndroidエミュレータを用いたマシンで起動する場合も同様に発生しました
- Unity 2022.3.59f1

# 補足
本現象ですがVRM1.0では確認できましたが、**VRM0.xでは再現はとれておりません**。
そのため、`MToonCore.cginc` 側の修正は過剰である可能性がありますが、VRM1.0側と同様の演算がされているものと考えたため合わせて提出させていただきます。

ご確認のほど、よろしくお願い申し上げます。