### PR TITLE
Replace math.normalize to math.normalizesafe

### DIFF
--- a/Packages/UniGLTF/Runtime/SpringBoneJobs/Anglelimit/Anglelimit.cs
+++ b/Packages/UniGLTF/Runtime/SpringBoneJobs/Anglelimit/Anglelimit.cs
@@ -18,7 +18,7 @@ namespace UniGLTF.SpringBoneJobs
                 case AnglelimitTypes.Cone:
                     {
                         var angleSpaceToWorld = anglelimitSpaceToWorld(logic, joint, parentRotation);
-                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalize(nextTail - head));
+                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalizesafe(nextTail - head));
                         tailDir = AnglelimitCone.Apply(tailDir, joint.anglelimit1);
                         return head + math.mul(angleSpaceToWorld, tailDir) * logic.length;
                     }
@@ -26,7 +26,7 @@ namespace UniGLTF.SpringBoneJobs
                 case AnglelimitTypes.Hinge:
                     {
                         var angleSpaceToWorld = anglelimitSpaceToWorld(logic, joint, parentRotation);
-                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalize(nextTail - head));
+                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalizesafe(nextTail - head));
                         tailDir = AnglelimitHinge.Apply(tailDir, joint.anglelimit1);
                         return head + math.mul(angleSpaceToWorld, tailDir) * logic.length;
                     }
@@ -35,7 +35,7 @@ namespace UniGLTF.SpringBoneJobs
                 case AnglelimitTypes.Spherical:
                     {
                         var angleSpaceToWorld = anglelimitSpaceToWorld(logic, joint, parentRotation);
-                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalize(nextTail - head));
+                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalizesafe(nextTail - head));
                         tailDir = AnglelimitSpherical.Apply(tailDir, joint.anglelimit1, joint.anglelimit2);
                         return head + math.mul(angleSpaceToWorld, tailDir) * logic.length;
                     }
@@ -84,7 +84,7 @@ namespace UniGLTF.SpringBoneJobs
 
             // General case
             // quaternion(cross(from, to); dot(from, to) + 1).normalized
-            return math.normalize(new quaternion(to.z, 0f, -to.x, dot1));
+            return math.normalizesafe(new quaternion(to.z, 0f, -to.x, dot1));
         }
     }
 }

--- a/Packages/UniGLTF/Runtime/SpringBoneJobs/Anglelimit/AnglelimitHinge.cs
+++ b/Packages/UniGLTF/Runtime/SpringBoneJobs/Anglelimit/AnglelimitHinge.cs
@@ -12,7 +12,7 @@ namespace UniGLTF.SpringBoneJobs
             // x要素を0にし、正規化する
             float3 tailDir = src;
             tailDir.x = 0.0f;
-            tailDir = math.normalize(tailDir);
+            tailDir = math.normalizesafe(tailDir);
 
             // tailDirのy要素をjointに設定されたangleの余弦と比較する
             var cosAngle = math.cos(limitAngle);

--- a/Packages/UniGLTF/Runtime/SpringBoneJobs/Blittables/BlittableTransform.cs
+++ b/Packages/UniGLTF/Runtime/SpringBoneJobs/Blittables/BlittableTransform.cs
@@ -140,7 +140,7 @@ namespace UniGLTF.SpringBoneJobs.Blittables
 
             if(parent.HasValue)
             {
-                newLocalRotation = math.normalize(math.mul(math.inverse(parent.Value.rotation), newRotation));
+                newLocalRotation = math.normalizesafe(math.mul(math.inverse(parent.Value.rotation), newRotation));
                 newLocalToWorldMatrix = math.mul(parent.Value.localToWorldMatrix, float4x4.TRS(localPosition, newLocalRotation, localScale));
             }
             else

--- a/Packages/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
+++ b/Packages/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
@@ -125,7 +125,7 @@ namespace UniGLTF.SpringBoneJobs.InputPorts
                     parentTransformIndex: Array.IndexOf<Transform>(Transforms, joint.Transform.parent),
                     tailTransformIndex: Array.IndexOf<Transform>(Transforms, tailJoint.Transform),
                     localRotation: joint.DefaultLocalRotation,
-                    boneAxis: math.normalize(localChildPosition),
+                    boneAxis: math.normalizesafe(localChildPosition),
                     length: math.length(localChildPosition));
             }
         }

--- a/Packages/UniGLTF/Runtime/SpringBoneJobs/SpringBoneCollision.cs
+++ b/Packages/UniGLTF/Runtime/SpringBoneJobs/SpringBoneCollision.cs
@@ -47,10 +47,10 @@ namespace UniGLTF.SpringBoneJobs
             if (math.lengthsq(nextTail - worldPosition) <= (r * r))
             {
                 // ヒット。Colliderの半径方向に押し出す
-                var normal = math.normalize(nextTail - worldPosition);
+                var normal = math.normalizesafe(nextTail - worldPosition);
                 var posFromCollider = worldPosition + normal * r;
                 // 長さをboneLengthに強制
-                newNextTail = headTransform.position + math.normalize(posFromCollider - headTransform.position) * logic.length;
+                newNextTail = headTransform.position + math.normalizesafe(posFromCollider - headTransform.position) * logic.length;
                 return true;
             }
             else
