### PR TITLE
Fix MToon10: Use G channel for outline width tex to match the specification

### DIFF
--- a/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_geometry_vertex.hlsl
+++ b/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_geometry_vertex.hlsl
@@ -16,7 +16,7 @@ inline half MToon_GetOutlineVertex_OutlineWidth(const float2 uv)
 {
     if (MToon_IsParameterMapOn())
     {
-        return _OutlineWidth * UNITY_SAMPLE_TEX2D_LOD(_OutlineWidthTex, uv, 0).x;
+        return _OutlineWidth * UNITY_SAMPLE_TEX2D_LOD(_OutlineWidthTex, uv, 0).g;
     }
     else
     {


### PR DESCRIPTION
MToon10シェーダーでは outlineWidthMultiplyTexture について R チャンネルを参照しておりますが、これはvrm-specificationと異なっております。

>### outlineWidthMultiplyTexture
>The texture to set multiplication factor of outline width. If it is not assigned, the value of outlineWidthFactor is used directly.
>The components of the texture are stored in linear colorspace. The G component of the texture is referred to.

https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_mtoon-1.0#outlinewidthmultiplytexture

仕様に合うようMToon10シェーダーを修正します。
