### PR TITLE
[SpringBone] reconstruct 時の center の index の offset 足し忘れを修正

### DIFF
--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneBufferCombiner.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneBufferCombiner.cs
@@ -32,21 +32,7 @@ namespace UniGLTF.SpringBoneJobs
 
         public bool HasBuffer => _buffers.Count > 0 && _combinedBuffer != null;
 
-        public void Register(FastSpringBoneBuffer buffer)
-        {
-            _request.Enqueue(new Request { Add = buffer });
-        }
-
-        public void Unregister(FastSpringBoneBuffer buffer)
-        {
-            _request.Enqueue(new Request { Remove = buffer });
-        }
-
-        /// <summary>
-        /// 順番が変わらないように更新する
-        /// </summary>
-        /// <param name="buffer"></param>
-        public void ReRegister(FastSpringBoneBuffer remove, FastSpringBoneBuffer add)
+        public void Register(FastSpringBoneBuffer add, FastSpringBoneBuffer remove)
         {
             _request.Enqueue(new Request { Remove = remove, Add = add });
         }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneBufferCombiner.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneBufferCombiner.cs
@@ -21,18 +21,34 @@ namespace UniGLTF.SpringBoneJobs
     {
         private FastSpringBoneCombinedBuffer _combinedBuffer;
         public FastSpringBoneCombinedBuffer Combined => _combinedBuffer;
-        private readonly LinkedList<FastSpringBoneBuffer> _buffers = new LinkedList<FastSpringBoneBuffer>();
-        private Queue<(bool isAdd, FastSpringBoneBuffer buffer)> _request = new();
+        private readonly List<FastSpringBoneBuffer> _buffers = new();
+
+        struct Request
+        {
+            public FastSpringBoneBuffer Remove;
+            public FastSpringBoneBuffer Add;
+        }
+        private Queue<Request> _request = new();
+
         public bool HasBuffer => _buffers.Count > 0 && _combinedBuffer != null;
 
         public void Register(FastSpringBoneBuffer buffer)
         {
-            _request.Enqueue((true, buffer));
+            _request.Enqueue(new Request { Add = buffer });
         }
 
         public void Unregister(FastSpringBoneBuffer buffer)
         {
-            _request.Enqueue((false, buffer));
+            _request.Enqueue(new Request { Remove = buffer });
+        }
+
+        /// <summary>
+        /// 順番が変わらないように更新する
+        /// </summary>
+        /// <param name="buffer"></param>
+        public void ReRegister(FastSpringBoneBuffer remove, FastSpringBoneBuffer add)
+        {
+            _request.Enqueue(new Request { Remove = remove, Add = add });
         }
 
         /// <summary>
@@ -60,14 +76,20 @@ namespace UniGLTF.SpringBoneJobs
             // buffer 増減
             while (_request.Count > 0)
             {
-                var (isAdd, buffer) = _request.Dequeue();
-                if (isAdd)
+                var req = _request.Dequeue();
+                if (req.Remove != null && req.Add != null)
                 {
-                    _buffers.AddLast(buffer);
+                    // 順番が変わらないように入れ替える
+                    var index = _buffers.IndexOf(req.Remove);
+                    _buffers[index] = req.Add;
                 }
-                else
+                else if (req.Add != null)
                 {
-                    _buffers.Remove(buffer);
+                    _buffers.Add(req.Add);
+                }
+                else if (req.Remove != null)
+                {
+                    _buffers.Remove(req.Remove);
                 }
             }
 

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
@@ -78,11 +78,14 @@ namespace UniGLTF.SpringBoneJobs
             _batchedBufferLogicSizes = batchedBufferLogicSizes;
         }
 
