### PR TITLE
Let com.unity.cloud.gltfast claim .glb/.gltf file format

### DIFF
--- a/Packages/UniGLTF/Editor/UniGLTF.Editor.asmdef
+++ b/Packages/UniGLTF/Editor/UniGLTF.Editor.asmdef
@@ -37,7 +37,17 @@
             "name": "com.atteneder.gltfast",
             "expression": "",
             "define": "UNIGLTF_DISABLE_DEFAULT_GLTF_IMPORTER"
-        }
+        },
+		{
+			"name": "com.unity.cloud.gltfast",
+			"expression": "",
+			"define": "UNIGLTF_DISABLE_DEFAULT_GLB_IMPORTER"
+		},
+		{
+			"name": "com.unity.cloud.gltfast",
+			"expression": "",
+			"define": "UNIGLTF_DISABLE_DEFAULT_GLTF_IMPORTER"
+		}
     ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Fixes #2775 

Note: `com.atteneder.gltfast` became `com.unity.cloud.gltfast` and is now offcially own by Unity.
I just copied the previous behavior for `com.atteneder.gltfast` so it does the same for `com.unity.cloud.gltfast`.

Tested on Unity 2022.3.62f3. .glb files are now correctly handled by GLTFast while UniVRM continues to handle .vrm files.
I'm not familiar with UniVRM, I'm not sure I understand why VRM claims .glb and if it can break something they do not? This has to be reviewed by someone familiar with that part of the code.

Wether or not leave `com.atteneder.gltfast` there: I don't know. Wouldn't hurt?