### PR TITLE
SpanによるUniGLTF.NativeArrayManager.CreateNativeArray(ArraySegment)の改善

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
@@ -69,8 +69,9 @@ namespace UniGLTF
         public NativeArray<T> CreateNativeArray<T>(ArraySegment<T> data) where T : struct
         {
             var array = CreateNativeArray<T>(data.Count);
-            for (int i = 0; i < data.Count; i++)
-                array[i] = data.Array[data.Offset + i];
+            var toSpan = array.AsSpan();
+            var fromSpan = data.AsSpan();
+            fromSpan.CopyTo(toSpan);
             return array;
         }
 


### PR DESCRIPTION
## `CreateNativeArray<T>(ArraySegment)` による GC Alloc の様子

以下のスクリーンショットは、手元のアプリケーションプログラムを実行した際、
VRM ファイルをロードしたフレームでの Unity Profiler の様子です

![image](https://github.com/user-attachments/assets/aacda029-06d1-43c6-8b36-64b6417286fa)

ここで、 GC Alloc の量が目立つ場所の１つに `NativeArrayManager.CreateNativeArray<T>()` 下の ``ArraySegment`1.ToArray()`` があります。

UniVRM v0.128.3 の時点での、このコードの実体は以下のようなループコピーですが

https://github.com/vrm-c/UniVRM/blob/v0.128.3/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs#L69-L75

```C#
public NativeArray<T> CreateNativeArray<T>(
  ArraySegment<T> data
) where T : struct
{
    var array = CreateNativeArray<T>(data.Count);
    for (int i = 0; i < data.Count; i++)
        array[i] = data.Array[data.Offset + i];
    return array;
}
```

ループ内の `data.Array[]` によって `ArraySegment<>.ToArray()` が呼び出されているため、結果として大量の GC Alloc が発生する場合があります。

## `Span` の使用による GC Alloc の軽減案

この PR では、 `ArraySegment.ToArray()` による GC Alloc を避けるために `Span` を使用しています。

Unity 2022 以降では、 `NativeArray`, `ArraySegment` ともに `AsSpan` が使用可能になりました。
これを利用して、 `Span` 間での `Span.CopyTo` によるコピーを用いることで、 `ArraySegment<>.ToArray()` の呼び出しを削減するのがこの PR の差分です。
結果として中間オブジェクト生成による  GC Alloc が行われないコピーが可能になります。

## 使用している API

以下の API を使用しています

- Unity 2022.3
  - [`NativeArray<T0>.AsSpan`](https://docs.unity3d.com/2022.3/Documentation/ScriptReference/Unity.Collections.NativeArray_1.AsSpan.html)
- .NET Standard 2.1
  - [`MemoryExtensions.AsSpan(ArraySegment)`](https://learn.microsoft.com/ja-jp/dotnet/api/system.memoryextensions.asspan?view=netstandard-2.1#system-memoryextensions-asspan-1(system-arraysegment((-0))))
  - [`Span<T>.CopyTo(Span<T>)`](https://learn.microsoft.com/ja-jp/dotnet/api/system.span-1.copyto?view=netstandard-2.1)