+        /// <summary>
+        /// Lidt<FastSpringBoneBuffer> をひとつの FastSpringBoneCombinedBuffer に統合する
+        /// </summary>
         internal static JobHandle Create(JobHandle handle,
-            LinkedList<FastSpringBoneBuffer> _buffers, out FastSpringBoneCombinedBuffer combined)
+            IReadOnlyList<FastSpringBoneBuffer> buffers, out FastSpringBoneCombinedBuffer combined)
         {
             Profiler.BeginSample("FastSpringBone.ReconstructBuffers.CopyToBatchedBuffers");
-            var batchedBuffers = _buffers.ToArray();
+            var batchedBuffers = buffers.ToArray();
             var batchedBufferLogicSizes = batchedBuffers.Select(buffer => buffer.Logics.Length).ToArray();
             Profiler.EndSample();
 
@@ -92,7 +95,7 @@ namespace UniGLTF.SpringBoneJobs
             var collidersCount = 0;
             var logicsCount = 0;
             var transformsCount = 0;
-            foreach (var buffer in _buffers)
+            foreach (var buffer in buffers)
             {
                 springsCount += buffer.Springs.Length;
                 collidersCount += buffer.Colliders.Length;
@@ -103,7 +106,7 @@ namespace UniGLTF.SpringBoneJobs
 
             // バッファの構築
             Profiler.BeginSample("FastSpringBone.ReconstructBuffers.CreateBuffers");
-            combined = new FastSpringBoneCombinedBuffer(logicsCount, springsCount, _buffers.Count,
+            combined = new FastSpringBoneCombinedBuffer(logicsCount, springsCount, buffers.Count,
                 collidersCount, transformsCount, batchedBuffers, batchedBufferLogicSizes);
             Profiler.EndSample();
 

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
@@ -303,7 +303,9 @@ namespace UniGLTF.SpringBoneJobs
             public void Execute(int springIndex)
             {
                 var spring = Springs[springIndex];
-                var center = spring.centerTransformIndex >= 0 ? Transforms[spring.centerTransformIndex] : (BlittableTransform?)null;
+                var center = spring.centerTransformIndex >= 0
+                    ? Transforms[spring.transformIndexOffset + spring.centerTransformIndex]
+                    : (BlittableTransform?)null;
                 for (int jointIndex = spring.logicSpan.startIndex; jointIndex < spring.logicSpan.EndIndex; ++jointIndex)
                 {
                     if (float.IsNaN(CurrentTails[jointIndex].x))

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneConbinedBuffer.cs
@@ -79,7 +79,7 @@ namespace UniGLTF.SpringBoneJobs
         }
 
         /// <summary>
-        /// Lidt<FastSpringBoneBuffer> をひとつの FastSpringBoneCombinedBuffer に統合する
+        /// Job向けに、Lidt[FastSpringBoneBuffer] をひとつの FastSpringBoneCombinedBuffer に統合する
         /// </summary>
         internal static JobHandle Create(JobHandle handle,
             IReadOnlyList<FastSpringBoneBuffer> buffers, out FastSpringBoneCombinedBuffer combined)

--- a/Assets/VRM/Runtime/SpringBone/Jobs/Vrm0XFastSpringBoneRuntime.cs
+++ b/Assets/VRM/Runtime/SpringBone/Jobs/Vrm0XFastSpringBoneRuntime.cs
@@ -57,7 +57,7 @@ namespace VRM
                 return;
             }
 
-            m_service.BufferCombiner.Unregister(m_buffer);
+            m_service.BufferCombiner.Register(add: null, remove: m_buffer);
             m_buffer.Dispose();
             m_buffer = null;
         }
@@ -67,7 +67,7 @@ namespace VRM
             Debug.Assert(m_buffer == null);
             var buffer = await SpringBoneJobs.FastSpringBoneReplacer.MakeBufferAsync(m_vrm, awaitCaller);
             m_buffer = buffer;
-            SpringBoneJobs.FastSpringBoneService.Instance.BufferCombiner.Register(buffer);
+            SpringBoneJobs.FastSpringBoneService.Instance.BufferCombiner.Register(add: buffer, remove: null);
 
         }
 

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntime.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntime.cs
@@ -55,7 +55,7 @@ namespace UniVRM10
         {
             if (m_fastSpringBoneBuffer != null)
             {
-                m_fastSpringBoneService.BufferCombiner.Unregister(m_fastSpringBoneBuffer);
+                m_fastSpringBoneService.BufferCombiner.Register(add: null, remove: m_fastSpringBoneBuffer);
                 m_fastSpringBoneBuffer.Dispose();
             }
         }
@@ -87,16 +87,10 @@ namespace UniVRM10
             }
             m_building = true;
 
-            // 登録削除
-            if (m_fastSpringBoneBuffer != null)
-            {
-                m_fastSpringBoneService.BufferCombiner.Unregister(m_fastSpringBoneBuffer);
-            }
+            var fastSpringBoneBuffer = await FastSpringBoneBufferFactory.ConstructSpringBoneAsync(awaitCaller, m_instance, m_fastSpringBoneBuffer);
 
-            m_fastSpringBoneBuffer = await FastSpringBoneBufferFactory.ConstructSpringBoneAsync(awaitCaller, m_instance, m_fastSpringBoneBuffer);
-
-            // 登録
-            m_fastSpringBoneService.BufferCombiner.Register(m_fastSpringBoneBuffer);
+            m_fastSpringBoneService.BufferCombiner.Register(add: fastSpringBoneBuffer, remove: m_fastSpringBoneBuffer);
+            m_fastSpringBoneBuffer = fastSpringBoneBuffer;
 
             m_building = false;
             return true;

--- a/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntimeStandalone.cs
+++ b/Assets/VRM10/Runtime/Components/Vrm10Runtime/Vrm10FastSpringboneRuntimeStandalone.cs
@@ -54,7 +54,7 @@ namespace UniVRM10
 
         public void Dispose()
         {
-            m_bufferCombiner.Unregister(m_fastSpringBoneBuffer);
+            m_bufferCombiner.Register(add: null, remove: m_fastSpringBoneBuffer);
             m_fastSpringBoneBuffer.Dispose();
 
             m_fastSpringBoneScheduler.Dispose();
@@ -88,16 +88,9 @@ namespace UniVRM10
             }
             m_building = true;
 
-            // 登録削除
-            if (m_fastSpringBoneBuffer != null)
-            {
-                m_bufferCombiner.Unregister(m_fastSpringBoneBuffer);
-            }
-
-            m_fastSpringBoneBuffer = await FastSpringBoneBufferFactory.ConstructSpringBoneAsync(awaitCaller, m_instance, m_fastSpringBoneBuffer);
-
-            // 登録
-            m_bufferCombiner.Register(m_fastSpringBoneBuffer);
+            var fastSpringBoneBuffer = await FastSpringBoneBufferFactory.ConstructSpringBoneAsync(awaitCaller, m_instance, m_fastSpringBoneBuffer);
+            m_bufferCombiner.Register(add: fastSpringBoneBuffer, remove: m_fastSpringBoneBuffer);
+            m_fastSpringBoneBuffer = fastSpringBoneBuffer;
 
             m_building = false;
             return true;


### PR DESCRIPTION
fixed #2611

#2609 のバグだった

ついでに unregister + register を一関数で一度にできるようにして、
あわせて順番が変わらないようにした。
