### PR TITLE
[VRM10Viewer][WebGL] FileDialog復旧。WWW警告解決

### DIFF
--- a/Assets/VRM10_Samples/VRM10Viewer/UIToolkit/VRM10MainView.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/UIToolkit/VRM10MainView.cs
@@ -78,7 +78,7 @@ namespace UniVRM10.VRM10Viewer
 
             root.Q<Button>("OpenModel").clicked += () =>
             {
-                m_controller.OnOpenModelClicked(MakeLoadOptions());
+                m_controller.OnOpenModelClicked(MakeLoadOptions(), name, nameof(FileSelected));
             };
 
             root.Q<Button>("OpenMotion").clicked += () =>
@@ -369,6 +369,16 @@ namespace UniVRM10.VRM10Viewer
             {
                 Debug.LogException(ex);
             }
+        }
+
+        /// <summary>
+        /// for WebGL
+        /// call from OpenFile.jslib
+        /// </summary>
+        public void FileSelected(string url)
+        {
+            UniGLTFLogger.Log($"FileSelected: {url}");
+            StartCoroutine(m_controller.LoadCoroutine(url, MakeLoadOptions()));
         }
     }
 }

--- a/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerController.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using UniGLTF;
 using UniGLTF.SpringBoneJobs.Blittables;
 using UnityEngine;
+using UnityEngine.Networking;
 using UnityEngine.Rendering;
 using static UniVRM10.Vrm10;
 
@@ -157,9 +158,9 @@ namespace UniVRM10.VRM10Viewer
 
         public IEnumerator LoadCoroutine(string url, LoadOptions opts)
         {
-            var www = new WWW(url);
-            yield return www;
-            var _ = LoadModelBytes("WebGL.vrm", www.bytes, opts);
+            var www = UnityWebRequest.Get(url);
+            yield return www.SendWebRequest();
+            var _ = LoadModelBytes("WebGL.vrm", www.downloadHandler.data, opts);
         }
 
         public void OnOpenModelClicked(LoadOptions opts, string callbackObject, string callbackMethod)

--- a/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerController.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerController.cs
@@ -138,7 +138,7 @@ namespace UniVRM10.VRM10Viewer
         [DllImport("__Internal")]
         public static extern void WebGL_VRM10_VRM10Viewer_FileDialog(string target, string message);
 
-        string FileDialog()
+        string FileDialog(string callbackObject, string callbackMethod)
         {
 #if UNITY_EDITOR 
             return UnityEditor.EditorUtility.OpenFilePanel("Open VRM", "", "vrm,glb,gltf,zip");
@@ -146,8 +146,8 @@ namespace UniVRM10.VRM10Viewer
             return VRM10FileDialogForWindows.FileDialog("open VRM", "vrm", "glb", "gltf", "zip");
 #elif UNITY_WEBGL
             // Open WebGL_VRM10_VRM10Viewer_FileDialog
-            // see: Assets/UniGLTF/Runtime/Utils/Plugins/OpenFile.jslib
-            WebGL_VRM10_VRM10Viewer_FileDialog("Canvas", "FileSelected");
+            // see: Assets\VRM10_Samples\VRM10Viewer\Plugins\WebGL_VRM10_VRM10Viewer.jslib
+            WebGL_VRM10_VRM10Viewer_FileDialog(callbackObject, callbackMethod);
             // Control flow does not return here. return empty string with dummy
             return null;
 #else
@@ -162,9 +162,9 @@ namespace UniVRM10.VRM10Viewer
             var _ = LoadModelBytes("WebGL.vrm", www.bytes, opts);
         }
 
-        public void OnOpenModelClicked(LoadOptions opts)
+        public void OnOpenModelClicked(LoadOptions opts, string callbackObject, string callbackMethod)
         {
-            var path = FileDialog();
+            var path = FileDialog(callbackObject, callbackMethod);
             _ = LoadModelPath(path, opts);
         }
 

--- a/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerController.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/VRM10ViewerController.cs
@@ -139,7 +139,7 @@ namespace UniVRM10.VRM10Viewer
         [DllImport("__Internal")]
         public static extern void WebGL_VRM10_VRM10Viewer_FileDialog(string target, string message);
 
-        string FileDialog(string callbackObject, string callbackMethod)
+        string FileDialog(string messageTarget, string messageName)
         {
 #if UNITY_EDITOR 
             return UnityEditor.EditorUtility.OpenFilePanel("Open VRM", "", "vrm,glb,gltf,zip");
@@ -148,7 +148,7 @@ namespace UniVRM10.VRM10Viewer
 #elif UNITY_WEBGL
             // Open WebGL_VRM10_VRM10Viewer_FileDialog
             // see: Assets\VRM10_Samples\VRM10Viewer\Plugins\WebGL_VRM10_VRM10Viewer.jslib
-            WebGL_VRM10_VRM10Viewer_FileDialog(callbackObject, callbackMethod);
+            WebGL_VRM10_VRM10Viewer_FileDialog(messageTarget, messageName);
             // Control flow does not return here. return empty string with dummy
             return null;
 #else
@@ -163,9 +163,9 @@ namespace UniVRM10.VRM10Viewer
             var _ = LoadModelBytes("WebGL.vrm", www.downloadHandler.data, opts);
         }
 
-        public void OnOpenModelClicked(LoadOptions opts, string callbackObject, string callbackMethod)
+        public void OnOpenModelClicked(LoadOptions opts, string messageTarget, string messageName)
         {
-            var path = FileDialog(callbackObject, callbackMethod);
+            var path = FileDialog(messageTarget, messageName);
             _ = LoadModelPath(path, opts);
         }
 

--- a/Assets/VRM10_Samples/VRM10Viewer/uGui/VRM10ViewerUI.cs
+++ b/Assets/VRM10_Samples/VRM10Viewer/uGui/VRM10ViewerUI.cs
@@ -188,7 +188,7 @@ namespace UniVRM10.VRM10Viewer
 
             m_version.text = string.Format("VRM10ViewerUI {0}", PackageVersion.VERSION);
 
-            m_openModel.onClick.AddListener(() => m_controller.OnOpenModelClicked(MakeLoadOptions()));
+            m_openModel.onClick.AddListener(() => m_controller.OnOpenModelClicked(MakeLoadOptions(), name, nameof(FileSelected)));
             m_openMotion.onClick.AddListener(m_controller.OnOpenMotionClicked);
             m_pastePose.onClick.AddListener(m_controller.OnPastePoseClicked);
             m_resetSpringBone.onClick.AddListener(m_controller.OnResetSpringBoneClicked);


### PR DESCRIPTION
- FileDialog が動かなくなっていたのを修正
- deprecated の WWWを UnityWebRequest に置き換え