### PR TITLE
fix(tangent): binarize tangent.w to ±1 to prevent NaNs and artifacts

### DIFF
--- a/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_utility.hlsl
+++ b/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_utility.hlsl
@@ -58,7 +58,11 @@ inline half3x3 MToon_GetTangentToWorld(const half3 normalWS, const half4 tangent
     const half3 normalizedNormalWS = normalize(normalWS);
     const half3 normalizedTangentWS = normalize(tangentWS.xyz);
 
-    const half3 normalizedBitangentWS = normalize(tangentWS.w * cross(normalizedNormalWS, normalizedTangentWS));
+    // NOTE: tangent Sign は本来、+1 か -1 の値が望まれる。そしてこれは通常、三角形内ですべておなじ値である。
+    //       しかし Unity 純正の Mesh.RecalculateTangents() を呼び出すと、頂点ごとに異なる tangent Sign を持つ三角形が生まれることがある。
+    //       その場合 interpolate されて 0 となり、ゼロ除算と NaN が発生し、Android 環境等でビジュアルアーティファクトが出る場合があるため、二値化する。
+    const half tangentSign = tangentWS.w > 0 ? 1.0 : -1.0;
+    const half3 normalizedBitangentWS = normalize(tangentSign * cross(normalizedNormalWS, normalizedTangentWS));
 
     return half3x3(normalizedTangentWS, normalizedBitangentWS, normalizedNormalWS);
 }


### PR DESCRIPTION
tangent Sign は本来、+1 か -1 の値が望まれる。そしてこれは通常、三角形内ですべておなじ値である。
しかし Unity 純正の `Mesh.RecalculateTangents()` を呼び出すと、頂点ごとに異なる tangent Sign を持つ三角形が生まれることがある。
その場合 interpolate されて 0 となり、ゼロ除算と NaN が発生し、Android 環境等 `half` 精度が採択された場合に、ビジュアルアーティファクトが顕著に出る場合がある。

そのためピクセルシェーダで tangent Sign を二値化する。
この処理は URP/Lit では行われていないが、URP/Lit では tangent を `float` とすることでたまたま回避できている。
ShaderGraph 製シェーダでは本 PullReq と同様の処理がなされているように読める。

UniVRM では UniGLTF の `ImporterContext` でのメッシュ生成時に `Mesh.RecalculateTangents()` を呼び出しているため、法線マップを利用するすべての glTF, VRM0.X, VRM1.0 に影響する。
https://github.com/vrm-c/UniVRM/blob/5885004730eb6843f61f6251f5fb4eb9d41adb70/Assets/UniGLTF/Runtime/UniGLTF/IO/MeshIO/MeshUploader.cs#L113

したがって根本的には、よりよい tangent 計算手法に置き換える必要があるが、本 PullReq では行わない。

図１：細かいが、黒線のアーティファクト。NaN のため、Bloom などをかけると非常に拡散する。
![image](https://github.com/user-attachments/assets/4146b19f-b90b-479a-8a01-e4580a500601)

図２：図１と同じところを映して `tangentWS.w * 0.5 + 0.5` を可視化したもの。同じポリゴン内で符号が異なり、補間されていることが分かる。
![image](https://github.com/user-attachments/assets/f5999c59-1ca7-4713-9435-e8955c2ff381)
