### PR TITLE
[github action] find installed unity

### DIFF
--- a/.github/workflows/create-unitypackage.yml
+++ b/.github/workflows/create-unitypackage.yml
@@ -33,7 +33,7 @@ jobs:
         UNITY_VERSION=`cat ${PROJECT_VERSION_PATH} | sed -n -E "s/^m_EditorVersion:\s+//p" | head -n 1`
         UNITY_CHANGESET=`cat ${PROJECT_VERSION_PATH} | sed -n -E "s/^m_EditorVersionWithRevision:\s+\S+\s+\((\S+)\)/\1/p" | head -n 1`
         UNITY_EDITOR_EXECUTABLE=`"${UNITY_HUB}" -- --headless editors --installed | \
-          sed -n -E "s/^${UNITY_VERSION} , installed at //p" | \
+          sed -n -E "s/^${UNITY_VERSION} installed at //p" | \
           head -n 1`
 
         if [ -z "${UNITY_EDITOR_EXECUTABLE}" ]; then


### PR DESCRIPTION
# Unity Hub 3.14.0

```
$ "C:\Program Files\Unity Hub\Unity Hub.exe" -- --headless editors --installed
2021.3.27f1 installed at C:\Program Files\Unity\Hub\Editor\2021.3.27f1\Editor\Unity.exe
2022.3.52f1 installed at C:\Program Files\Unity\Hub\Editor\2022.3.52f1\Editor\Unity.exe
6000.0.49f1 installed at C:\Program Files\Unity\Hub\Editor\6000.0.49f1\Editor\Unity.exe
```

UnityHub のバージョンアップ(3.12くらい？)で出力が変わったと思われるのだが、
`UnityHubの過去バージョン` を入手することができないので検証できない 😠 

