### PR TITLE
Editor Importer Optimization: AssetDatabase StartAssetEditing & StopAssetEditing blocks

### DIFF
--- a/Packages/UniGLTF/Editor/UniGLTF/ScriptedImporter/TextureExtractor.cs
+++ b/Packages/UniGLTF/Editor/UniGLTF/ScriptedImporter/TextureExtractor.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityEngine;
-using UnityEditor;
 using System.Linq;
+using Unity.Profiling;
+using UnityEditor;
+using UnityEngine;
 
 namespace UniGLTF
 {
@@ -19,6 +20,9 @@ namespace UniGLTF
         public readonly Dictionary<SubAssetKey, UnityPath> Textures = new Dictionary<SubAssetKey, UnityPath>();
         private readonly IReadOnlyDictionary<SubAssetKey, Texture> m_subAssets;
         UnityPath m_textureDirectory;
+
+        private static ProfilerMarker s_MarkerStartExtractTextures = new ProfilerMarker("Start Extract Textures");
+        private static ProfilerMarker s_MarkerDelayedExtractTextures = new ProfilerMarker("Delayed Extract Textures");
 
         public TextureExtractor(GltfData data, UnityPath textureDirectory, IReadOnlyDictionary<SubAssetKey, Texture> subAssets)
         {
@@ -77,14 +81,20 @@ namespace UniGLTF
             Action<SubAssetKey, Texture2D> addRemap,
             Action<IEnumerable<UnityPath>> onCompleted = null)
         {
+            s_MarkerStartExtractTextures.Begin();
+
             var extractor = new TextureExtractor(data, textureDirectory, subAssets);
             foreach (var param in textureDescriptorGenerator.Get().GetEnumerable())
             {
                 extractor.Extract(param.SubAssetKey, param);
             }
 
+            s_MarkerStartExtractTextures.End();
+
             EditorApplication.delayCall += () =>
             {
+                s_MarkerDelayedExtractTextures.Begin();
+
                 // Wait for the texture assets to be imported
 
                 foreach (var (key, targetPath) in extractor.Textures)
@@ -96,6 +106,8 @@ namespace UniGLTF
                         addRemap(key, externalObject);
                     }
                 }
+
+                s_MarkerDelayedExtractTextures.End();
 
                 if (onCompleted != null)
                 {

--- a/Packages/UniGLTF/Editor/UniGLTF/ScriptedImporter/TextureExtractor.cs
+++ b/Packages/UniGLTF/Editor/UniGLTF/ScriptedImporter/TextureExtractor.cs
@@ -84,9 +84,22 @@ namespace UniGLTF
             s_MarkerStartExtractTextures.Begin();
 
             var extractor = new TextureExtractor(data, textureDirectory, subAssets);
-            foreach (var param in textureDescriptorGenerator.Get().GetEnumerable())
+            try
             {
-                extractor.Extract(param.SubAssetKey, param);
+                AssetDatabase.StartAssetEditing();
+
+                foreach (var param in textureDescriptorGenerator.Get().GetEnumerable())
+                {
+                    extractor.Extract(param.SubAssetKey, param);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
             }
 
             s_MarkerStartExtractTextures.End();

--- a/Packages/VRM/Editor/Format/VRMEditorImporterContext.cs
+++ b/Packages/VRM/Editor/Format/VRMEditorImporterContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UniGLTF;
+using Unity.Profiling;
 using UnityEditor;
 using UnityEngine;
 
@@ -11,6 +12,8 @@ namespace VRM
         VRMImporterContext m_context;
         UnityPath m_prefabPath;
         List<UnityPath> m_paths = new List<UnityPath>();
+
+        private static ProfilerMarker s_MarkerConvertAndExtractImages = new ProfilerMarker("Convert and Extract Images");
 
         public ITextureDescriptorGenerator TextureDescriptorGenerator => m_context.TextureDescriptorGenerator;
 
@@ -76,22 +79,27 @@ namespace VRM
         /// </summary>
         public void ConvertAndExtractImages(Action<IEnumerable<UnityPath>> onTextureReloaded)
         {
+            s_MarkerConvertAndExtractImages.Begin();
+
             //
             // convert images(metallic roughness, occlusion map)
             //
             var task = m_context.LoadMaterialsAsync(new ImmediateCaller());
             if (!task.IsCompleted)
             {
+                s_MarkerConvertAndExtractImages.End();
                 throw new Exception();
             }
             if (task.IsFaulted)
             {
                 if (task.Exception is AggregateException ae && ae.InnerExceptions.Count == 1)
                 {
+                    s_MarkerConvertAndExtractImages.End();
                     throw ae.InnerException;
                 }
                 else
                 {
+                    s_MarkerConvertAndExtractImages.End();
                     throw task.Exception;
                 }
             }
@@ -100,6 +108,7 @@ namespace VRM
             var task2 = m_context.ReadMetaAsync(new ImmediateCaller());
             if (!task2.IsCompleted || task2.IsCanceled || task2.IsFaulted)
             {
+                s_MarkerConvertAndExtractImages.End();
                 throw new Exception();
             }
 
@@ -110,6 +119,8 @@ namespace VRM
             var vrmTextures = new BuiltInVrmMaterialDescriptorGenerator(m_context.VRM);
             var dirName = $"{m_prefabPath.FileNameWithoutExtension}.Textures";
             TextureExtractor.ExtractTextures(m_context.Data, m_prefabPath.Parent.Child(dirName), m_context.TextureDescriptorGenerator, subAssets, (_x, _y) => { }, onTextureReloaded);
+
+            s_MarkerConvertAndExtractImages.End();
         }
 
         void SaveAsAsset(SubAssetKey _, UnityEngine.Object o)

--- a/Packages/VRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Packages/VRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UniGLTF;
+using Unity.Profiling;
 using UnityEditor;
 using UnityEngine;
 
@@ -10,6 +11,8 @@ namespace VRM
 {
     public class vrmAssetPostprocessor : AssetPostprocessor
     {
+        private static ProfilerMarker s_MarkerCreatePrefab = new ProfilerMarker("Create Prefab");
+
 #if !VRM_STOP_ASSETPOSTPROCESSOR
         static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
         {
@@ -76,6 +79,8 @@ namespace VRM
             /// <value></value>
             Action<IEnumerable<UnityPath>> onCompleted = texturePaths =>
             {
+                s_MarkerCreatePrefab.Begin();
+
                 var map = texturePaths
                     .Select(x => x.LoadAsset<Texture>())
                     .ToDictionary(x => new SubAssetKey(x), x => x as UnityEngine.Object);
@@ -93,6 +98,9 @@ namespace VRM
                     var loaded = context.Load();
                     editor.SaveAsAsset(loaded);
                 }
+
+
+                s_MarkerCreatePrefab.End();
 
                 sw.Stop();
 

--- a/Packages/VRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Packages/VRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -84,21 +84,35 @@ namespace VRM
                 var map = texturePaths
                     .Select(x => x.LoadAsset<Texture>())
                     .ToDictionary(x => new SubAssetKey(x), x => x as UnityEngine.Object);
-                var settings = new ImporterContextSettings();
 
-                // 確実に Dispose するために敢えて再パースしている
-                using (var data = new GlbFileParser(vrmPath).Parse())
-                using (var context = new VRMImporterContext(new VRMData(data), externalObjectMap: map, settings: settings))
+                try
                 {
-                    var editor = new VRMEditorImporterContext(context, prefabPath);
-                    foreach (var textureInfo in context.TextureDescriptorGenerator.Get().GetEnumerable())
-                    {
-                        TextureImporterConfigurator.Configure(textureInfo, context.TextureFactory.ExternalTextures);
-                    }
-                    var loaded = context.Load();
-                    editor.SaveAsAsset(loaded);
-                }
+                    AssetDatabase.StartAssetEditing();
 
+                    var settings = new ImporterContextSettings();
+
+                    // 確実に Dispose するために敢えて再パースしている
+                    using (var data = new GlbFileParser(vrmPath).Parse())
+                    using (var context = new VRMImporterContext(new VRMData(data), externalObjectMap: map, settings: settings))
+                    {
+                        var editor = new VRMEditorImporterContext(context, prefabPath);
+                        foreach (var textureInfo in context.TextureDescriptorGenerator.Get().GetEnumerable())
+                        {
+                            TextureImporterConfigurator.Configure(textureInfo, context.TextureFactory.ExternalTextures);
+                        }
+                        var loaded = context.Load();
+                        editor.SaveAsAsset(loaded);
+                    }
+
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
+                finally
+                {
+                    AssetDatabase.StopAssetEditing();
+                }
 
                 s_MarkerCreatePrefab.End();
 

--- a/Packages/VRM/Editor/Format/vrmAssetPostprocessor.cs
+++ b/Packages/VRM/Editor/Format/vrmAssetPostprocessor.cs
@@ -63,6 +63,9 @@ namespace VRM
                 return;
             }
 
+            System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+            sw.Start();
+
             /// <summary>
             /// これは EditorApplication.delayCall により呼び出される。
             /// 
@@ -91,6 +94,9 @@ namespace VRM
                     editor.SaveAsAsset(loaded);
                 }
 
+                sw.Stop();
+
+                Debug.Log($"Import complete [importMs={sw.ElapsedMilliseconds}]");
             };
 
             using (var data = new GlbFileParser(vrmPath).Parse())


### PR DESCRIPTION
Setup AssetDatabase.StartAssetEditing() and AssetDatabase.StopAssetEditing() blocks around sections where the Import VRM creates assets that the Unity Editor has to import. This allows the Unity Editor to batch import operations which is generally more performant.

Only tested on a single Windows machine using 3 Vroid sample VRMs but regardless of Built-In or URP render pipeline reduces import times by almost 50% for me. Unknown if changes would be as beneficial on other OSes and hardware.

Also added timing code and some ProfilerMarkers for Import VRM to make it easier to observe performance.
