### PR TITLE
Add CustomPropertyDrawer to MToon10 Showcase

### DIFF
--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/AlphaModeEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/AlphaModeEntryDrawer.cs
@@ -10,8 +10,8 @@ namespace VRM10.Samples.MToon10Showcase
         {
             EditorGUILayout.PropertyField(
                 property.FindPropertyRelative(nameof(AlphaModeShowcase.AlphaModeEntry.alphaMode)));
-            EditorGUILayout.PropertyField(
-                property.FindPropertyRelative(nameof(AlphaModeShowcase.AlphaModeEntry.alphaCutoff)));
+            EditorGUILayout.Slider(
+                property.FindPropertyRelative(nameof(AlphaModeShowcase.AlphaModeEntry.alphaCutoff)), 0, 1);
             EditorGUILayout.PropertyField(
                 property.FindPropertyRelative(nameof(AlphaModeShowcase.AlphaModeEntry.doubleSidedMode)));
             EditorGUILayout.PropertyField(

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/AlphaModeEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/AlphaModeEntryDrawer.cs
@@ -1,0 +1,21 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(AlphaModeShowcase.AlphaModeEntry))]
+    public sealed class AlphaModeEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(AlphaModeShowcase.AlphaModeEntry.alphaMode)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(AlphaModeShowcase.AlphaModeEntry.alphaCutoff)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(AlphaModeShowcase.AlphaModeEntry.doubleSidedMode)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(AlphaModeShowcase.AlphaModeEntry.transparentWithZWriteMode)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/AlphaModeEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/AlphaModeEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3fee9b12cbf4465e83bd9ac5cc2d477e
+timeCreated: 1744177935

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/EmissionEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/EmissionEntryDrawer.cs
@@ -1,0 +1,17 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(EmissionShowcase.EmissionEntry))]
+    public sealed class EmissionEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(EmissionShowcase.EmissionEntry.emissiveTexture)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(EmissionShowcase.EmissionEntry.emissiveFactorLinear)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/EmissionEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/EmissionEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 98220e137fc2407e89f281bb08beae57
+timeCreated: 1744181619

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/GIEqualizationEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/GIEqualizationEntryDrawer.cs
@@ -1,0 +1,15 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(GIEqualizationShowcase.GIEqualizationEntry))]
+    public sealed class GIEqualizationEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(GIEqualizationShowcase.GIEqualizationEntry.giEqualizationFactor)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/GIEqualizationEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/GIEqualizationEntryDrawer.cs
@@ -8,8 +8,9 @@ namespace VRM10.Samples.MToon10Showcase
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            EditorGUILayout.PropertyField(
-                property.FindPropertyRelative(nameof(GIEqualizationShowcase.GIEqualizationEntry.giEqualizationFactor)));
+            EditorGUILayout.Slider(
+                property.FindPropertyRelative(nameof(GIEqualizationShowcase.GIEqualizationEntry.giEqualizationFactor)),
+                0, 1);
         }
     }
 }

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/GIEqualizationEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/GIEqualizationEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 57a82d70b56740d0bc23cc36130d9612
+timeCreated: 1744181638

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/MatcapEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/MatcapEntryDrawer.cs
@@ -1,0 +1,17 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(MatcapShowcase.MatcapEntry))]
+    public sealed class MatcapEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(MatcapShowcase.MatcapEntry.matcapTexture)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(MatcapShowcase.MatcapEntry.matcapColorFactor)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/MatcapEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/MatcapEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: be96b3c6ab904720991f11ab006cd4ea
+timeCreated: 1744181656

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/NormalMapEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/NormalMapEntryDrawer.cs
@@ -1,0 +1,17 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(NormalMapShowcase.NormalMapEntry))]
+    public class NormalMapEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(NormalMapShowcase.NormalMapEntry.normalTexture)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(NormalMapShowcase.NormalMapEntry.normalTextureScale)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/NormalMapEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/NormalMapEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0be204fce50046c292e00c3af1133af7
+timeCreated: 1744181673

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/OutlineEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/OutlineEntryDrawer.cs
@@ -1,0 +1,23 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(OutlineShowcase.OutlineEntry))]
+    public sealed class OutlineEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineWidthMode)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineWidthFactor)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineColorFactor)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineWidthMultiplyTexture)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineLightingMixFactor)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/OutlineEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/OutlineEntryDrawer.cs
@@ -10,14 +10,16 @@ namespace VRM10.Samples.MToon10Showcase
         {
             EditorGUILayout.PropertyField(
                 property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineWidthMode)));
-            EditorGUILayout.PropertyField(
-                property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineWidthFactor)));
+            EditorGUILayout.Slider(
+                property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineWidthFactor)),
+                0, 0.05f);
             EditorGUILayout.PropertyField(
                 property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineColorFactor)));
             EditorGUILayout.PropertyField(
                 property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineWidthMultiplyTexture)));
