### PR TITLE
SpringBoneJobsのBurst対応シンボルの有効化

### DIFF
--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/SpringBoneJobs.asmdef
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/SpringBoneJobs.asmdef
@@ -2,7 +2,8 @@
     "name": "SpringBoneJobs",
     "rootNamespace": "",
     "references": [
-        "GUID:8d76e605759c3f64a957d63ef96ada7c"
+        "GUID:8d76e605759c3f64a957d63ef96ada7c",
+        "GUID:2665a8d13d1b3f18800f46e256720795"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -11,6 +12,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.burst",
+            "expression": "0.01",
+            "define": "ENABLE_SPRINGBONE_BURST"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
SpringBoneJobs.asmdef にて Burstパッケージが存在する場合に ENABLE_SPRINGBONE_BURST シンボルを有効化する定義を追加しました。
FastSpringBone10.asmdef と同様の定義内容です。