### PR TITLE
FastSpringBoneジョブのJobHandleをより柔軟に扱えるようにする変更

### DIFF
--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneScheduler.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/FastSpringBoneScheduler.cs
@@ -18,9 +18,13 @@ namespace UniGLTF.SpringBoneJobs
             _bufferCombiner.Dispose();
         }
 
-        public JobHandle Schedule(float deltaTime)
+        public JobHandle Schedule(float deltaTime, JobHandle? dependency = null)
         {
             var handle = _bufferCombiner.ReconstructIfDirty(default);
+            if(dependency.HasValue)
+            {
+                handle = JobHandle.CombineDependencies(handle, dependency.Value);
+            }
             if (!_bufferCombiner.HasBuffer)
             {
                 return handle;

--- a/Assets/VRM10/Runtime/FastSpringBone/FastSpringBoneService.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/FastSpringBoneService.cs
@@ -1,4 +1,5 @@
 using UniGLTF.SpringBoneJobs;
+using Unity.Jobs;
 using UnityEngine;
 
 namespace UniVRM10.FastSpringBones
@@ -96,11 +97,16 @@ namespace UniVRM10.FastSpringBones
 
         public void ManualUpdate(float deltaTime)
         {
+            ManualUpdate(deltaTime, null).Complete();
+        }
+        
+        public JobHandle ManualUpdate(in float deltaTime, in JobHandle? dependency = null)
+        {
             if (UpdateType != UpdateTypes.Manual)
             {
                 throw new global::System.ArgumentException("require UpdateTypes.Manual");
             }
-            _fastSpringBoneScheduler.Schedule(deltaTime).Complete();
+            return _fastSpringBoneScheduler.Schedule(deltaTime, dependency);
         }
 
         public void OnDrawGizmosSelected()


### PR DESCRIPTION
HybridECS環境など、独自のJob管理を行いたい場合のオプションとして、FastSpringBone Job の JobHandle を受け取ることができる ManualUpdate のオーバーロードを追加しました