### PR TITLE
migrate MuscleInspectorEditor to generic IMGUI TreeView API (Unity 6000) and fix RowGUIArgs usage

### DIFF
--- a/Assets/UniGLTF/Editor/UniHumanoid/MuscleInspectorEditor.cs
+++ b/Assets/UniGLTF/Editor/UniHumanoid/MuscleInspectorEditor.cs
@@ -1,20 +1,16 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
-
 
 namespace UniHumanoid
 {
     class BoneNode : IEnumerable<BoneNode>
     {
         public HumanBodyBones Bone { get; private set; }
-
         public List<BoneNode> Children = new List<BoneNode>();
-
         public int[] Muscles;
 
         public BoneNode(HumanBodyBones bone, params int[] muscles)
@@ -25,45 +21,33 @@ namespace UniHumanoid
 
         public IEnumerator<BoneNode> GetEnumerator()
         {
-            throw new NotImplementedException();
+            yield return this;
+            foreach (var c in Children)
+            {
+                foreach (var n in c) yield return n;
+            }
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            throw new NotImplementedException();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public void Add(BoneNode child)
-        {
-            Children.Add(child);
-        }
+        public void Add(BoneNode child) => Children.Add(child);
     }
 
-    class BoneTreeViewItem : TreeViewItem
+    class BoneTreeViewItem : TreeViewItem<int>
     {
-        //HumanBodyBones m_bone;
-
-        public BoneTreeViewItem(int id, int depth, HumanBodyBones bone) : base(id, depth, bone.ToString())
-        {
-            //m_bone = bone;
-        }
+        public BoneTreeViewItem(int id, int depth, HumanBodyBones bone) : base(id, depth, bone.ToString()) { }
     }
 
-    class MuscleTreeViewItem : TreeViewItem
+    class MuscleTreeViewItem : TreeViewItem<int>
     {
-        public int Muscle
-        {
-            get;
-            private set;
-        }
-
+        public int Muscle { get; private set; }
         public MuscleTreeViewItem(int id, int depth, int muscle) : base(id, depth, HumanTrait.MuscleName[muscle])
         {
             Muscle = muscle;
         }
     }
 
-    class BoneTreeView : TreeView
+    class BoneTreeView : TreeView<int>
     {
         static BoneNode Skeleton = new BoneNode(HumanBodyBones.Hips)
         {
@@ -109,10 +93,8 @@ namespace UniHumanoid
             }
         };
 
-        //Animator m_animator;
         HumanPoseHandler m_handler;
         HumanPose m_pose;
-
         bool m_updated;
 
         public void Begin()
@@ -129,24 +111,21 @@ namespace UniHumanoid
             m_updated = false;
         }
 
-        public BoneTreeView(TreeViewState treeViewState, MultiColumnHeader header, HumanPoseHandler handler)
+        public BoneTreeView(TreeViewState<int> treeViewState, MultiColumnHeader header, HumanPoseHandler handler)
             : base(treeViewState, header)
         {
             m_handler = handler;
             Reload();
         }
 
-        protected override TreeViewItem BuildRoot()
+        protected override TreeViewItem<int> BuildRoot()
         {
-            return new TreeViewItem { id = 0, depth = -1 };
+            return new TreeViewItem<int> { id = 0, depth = -1 };
         }
 
-        protected override IList<TreeViewItem> BuildRows(TreeViewItem root)
+        protected override IList<TreeViewItem<int>> BuildRows(TreeViewItem<int> root)
         {
-            var rows = GetRows() ?? new List<TreeViewItem>(200);
-
-            // We use the GameObject instanceIDs as ids for items as we want to 
-            // select the game objects and not the transform components.
+            var rows = GetRows() ?? new List<TreeViewItem<int>>(200);
             rows.Clear();
 
             var item = CreateTreeViewItemForBone(HumanBodyBones.Hips);
@@ -163,14 +142,14 @@ namespace UniHumanoid
             }
 
             SetupDepthsFromParentsAndChildren(root);
-
             return rows;
         }
 
