### PR TITLE
Change RenderPipelineUtility to use GraphicsSettings.currentRenderPipeline

### DIFF
--- a/Packages/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineUtility.cs
+++ b/Packages/UniGLTF/Runtime/UniGLTF/IO/MaterialIO/RenderPipelineUtility.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine.Rendering;
+using UnityEngine.Rendering;
 
 namespace UniGLTF
 {
@@ -6,19 +6,19 @@ namespace UniGLTF
     {
         public static RenderPipelineTypes GetRenderPipelineType()
         {
-            RenderPipeline currentPipeline = RenderPipelineManager.currentPipeline;
+            RenderPipelineAsset currentRenderPipelineAsset = GraphicsSettings.currentRenderPipeline;
 
-            if (currentPipeline == null)
+            if (currentRenderPipelineAsset == null)
             {
                 return RenderPipelineTypes.BuiltinRenderPipeline;
             }
 
-            if (currentPipeline.GetType().Name.Contains("HDRenderPipeline"))
+            if (currentRenderPipelineAsset.GetType().Name.Contains("HDRenderPipeline"))
             {
                 return RenderPipelineTypes.HighDefinitionRenderPipeline;
             }
 
-            if (currentPipeline.GetType().Name.Contains("UniversalRenderPipeline"))
+            if (currentRenderPipelineAsset.GetType().Name.Contains("UniversalRenderPipeline"))
             {
                 return RenderPipelineTypes.UniversalRenderPipeline;
             }


### PR DESCRIPTION
#2740 

Changes the use of `RenderPipelineManager.currentPipeline` in `RenderPipelineUtility.GetRenderPipelineType()` which isn't valid for the first few frames, to `GraphicsSettings.currentRenderPipeline`, which is.