### PR TITLE
add dependency to com.unity.timeline

### DIFF
--- a/Assets/VRM/Editor/Format/VRMVersionMenu.cs
+++ b/Assets/VRM/Editor/Format/VRMVersionMenu.cs
@@ -130,6 +130,7 @@ namespace UniGLTF
     ""name"": ""VRM Consortium""
   }},
   ""dependencies"": {{
+    ""com.unity.timeline"": ""1.7.6"",
     ""com.vrmc.gltf"": ""{0}""
   }},
   ""samples"": [

--- a/Assets/VRM10/package.json
+++ b/Assets/VRM10/package.json
@@ -14,6 +14,7 @@
     "name": "VRM Consortium"
   },
   "dependencies": {
+    "com.unity.timeline": "1.7.6",
     "com.vrmc.gltf": "0.128.3"
   },
   "samples": [


### PR DESCRIPTION
fixed #2602

最近の新規 project の template だと最初から  Packages/manifest.json に com.unity.timeline が含まれているぽい。
含まれていない template を選択したり、過去のバージョンから引き継がれたプロジェクトでは無いかもしれない。