@@ -76,7 +76,7 @@ namespace UniGLTF.SpringBoneJobs
                 // head側半球の球判定
                 return TryResolveSphereCollision(joint, collider, worldPosition, headTransform, maxColliderScale, logic, nextTail, out newNextTail);
             }
-            var P = math.normalize(direction);
+            var P = math.normalizesafe(direction);
             var Q = headTransform.position - worldPosition;
             var dot = math.dot(P, Q);
             if (dot <= 0)
@@ -110,7 +110,7 @@ namespace UniGLTF.SpringBoneJobs
             in float3 nextTail, out float3 newNextTail)
         {
             var transformedOffset = MathHelper.MultiplyPoint(colliderTransform.localToWorldMatrix, collider.offset);
-            var transformedNormal = math.normalize(MathHelper.MultiplyVector(colliderTransform.localToWorldMatrix, collider.tailOrNormal));
+            var transformedNormal = math.normalizesafe(MathHelper.MultiplyVector(colliderTransform.localToWorldMatrix, collider.tailOrNormal));
             var delta = nextTail - transformedOffset;
 
             // ジョイントとコライダーの距離。負の値は衝突していることを示す
@@ -145,7 +145,7 @@ namespace UniGLTF.SpringBoneJobs
             // ジョイントとコライダーの距離の方向。衝突している場合、この方向にジョイントを押し出す
             if (distance < 0)
             {
-                var direction = -1 * math.normalize(delta);
+                var direction = -1 * math.normalizesafe(delta);
                 newNextTail = nextTail - direction * distance;
                 return true;
             }
@@ -192,7 +192,7 @@ namespace UniGLTF.SpringBoneJobs
             // ジョイントとコライダーの距離の方向。衝突している場合、この方向にジョイントを押し出す
             if (distance < 0)
             {
-                var direction = -1 * math.normalize(delta);
+                var direction = -1 * math.normalizesafe(delta);
                 newNextTail = nextTail - direction * distance;
                 return true;
             }

--- a/Packages/UniGLTF/Runtime/SpringBoneJobs/UpdateFastSpringBoneJob.cs
+++ b/Packages/UniGLTF/Runtime/SpringBoneJobs/UpdateFastSpringBoneJob.cs
@@ -92,7 +92,7 @@ namespace UniGLTF.SpringBoneJobs
                                + external * scalingFactor; // 外力による移動量
 
                 // 長さをboneLengthに強制
-                nextTail = headTransform.position + math.normalize(nextTail - headTransform.position) * logic.length;
+                nextTail = headTransform.position + math.normalizesafe(nextTail - headTransform.position) * logic.length;
 
                 nextTail = Anglelimit.Apply(logic, joint, parentRotation, head: headTransform.position, nextTail: nextTail);
 

--- a/Packages/UniGLTF/Runtime/Utils/MathHelper.cs
+++ b/Packages/UniGLTF/Runtime/Utils/MathHelper.cs
@@ -32,8 +32,8 @@ namespace UniGLTF.Runtime.Utils
                 return quaternion.identity;
             }
 
-            float3 from = math.normalize(fromVector);
-            float3 to = math.normalize(toVector);
+            float3 from = math.normalizesafe(fromVector);
+            float3 to = math.normalizesafe(toVector);
 
             var dot = math.dot(from, to);
             switch(dot)
@@ -47,13 +47,13 @@ namespace UniGLTF.Runtime.Utils
                     {
                         axis = math.cross(from, new float3(0, 1, 0));
                     }
-                    return quaternion.AxisAngle(math.normalize(axis), math.PI);
+                    return quaternion.AxisAngle(math.normalizesafe(axis), math.PI);
                 }
                 default:
                 {
                     var angle = math.acos(dot);
                     var axis = math.cross(from, to);
-                    return quaternion.AxisAngle(math.normalize(axis), angle);
+                    return quaternion.AxisAngle(math.normalizesafe(axis), angle);
                 }
             }
         }


### PR DESCRIPTION
math.normalizeを一律でmath.normalizesafeにリプレイスします
ごく局所的な状況で、特に[MathHelper.cs](https://github.com/vrm-c/UniVRM/compare/master...notargs:UniVRM:replace_math_normalize?expand=1#diff-bd1410c4d38da148bafa0c5c3177b350e1d6b05e9bd88a54c8390a37bc29333c) .FromToRotationに起因して挙動がおかしくなる現象が見られたため、安全に倒しておきたい