### PR TITLE
Fix RebuildHumanAvatar so it works in play mode

### DIFF
--- a/Packages/UniGLTF/Runtime/UniHumanoid/HumanoidLoader.cs
+++ b/Packages/UniGLTF/Runtime/UniHumanoid/HumanoidLoader.cs
@@ -55,7 +55,10 @@ namespace UniHumanoid
         /// HumanBone のマッピングを流用して、新たな Avatar を作り直す。
         /// 古い Avatar は破棄する。
         /// </summary>
-        public static void RebuildHumanAvatar(Animator animator)
+        /// <remarks>
+        /// This method runs asynchronously only in play mode.
+        /// </remarks>
+        public static async Awaitable RebuildHumanAvatar(Animator animator)
         {
             if (animator == null)
             {
@@ -77,6 +80,9 @@ namespace UniHumanoid
             if (Application.isPlaying)
             {
                 GameObject.Destroy(animator);
+
+                // Else, the following AddComponent call will fail.
+                await Awaitable.NextFrameAsync();
             }
             else
             {

--- a/Packages/VRM/Runtime/SkinnedMeshUtility/VRMBoneNormalizer.cs
+++ b/Packages/VRM/Runtime/SkinnedMeshUtility/VRMBoneNormalizer.cs
@@ -53,7 +53,10 @@ namespace VRM
         /// <param name="go">対象モデルのルート</param>
         /// <param name="forceTPose">強制的にT-Pose化するか</param>
         /// <param name="useCurrentBlendShapeWeight">BlendShape の現状をbakeするか</param>
-        public static void Execute(GameObject go, bool forceTPose, bool useCurrentBlendShapeWeight)
+        /// <remarks>
+        /// This method runs asynchronously only in play mode.
+        /// </remarks>
+        public static async Awaitable Execute(GameObject go, bool forceTPose, bool useCurrentBlendShapeWeight)
         {
             if (forceTPose)
             {
@@ -83,7 +86,7 @@ namespace VRM
             // 回転とスケールが除去された新しいヒエラルキーからAvatarを作る
             if (go.TryGetComponent<Animator>(out var animator))
             {
-                HumanoidLoader.RebuildHumanAvatar(animator);
+                await HumanoidLoader.RebuildHumanAvatar(animator);
             }
         }
 


### PR DESCRIPTION
Object.Destroy takes a frame to fully take effect. You cannot destroy a component and add a new one of the same type in the same frame if it does not allow multiple instances. Object.DestroyImmediate cannot be used in play mode and in builds.

The existing editor code that calls these functions does not need to change because the asynchronous code path is not taken in that case.