### PR TITLE
Fixes texture importing issue when images[].uri is Data URI and images[].mimeType is empty

### DIFF
--- a/Packages/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs
+++ b/Packages/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs
@@ -397,6 +397,24 @@ namespace UniGLTF
             {
                 return null;
             }
+
+            // for Data URI
+            if (uri.StartsWith("data:", StringComparison.Ordinal))
+            {
+                var headerEnd = uri.IndexOf(',');
+                if (headerEnd < 0)
+                {
+                    return null;
+                }
+
+                const int dataPrefixLength = 5; // "data:".Length
+                var header = uri[dataPrefixLength..headerEnd];
+                var semicolonPos = header.IndexOf(';');
+                var mime = semicolonPos >= 0 ? header[..semicolonPos] : header;
+
+                return mime is "image/png" or "image/jpeg" ? mime : null;
+            }
+
             var ext = System.IO.Path.GetExtension(uri).ToLowerInvariant();
             switch (ext)
             {


### PR DESCRIPTION
## 概要

glTFファイルの`images[].uri`がData URI形式で、`images[].mimeType`が省略されている場合にテクスチャを正しく読み込めない問題を修正しました。

## 問題

- `images[].uri`がData URI（例: `data:image/png;base64,...`）かつ`images[].mimeType`が未指定の場合、テクスチャの読み込みに失敗していた
- glTF 2.0仕様では`mimeType`はoptionalなプロパティであり（`bufferView`が定義される場合のみ必須）、省略されることがある
  - https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/image.schema.json

## 変更内容

- `mimeType`が未指定かつ`uri`がData URI形式の場合、URIのスキーム部分（`data:image/png;base64`など）から`mimeType`を抽出するロジックを追加
  - Data URI形式: `data:[<mediatype>][;base64],<data>`の`<mediatype>`部分をパースして使用
  - 既存実装に合わせてpng/jpeg以外のファイルは無視する