-        void AddChildrenRecursive(BoneNode bone, TreeViewItem item, IList<TreeViewItem> rows)
+        void AddChildrenRecursive(BoneNode bone, TreeViewItem<int> item, IList<TreeViewItem<int>> rows)
         {
             int childCount = bone.Children.Count;
-            item.children = new List<TreeViewItem>(childCount);
+            item.children = new List<TreeViewItem<int>>(childCount);
+
             if (bone.Muscles != null)
             {
                 foreach (var muscle in bone.Muscles)
@@ -187,26 +166,24 @@ namespace UniHumanoid
                 item.AddChild(childItem);
                 rows.Add(childItem);
 
-                //if (child.Children.Count > 0)
+                if (IsExpanded(childItem.id))
                 {
-                    if (IsExpanded(childItem.id))
-                    {
-                        AddChildrenRecursive(child, childItem, rows);
-                    }
-                    else
-                    {
-                        childItem.children = CreateChildListForCollapsedParent();
-                    }
+                    AddChildrenRecursive(child, childItem, rows);
+                }
+                else
+                {
+                    childItem.children = CreateChildListForCollapsedParent();
                 }
             }
         }
 
-        static TreeViewItem CreateTreeViewItemForBone(HumanBodyBones bone)
+        static TreeViewItem<int> CreateTreeViewItemForBone(HumanBodyBones bone)
         {
-            return new TreeViewItem((int)bone, -1, Enum.GetName(typeof(HumanBodyBones), bone));
+            return new BoneTreeViewItem((int)bone, -1, bone);
         }
 
-        protected override void RowGUI(RowGUIArgs args)
+        // inside class BoneTreeView : TreeView<int>
+        protected override void RowGUI(UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs args)
         {
             for (int i = 0; i < args.GetNumVisibleColumns(); ++i)
             {
@@ -214,41 +191,33 @@ namespace UniHumanoid
             }
         }
 
-        void CellGUI(Rect cellRect, int index, ref RowGUIArgs args)
+        void CellGUI(Rect cellRect, int index, ref UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs args)
         {
-            // Center cell rect vertically (makes it easier to place controls, icons etc in the cells)
             CenterRectUsingSingleLineHeight(ref cellRect);
 
             switch (index)
             {
                 case 0:
-                    {
-                        // Default icon and label
-                        args.rowRect = cellRect;
-                        base.RowGUI(args);
-                    }
+                {
+                    args.rowRect = cellRect;
+                    base.RowGUI(args);
                     break;
-
+                }
                 case 1:
+                {
+                    if (args.item is MuscleTreeViewItem muscleItem)
                     {
-                        var muscleItem = args.item as MuscleTreeViewItem;
-                        if (muscleItem != null)
+                        var muscleIndex = muscleItem.Muscle;
+                        var muscles = m_pose.muscles;
+                        var value = EditorGUI.Slider(cellRect, GUIContent.none, muscles[muscleIndex], -1f, 1f);
+                        if (!Mathf.Approximately(value, muscles[muscleIndex]))
                         {
-                            var muscleIndex = muscleItem.Muscle;
-                            var muscles = m_pose.muscles;
-                            var value = EditorGUI.Slider(cellRect, GUIContent.none, muscles[muscleIndex], -1f, 1f);
-                            if (value != muscles[muscleIndex])
-                            {
-                                muscles[muscleIndex] = value;
-                                m_updated = true;
-                            }
-                        }
-                        else
-                        {
-
+                            muscles[muscleIndex] = value;
+                            m_updated = true;
                         }
                     }
                     break;
+                }
             }
         }
 
@@ -278,32 +247,24 @@ namespace UniHumanoid
         }
     }
 
