### PR TITLE
Recovering the editor gizmo in VRMSpringBoneColliderGroup component.

### DIFF
--- a/Assets/VRM/Editor/SpringBone/VRMSpringBoneColliderGroupEditor.cs
+++ b/Assets/VRM/Editor/SpringBone/VRMSpringBoneColliderGroupEditor.cs
@@ -16,6 +16,30 @@ namespace VRM
             m_target = (VRMSpringBoneColliderGroup)target;
         }
 
+        private void OnSceneGUI()
+        {
+            Undo.RecordObject(m_target, "VRMSpringBoneColliderGroupEditor");
+
+            Handles.matrix = m_target.transform.localToWorldMatrix;
+            Gizmos.color = Color.green;
+
+            bool changed = false;
+
+            foreach (var x in m_target.Colliders)
+            {
+                var offset = Handles.PositionHandle(x.Offset, Quaternion.identity);
+                if (offset != x.Offset)
+                {
+                    changed = true;
+                    x.Offset = offset;
+                }
+            }
+
+            if (changed)
+            {
+                EditorUtility.SetDirty(m_target);
+            }
+        }
 
         override public void OnInspectorGUI()
         {

--- a/Assets/VRM/Editor/SpringBone/VRMSpringBoneColliderGroupEditor.cs
+++ b/Assets/VRM/Editor/SpringBone/VRMSpringBoneColliderGroupEditor.cs
@@ -79,6 +79,28 @@ namespace VRM
             target.Colliders = target.Colliders.OrderBy(x => -x.Radius).ToArray();
         }
 
+        [MenuItem("CONTEXT/VRMSpringBoneColliderGroup/Sort Colliders Reversed")]
+        private static void SortReverse(MenuCommand command)
+        {
+            var target = command.context as VRMSpringBoneColliderGroup;
+            if (target == null) return;
+
+            Undo.RecordObject(target, "Sort Colliders Reversed");
+
+            target.Colliders = target.Colliders.Reverse().ToArray();
+        }
+
+        [MenuItem("CONTEXT/VRMSpringBoneColliderGroup/Sort Colliders by Offset X")]
+        private static void SortByOffsetX(MenuCommand command)
+        {
+            var target = command.context as VRMSpringBoneColliderGroup;
+            if (target == null) return;
+
+            Undo.RecordObject(target, "Sort Colliders by Offset X");
+
+            target.Colliders = target.Colliders.OrderBy(x => x.Offset.x).ToArray();
+        }
+
         [MenuItem("CONTEXT/VRMSpringBoneColliderGroup/Sort Colliders by Offset Y")]
         private static void SortByOffsetY(MenuCommand command)
         {
@@ -87,7 +109,18 @@ namespace VRM
 
             Undo.RecordObject(target, "Sort Colliders by Offset Y");
 
-            target.Colliders = target.Colliders.OrderBy(x => -x.Offset.y).ToArray();
+            target.Colliders = target.Colliders.OrderBy(x => x.Offset.y).ToArray();
+        }
+
+        [MenuItem("CONTEXT/VRMSpringBoneColliderGroup/Sort Colliders by Offset Z")]
+        private static void SortByOffsetZ(MenuCommand command)
+        {
+            var target = command.context as VRMSpringBoneColliderGroup;
+            if (target == null) return;
+
+            Undo.RecordObject(target, "Sort Colliders by Offset Z");
+
+            target.Colliders = target.Colliders.OrderBy(x => x.Offset.z).ToArray();
         }
     }
 }


### PR DESCRIPTION
Fixed https://github.com/vrm-c/UniVRM/issues/2650

VRM 0.X における ColliderGroup の編集 Gizmo が https://github.com/vrm-c/UniVRM/pull/1876 で消されていました。
この PullReq の主たる意図は VRM 1.0 を対象としたものと見受けられます。
したがって VRM 0.X の Gizmo Handle が消されたのは巻き添えに思えるので、これを復活させます。