### PR TITLE
Fix RestoreInitialTransform init-pose

### DIFF
--- a/Packages/VRM10/Runtime/Components/Vrm10Runtime/Springbone/Vrm10FastSpringboneRuntime.cs
+++ b/Packages/VRM10/Runtime/Components/Vrm10Runtime/Springbone/Vrm10FastSpringboneRuntime.cs
@@ -101,7 +101,7 @@ namespace UniVRM10
         public void RestoreInitialTransform()
         {
             // Spring の joint に対応する transform の回転を初期状態
-            var pose = RuntimeGltfInstance.SafeGetInitialPose(m_instance.transform);
+            var pose = m_instance.Runtime.InitPose;
             foreach (var logic in m_fastSpringBoneBuffer.Logics)
             {
                 var transform = m_fastSpringBoneBuffer.Transforms[logic.headTransformIndex];

--- a/Packages/VRM10/Runtime/Components/Vrm10Runtime/Springbone/Vrm10FastSpringboneRuntimeStandalone.cs
+++ b/Packages/VRM10/Runtime/Components/Vrm10Runtime/Springbone/Vrm10FastSpringboneRuntimeStandalone.cs
@@ -107,7 +107,7 @@ namespace UniVRM10
         public void RestoreInitialTransform()
         {
             // Spring の joint に対応する transform の回転を初期状態
-            var pose = RuntimeGltfInstance.SafeGetInitialPose(m_instance.transform);
+            var pose = m_instance.Runtime.InitPose;
             foreach (var logic in m_fastSpringBoneBuffer.Logics)
             {
                 var transform = m_fastSpringBoneBuffer.Transforms[logic.headTransformIndex];

--- a/Packages/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
+++ b/Packages/VRM10/Runtime/Components/Vrm10Runtime/Vrm10Runtime.cs
@@ -33,6 +33,7 @@ namespace UniVRM10
         public Vrm10RuntimeLookAt LookAt { get; }
         public IVrm10SpringBoneRuntime SpringBone { get; }
         public IVrm10Animation VrmAnimation { get; set; }
+        public IReadOnlyDictionary<Transform, TransformState> InitPose { get; }
 
         [Obsolete("use Vrm10Runtime.SpringBone.SetModelLevel")]
         public Vector3 ExternalForce
@@ -49,8 +50,6 @@ namespace UniVRM10
             }
         }
 
-        IReadOnlyDictionary<Transform, TransformState> _initPose;
-
         public Vrm10Runtime(Vrm10Instance instance, bool useControlRig, IVrm10SpringBoneRuntime springBoneRuntime,
             IReadOnlyDictionary<Transform, TransformState> initPose, bool isPrefabInstance)
         {
@@ -59,7 +58,7 @@ namespace UniVRM10
                 UniGLTFLogger.Warning($"{nameof(Vrm10Runtime)} expects runtime behaviour.");
             }
 
-            _initPose = initPose;
+            InitPose = initPose;
             m_instance = instance;
             if (m_instance == null)
             {
@@ -135,8 +134,8 @@ namespace UniVRM10
                 if (constraint.ConstraintSource != null)
                 {
                     constraint.Process(
-                        targetInitState: _initPose[constraint.ConstraintTarget],
-                        sourceInitState: _initPose[constraint.ConstraintSource]);
+                        targetInitState: InitPose[constraint.ConstraintTarget],
+                        sourceInitState: InitPose[constraint.ConstraintSource]);
                 }
             }
 


### PR DESCRIPTION
Fix a bug where `RestoreInitialTransform` incorrectly uses the current pose instead of the initial pose due to #2781.

Since `Vrm10Runtime` maintains `initPose`, it should be used for the restore process.