-
     [CustomEditor(typeof(MuscleInspector))]
     public class MuscleInspectorEditor : Editor
     {
         [NonSerialized] bool m_Initialized;
-        [SerializeField] TreeViewState m_TreeViewState; // Serialized in the window layout file so it survives assembly reloading
-        //[SerializeField] MultiColumnHeaderState m_MultiColumnHeaderState;
+
+        // Note: Unity 6000 recommends generic state. It's fine if this isn't serialized by Unity's object serializer;
+        // the TreeView manages its own persistence in editor layouts.
+        [SerializeField] TreeViewState<int> m_TreeViewState;
+
         SearchField m_SearchField;
         BoneTreeView m_TreeView;
 
         MuscleInspector m_target;
         HumanPoseHandler m_handler;
 
-
         MultiColumnHeader GetHeaderState()
         {
-            //bool firstInit = m_MultiColumnHeaderState == null;
-
             var headerState = BoneTreeView.CreateDefaultMultiColumnHeaderState();
-            /*
-            if (MultiColumnHeaderState.CanOverwriteSerializedFields(m_MultiColumnHeaderState, headerState))
-            {
-                MultiColumnHeaderState.OverwriteSerializedFields(m_MultiColumnHeaderState, headerState);
-            }
-            m_MultiColumnHeaderState = headerState;
-            */
             var multiColumnHeader = new MultiColumnHeader(headerState);
             multiColumnHeader.ResizeToFit();
             return multiColumnHeader;
@@ -311,17 +272,19 @@ namespace UniHumanoid
 
         void OnEnable()
         {
-            var mi = this.target as MuscleInspector;
-            if (mi.TryGetComponent<Animator>(out var animator)
-            && animator.avatar != null
-            && animator.avatar.isValid
-            && animator.avatar.isHuman
-            )
+            var mi = target as MuscleInspector;
+            if (mi != null &&
+                mi.TryGetComponent<Animator>(out var animator) &&
+                animator.avatar != null &&
+                animator.avatar.isValid &&
+                animator.avatar.isHuman)
             {
                 UniGLTF.UniGLTFLogger.Log("MuscleInspectorEditor.OnEnable");
                 m_handler = new HumanPoseHandler(animator.avatar, animator.transform);
 
-                m_TreeView = new BoneTreeView(new TreeViewState(), GetHeaderState(), m_handler);
+                // Use existing state if available, else create a new one
+                if (m_TreeViewState == null) m_TreeViewState = new TreeViewState<int>();
+                m_TreeView = new BoneTreeView(m_TreeViewState, GetHeaderState(), m_handler);
             }
         }
 


### PR DESCRIPTION

<img width="2559" height="1003" alt="image" src="https://github.com/user-attachments/assets/431e4b77-9775-4c97-af64-f8b8d0d4ba5f" />


## English — Detailed Description

### What problem was fixed?

1. **Obsolete API warnings (CS0618)** in Unity 6000+:

* `TreeViewItem` → obsolete
* `TreeView` → obsolete
* `TreeViewState` → obsolete

Unity’s editor IMGUI TreeView API was upgraded to *generic* types, which deprecates the old non-generic classes.

2. **Compilation error**:

> `Struct 'UnityEditor.IMGUI.Controls.TreeView<TIdentifier>.RowGUIArgs' does not have type parameters`

`RowGUIArgs` is a **nested, non-generic** struct inside `TreeView<TIdentifier>`. Using `RowGUIArgs<int>` is invalid; you must reference it as `UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs` (or use a `using` alias).

---

### What changed?

#### A) Migrate to the generic TreeView API

* `class BoneTreeView : TreeView` → `class BoneTreeView : TreeView<int>`
* `class BoneTreeViewItem : TreeViewItem` → `class BoneTreeViewItem : TreeViewItem<int>`
* `class MuscleTreeViewItem : TreeViewItem` → `class MuscleTreeViewItem : TreeViewItem<int>`
* `[SerializeField] TreeViewState m_TreeViewState;` → `[SerializeField] TreeViewState<int> m_TreeViewState;`

#### B) Update overridden signatures & collections to generic equivalents

* `protected override TreeViewItem BuildRoot()` → `protected override TreeViewItem<int> BuildRoot()`
* `protected override IList<TreeViewItem> BuildRows(TreeViewItem root)` → `protected override IList<TreeViewItem<int>> BuildRows(TreeViewItem<int> root)`
* `protected override void RowGUI(RowGUIArgs args)` →
  `protected override void RowGUI(UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs args)`
  (optionally alias with `using RowArgs = UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs;`)
* All lists/children now use `TreeViewItem<int>`.

#### C) Fix `RowGUIArgs` usage (non-generic nested type)

Before (invalid):

```csharp
protected override void RowGUI(RowGUIArgs<int> args) { ... }
void CellGUI(Rect r, int i, ref RowGUIArgs<int> args) { ... }
```

After (valid):

```csharp
protected override void RowGUI(UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs args) { ... }
void CellGUI(Rect r, int i, ref UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs args) { ... }
// or with alias:
// using RowArgs = UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs;
```

#### D) Implement `IEnumerable<BoneNode>`

`BoneNode.GetEnumerator()` previously threw `NotImplementedException`.
Now it yields the node and its descendants:

```csharp
public IEnumerator<BoneNode> GetEnumerator() {
    yield return this;
    foreach (var c in Children)
        foreach (var n in c)
            yield return n;
}
IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
```

#### E) Stability tweak on slider writes

Use `Mathf.Approximately` to avoid noisy float diffs:

```csharp
if (!Mathf.Approximately(value, muscles[muscleIndex])) {
    muscles[muscleIndex] = value;
    m_updated = true;
}
```

#### F) Initialize generic state on enable

```csharp
if (m_TreeViewState == null) m_TreeViewState = new TreeViewState<int>();
```

---

### How to reproduce the original issues

* Open the project in **Unity 6000.2.3f1** (URP).
* Compile editor scripts.
  You will see CS0618 warnings for `TreeView`, `TreeViewItem`, `TreeViewState`.
* If you attempt to change `RowGUIArgs` to `RowGUIArgs<int>`, compilation fails with the “does not have type parameters” error.

---

### Verification

* Open an object with `MuscleInspector` and a valid **Humanoid** avatar.
* The TreeView renders the bone hierarchy and muscle rows.
* Moving sliders updates `HumanPose` live.
* **No CS0618 warnings** remain. **No compile errors**.

---

### Compatibility notes

* This change targets Unity 6000’s generic IMGUI TreeView API.
* If you need to support older Unity versions, guard with `#if` and keep the legacy types in an `#else` block.

---

## 日本語 — 詳細説明

### 修正した問題

1. **非推奨 API 警告 (CS0618)**（Unity 6000+）
   `TreeViewItem` / `TreeView` / `TreeViewState` が**非推奨**になりました。
   Unity の IMGUI TreeView は **ジェネリック版** に刷新され、旧 API は警告が出ます。

2. **コンパイルエラー**

> `Struct 'UnityEditor.IMGUI.Controls.TreeView<TIdentifier>.RowGUIArgs' does not have type parameters`

`RowGUIArgs` は `TreeView<TIdentifier>` 内の **ネストされた非ジェネリック構造体** です。
`RowGUIArgs<int>` のように型引数は付けられません。`UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs` のように参照します（`using` エイリアス可）。

---

### 変更点

#### A) ジェネリック TreeView API への移行

* `class BoneTreeView : TreeView` → `class BoneTreeView : TreeView<int>`
* `class BoneTreeViewItem : TreeViewItem` → `class BoneTreeViewItem : TreeViewItem<int>`
* `class MuscleTreeViewItem : TreeViewItem` → `class MuscleTreeViewItem : TreeViewItem<int>`
* `[SerializeField] TreeViewState m_TreeViewState;` → `[SerializeField] TreeViewState<int> m_TreeViewState;`

#### B) オーバーライドやコレクションの型を更新

* `BuildRoot()` → `TreeViewItem<int>` を返す
* `BuildRows(TreeViewItem root)` → `BuildRows(TreeViewItem<int> root)` に変更
* `RowGUI(RowGUIArgs args)` →
  `RowGUI(UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs args)` に変更
  （`using RowArgs = UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs;` も可）
* `List<TreeViewItem>` 等を `List<TreeViewItem<int>>` に統一

#### C) `RowGUIArgs` の正しい参照（非ジェネリック）

**誤り（無効）**：

```csharp
protected override void RowGUI(RowGUIArgs<int> args) { ... }
void CellGUI(Rect r, int i, ref RowGUIArgs<int> args) { ... }
```

**正解**：

```csharp
protected override void RowGUI(UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs args) { ... }
void CellGUI(Rect r, int i, ref UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs args) { ... }
// or: using RowArgs = UnityEditor.IMGUI.Controls.TreeView<int>.RowGUIArgs;
```

#### D) `IEnumerable<BoneNode>` を実装

`GetEnumerator()` が `NotImplementedException` を投げていたため、
木構造を列挙できるように修正：

```csharp
public IEnumerator<BoneNode> GetEnumerator() {
    yield return this;
    foreach (var c in Children)
        foreach (var n in c)
            yield return n;
}
IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
```

#### E) スライダーの比較を安定化

浮動小数の微小差で更新が走らないよう `Mathf.Approximately` を使用：

```csharp
if (!Mathf.Approximately(value, muscles[muscleIndex])) {
    muscles[muscleIndex] = value;
    m_updated = true;
}
```

#### F) 有効化時にジェネリック状態を初期化

```csharp
if (m_TreeViewState == null) m_TreeViewState = new TreeViewState<int>();
```

---

### 元の問題の再現手順

* **Unity 6000.2.3f1**（URP）でプロジェクトを開く。
* エディタースクリプトをコンパイルすると、旧 API で **CS0618 警告**が出ます。
* `RowGUIArgs<int>` を使うと「型パラメータが無い」という**コンパイルエラー**になります。

---

### 動作確認

* `MuscleInspector` を持ち、**Humanoid** アバターが有効な `Animator` をアタッチしたオブジェクトを選択。
* TreeView がボーン階層と筋肉スライダーを表示。
* スライダー操作で `HumanPose` が即時更新。
* **CS0618 警告なし**、**コンパイルエラーなし**。

---

### 互換性

* この修正は Unity 6000 のジェネリック IMGUI TreeView API を前提としています。
* 旧バージョンもサポートする場合は、`#if` ディレクティブでレガシー型の実装を併存させてください。

---