-            EditorGUILayout.PropertyField(
-                property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineLightingMixFactor)));
+            EditorGUILayout.Slider(
+                property.FindPropertyRelative(nameof(OutlineShowcase.OutlineEntry.outlineLightingMixFactor)),
+                0, 1);
         }
     }
 }

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/OutlineEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/OutlineEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8d7b8324969947f695eea28f9e455443
+timeCreated: 1744181687

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/PrametricRimEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/PrametricRimEntryDrawer.cs
@@ -10,11 +10,11 @@ namespace VRM10.Samples.MToon10Showcase
         {
             EditorGUILayout.PropertyField(
                 property.FindPropertyRelative(nameof(ParametricRimShowcase.ParametricRimEntry.parametricRimColor)));
-            EditorGUILayout.PropertyField(property.FindPropertyRelative(nameof(ParametricRimShowcase.ParametricRimEntry
-                .parametricRimFresnelPowerFactor)));
-            EditorGUILayout.PropertyField(
+            EditorGUILayout.Slider(property.FindPropertyRelative(nameof(ParametricRimShowcase.ParametricRimEntry
+                .parametricRimFresnelPowerFactor)), 0, 100);
+            EditorGUILayout.Slider(
                 property.FindPropertyRelative(nameof(ParametricRimShowcase.ParametricRimEntry
-                    .parametricRimLiftFactor)));
+                    .parametricRimLiftFactor)), 0, 1);
         }
     }
 }

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/PrametricRimEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/PrametricRimEntryDrawer.cs
@@ -1,0 +1,20 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(ParametricRimShowcase.ParametricRimEntry))]
+    public sealed class ParametricRimEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(ParametricRimShowcase.ParametricRimEntry.parametricRimColor)));
+            EditorGUILayout.PropertyField(property.FindPropertyRelative(nameof(ParametricRimShowcase.ParametricRimEntry
+                .parametricRimFresnelPowerFactor)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(ParametricRimShowcase.ParametricRimEntry
+                    .parametricRimLiftFactor)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/PrametricRimEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/PrametricRimEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3eea0197be7b48ed85c7e4f63cb196a8
+timeCreated: 1744181696

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/RenderQueueOffsetEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/RenderQueueOffsetEntryDrawer.cs
@@ -1,0 +1,16 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(RenderQueueOffsetShowcase.RenderQueueOffsetEntry))]
+    public sealed class RenderQueueOffsetEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(
+                    nameof(RenderQueueOffsetShowcase.RenderQueueOffsetEntry.renderQueueOffset)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/RenderQueueOffsetEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/RenderQueueOffsetEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1252c8a4ee97479cab2143c175211921
+timeCreated: 1744181707

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/RimLightingEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/RimLightingEntryDrawer.cs
@@ -1,0 +1,19 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(RimLightingShowcase.RimLightingMixFactorEntry))]
+    public sealed class RimLightingEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(
+                    nameof(RimLightingShowcase.RimLightingMixFactorEntry.rimLightingMixFactor)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(RimLightingShowcase.RimLightingMixFactorEntry
+                    .rimMultiplyTexture)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/RimLightingEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/RimLightingEntryDrawer.cs
@@ -10,10 +10,11 @@ namespace VRM10.Samples.MToon10Showcase
         {
             EditorGUILayout.PropertyField(
                 property.FindPropertyRelative(
-                    nameof(RimLightingShowcase.RimLightingMixFactorEntry.rimLightingMixFactor)));
-            EditorGUILayout.PropertyField(
-                property.FindPropertyRelative(nameof(RimLightingShowcase.RimLightingMixFactorEntry
-                    .rimMultiplyTexture)));
+                    nameof(RimLightingShowcase.RimLightingMixFactorEntry.rimMultiplyTexture)));
+            EditorGUILayout.Slider(
+                property.FindPropertyRelative(
+                    nameof(RimLightingShowcase.RimLightingMixFactorEntry.rimLightingMixFactor)),
+                0, 1);
         }
     }
 }

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/RimLightingEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/RimLightingEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 13cddcf1d05c49b59f5a28ffa8598473
+timeCreated: 1744181720

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingShiftEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingShiftEntryDrawer.cs
@@ -1,0 +1,17 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(ShadingShiftShowcase.ShadingShiftEntry))]
+    public sealed class ShadingShiftEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(ShadingShiftShowcase.ShadingShiftEntry.shadingShiftTexture)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(ShadingShiftShowcase.ShadingShiftEntry.shadingShiftTextureScale)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingShiftEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingShiftEntryDrawer.cs
@@ -10,8 +10,9 @@ namespace VRM10.Samples.MToon10Showcase
         {
             EditorGUILayout.PropertyField(
                 property.FindPropertyRelative(nameof(ShadingShiftShowcase.ShadingShiftEntry.shadingShiftTexture)));
-            EditorGUILayout.PropertyField(
-                property.FindPropertyRelative(nameof(ShadingShiftShowcase.ShadingShiftEntry.shadingShiftTextureScale)));
+            EditorGUILayout.Slider(
+                property.FindPropertyRelative(nameof(ShadingShiftShowcase.ShadingShiftEntry.shadingShiftTextureScale)),
+                -3f, 3f);
         }
     }
 }

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingShiftEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingShiftEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 985ae8c939844b249a4a5562cb28bf3a
+timeCreated: 1744181741

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingToonyEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingToonyEntryDrawer.cs
@@ -1,0 +1,17 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(ShadingToonyShowcase.ShadingToonyEntry))]
+    public sealed class ShadingToonyEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(ShadingToonyShowcase.ShadingToonyEntry.shadingToonyFactor)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(ShadingToonyShowcase.ShadingToonyEntry.shadingShiftFactor)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingToonyEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingToonyEntryDrawer.cs
@@ -8,10 +8,12 @@ namespace VRM10.Samples.MToon10Showcase
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            EditorGUILayout.PropertyField(
-                property.FindPropertyRelative(nameof(ShadingToonyShowcase.ShadingToonyEntry.shadingToonyFactor)));
-            EditorGUILayout.PropertyField(
-                property.FindPropertyRelative(nameof(ShadingToonyShowcase.ShadingToonyEntry.shadingShiftFactor)));
+            EditorGUILayout.Slider(
+                property.FindPropertyRelative(nameof(ShadingToonyShowcase.ShadingToonyEntry.shadingToonyFactor)),
+                0f, 1f);
+            EditorGUILayout.Slider(
+                property.FindPropertyRelative(nameof(ShadingToonyShowcase.ShadingToonyEntry.shadingShiftFactor)),
+                -1f, 1f);
         }
     }
 }

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingToonyEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/ShadingToonyEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1cb4e1dfc0414b94a77ca53a7df387a1
+timeCreated: 1744181752

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/UVAnimationEntryDrawer.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/UVAnimationEntryDrawer.cs
@@ -1,0 +1,24 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VRM10.Samples.MToon10Showcase
+{
+    [CustomPropertyDrawer(typeof(UVAnimationShowcase.UVAnimationEntry))]
+    public class UVAnimationEntryDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(nameof(UVAnimationShowcase.UVAnimationEntry.uvAnimationMaskTexture)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(
+                    nameof(UVAnimationShowcase.UVAnimationEntry.uvAnimationScrollXSpeedFactor)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(
+                    nameof(UVAnimationShowcase.UVAnimationEntry.uvAnimationScrollYSpeedFactor)));
+            EditorGUILayout.PropertyField(
+                property.FindPropertyRelative(
+                    nameof(UVAnimationShowcase.UVAnimationEntry.uvAnimationRotationSpeedFactor)));
+        }
+    }
+}

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/UVAnimationEntryDrawer.cs.meta
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/CustomEditor/UVAnimationEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3bcab6f07e49404db13cd543829dd7f4
+timeCreated: 1744181759

