### PR TITLE
unitypackage 作成を Packages 下に対応させました

### DIFF
--- a/Packages/VRM/Editor/Format/VRMSampleCopy.cs
+++ b/Packages/VRM/Editor/Format/VRMSampleCopy.cs
@@ -21,9 +21,9 @@ namespace VRM
         }
 
         static CopyInfo[] CopyList = new CopyInfo[]{
-            new CopyInfo(Path.Combine(Application.dataPath, "VRM_Samples"), Path.Combine(Application.dataPath, "VRM/Samples~")),
-            new CopyInfo(Path.Combine(Application.dataPath, "VRM10_Samples"), Path.Combine(Application.dataPath, "VRM10/Samples~")),
-            new CopyInfo(Path.Combine(Application.dataPath, "UniGLTF_Samples"), Path.Combine(Application.dataPath, "UniGLTF/Samples~")),
+            new CopyInfo(Path.Combine(Application.dataPath, "VRM_Samples"), Path.Combine(Application.dataPath, "../Packages/VRM/Samples~")),
+            new CopyInfo(Path.Combine(Application.dataPath, "VRM10_Samples"), Path.Combine(Application.dataPath, "../Packages/VRM10/Samples~")),
+            new CopyInfo(Path.Combine(Application.dataPath, "UniGLTF_Samples"), Path.Combine(Application.dataPath, "../Packages/UniGLTF/Samples~")),
         };
 
         /// <summary>


### PR DESCRIPTION
#2736

従来の AssetDatabase.ExportPackage では Packages 下のファイルを渡すとエラーになります。
internal PackageUtility.ExportPackage は Package の unitypackage 化ができます。

あわせて、フォルダー下のファイルを集める関数
internal AssetDatabase.CollectAllChildren も使いました。

unitypackage 版もパッケージマネージャーから Sample をインストールできるようになったので、独立した sample パッケージは廃止となります( 本体に含まれている )。