### PR TITLE
prefab instanciate 向けのマテリアルコピー器 => #2685 採用

### DIFF
--- a/Assets/UniGLTF/Runtime/UniGLTF/CopyMaterialsOnAwake.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/CopyMaterialsOnAwake.cs
@@ -26,10 +26,8 @@ namespace UniGLTF
     {
         Dictionary<Material, Material> copyMap = new();
 
-        // public for show on inspector(debug)
-        public List<Material> originalMaterials;
-        // public for show on inspector(debug)
-        public List<Material> copyMaterials;
+        private List<Material> originalMaterials;
+        private List<Material> copyMaterials;
 
         Material GetOrCopyMaterial(Material src)
         {

--- a/Assets/UniGLTF/Runtime/UniGLTF/CopyMaterialsOnAwake.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/CopyMaterialsOnAwake.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UniGLTF
+{
+    /// <summary>
+    /// https://github.com/vrm-c/UniVRM/issues/2675
+    /// https://github.com/vrm-c/UniVRM/pull/2677
+    /// 
+    /// Resolves unintended material sharing between two models.
+    /// 
+    /// example
+    /// ```cs
+    /// GameObject prefab;
+    /// 
+    /// var vrm1 = Instantiate(prefab)
+    /// var vrm2 = Instantiate(prefab)
+    /// // vrm1 and vrm2 sharing same material
+    /// 
+    /// // use copy
+    /// vrm1.AddComponent<CopyMaterialsOnAwake>();
+    /// vrm2.AddComponent<CopyMaterialsOnAwake>();
+    /// ```
+    /// </summary>
+    public class CopyMaterialsOnAwake : MonoBehaviour
+    {
+        Dictionary<Material, Material> copyMap = new();
+
+        // public for show on inspector(debug)
+        public List<Material> originalMaterials;
+        // public for show on inspector(debug)
+        public List<Material> copyMaterials;
+
+        Material GetOrCopyMaterial(Material src)
+        {
+            if (!src)
+            {
+                return default;
+            }
+
+            if (copyMap.TryGetValue(src, out var copy))
+            {
+                return copy;
+            }
+
+            copy = new Material(src);
+            // copy.name = src.name + ".copy";
+            // Debug.Log($"copy {src} to {copy}");
+            // 名前を変えてはだめ。vrm Expression が動かない
+            copyMap.Add(src, copy);
+            originalMaterials.Add(src);
+            copyMaterials.Add(copy);
+            return copy;
+        }
+
+        void Awake()
+        {
+            foreach (var r in GetComponentsInChildren<Renderer>())
+            {
+                var sharedMaterials = r.sharedMaterials;
+                for (int i = 0; i < sharedMaterials.Length; ++i)
+                {
+                    var m = sharedMaterials[i];
+                    var replace = GetOrCopyMaterial(m);
+                    sharedMaterials[i] = replace;
+                }
+                r.sharedMaterials = sharedMaterials;
+            }
+        }
+
+        void OnDestroy()
+        {
+            foreach (var copy in copyMaterials)
+            {
+                UniGLTFLogger.Log($"GetOrCopyMaterial.OnDestroy: destroy {copy}");
+                Material.Destroy(copy);
+            }
+        }
+    }
+}

--- a/Assets/UniGLTF/Runtime/UniGLTF/CopyMaterialsOnAwake.cs.meta
+++ b/Assets/UniGLTF/Runtime/UniGLTF/CopyMaterialsOnAwake.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e701a21874e118439f052114717f4c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
fixed #2675

#2677 に関連。

#2582 も。

# 起きている事象

- コードによる prefab instanciate もしくは prefab のシーン配置により、単一の prefab から複数の instance を生成
- 意図しない material の共有が発生する
- vrm の expression を通して material を操作すると、共有されたモデルすべてに結果が反映される(そのフレームの一番最後に実行したもので上書きされる)

# 備考

- material copy により、material 共有を解消する
- vrm0 と vrm1 共用にできる
- 既存の RuntimeLoad 運用に影響しない
- OnDestroy
