### PR TITLE
Fix crash when reading texture transform bind without scale

### DIFF
--- a/Packages/VRM10/Runtime/IO/ExpressionExtensions.cs
+++ b/Packages/VRM10/Runtime/IO/ExpressionExtensions.cs
@@ -60,7 +60,15 @@ namespace UniVRM10
             var binding = default(UniVRM10.MaterialUVBinding?);
             if (material != null)
             {
-                var (scale, offset) = UniGLTF.TextureTransform.VerticalFlipScaleOffset(new Vector2(bind.Scale[0], bind.Scale[1]), new Vector2(bind.Offset[0], bind.Offset[1]));
+                // Default values: scale [1, 1], offset [0, 0]
+                Vector2 scaleVec = bind.Scale != null && bind.Scale.Length >= 2
+                    ? new Vector2(bind.Scale[0], bind.Scale[1])
+                    : new Vector2(1.0f, 1.0f);
+                Vector2 offsetVec = bind.Offset != null && bind.Offset.Length >= 2
+                    ? new Vector2(bind.Offset[0], bind.Offset[1])
+                    : new Vector2(0.0f, 0.0f);
+
+                var (scale, offset) = UniGLTF.TextureTransform.VerticalFlipScaleOffset(scaleVec, offsetVec);
 
                 try
                 {


### PR DESCRIPTION
The existing code assumes that all texture binds have both offset and scale defined. However, [according to the schema](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/schema/VRMC_vrm.expressions.expression.textureTransformBind.schema.json), neither of these are required properties, and both of which have default values. UniVRM will fail to import files where at least one of these is not defined or has insufficient length. This PR fixes the problem by first checking if the array is long enough, and if not, using the default values.