--- a/Assets/VRM10_Samples/MToon10Showcase/Editor/VRM10.Samples.MToon10Showcase.Editor.asmdef
+++ b/Assets/VRM10_Samples/MToon10Showcase/Editor/VRM10.Samples.MToon10Showcase.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "VRM10.Samples.MToon10Showcase.Editor",
     "rootNamespace": "",
     "references": [
-        "GUID:151799a9fa5ec7e44bc6c5293df4b6b3"
+        "GUID:151799a9fa5ec7e44bc6c5293df4b6b3",
+        "GUID:0aaf403bd13871a44b7127aef2695ff8"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/VRM10_Samples/MToon10Showcase/Runtime/ShowcaseTemplates/OutlineShowcase.cs
+++ b/Assets/VRM10_Samples/MToon10Showcase/Runtime/ShowcaseTemplates/OutlineShowcase.cs
@@ -16,7 +16,7 @@ namespace VRM10.Samples.MToon10Showcase
         [Serializable]
         public sealed class OutlineEntry
         {
-            [FormerlySerializedAs("outlineMode")] public MToon10OutlineMode outlineWidthMode;
+            public MToon10OutlineMode outlineWidthMode;
             public float outlineWidthFactor;
             public Color outlineColorFactor;
             public Texture outlineWidthMultiplyTexture;


### PR DESCRIPTION
MToon10 Showcase に CustomPropertyDrawer を追加し、マテリアル設定値を保持する ScriptableObject の Inpector の視認性を改善します。