### PR TITLE
Unity 6000.5 の破壊的変更で生じたエラーへの対応。InstanceID to EntityId

### DIFF
--- a/Assets/VRM10_Samples/ClothSample/ClothWarp/Editor/ClothWarpRootEditor.cs
+++ b/Assets/VRM10_Samples/ClothSample/ClothWarp/Editor/ClothWarpRootEditor.cs
@@ -154,13 +154,18 @@ namespace UniVRM10.ClothWarp.Components
                 p = m_target.GetParticleFromTransform(p.Transform);
                 var t = p.Transform;
                 Handles.color = Color.green;
-                Handles.SphereHandleCap(GetControlId(t), t.position, t.rotation, p.Settings.Radius * 2, EventType.Repaint);
+                Handles.SphereHandleCap(t.GetControlId(), t.position, t.rotation, p.Settings.Radius * 2, EventType.Repaint);
             }
         }
+    }
+
+    static class ClothWarpRootEditorExtensions
+    {
+        internal static int GetControlId(this Component component) 
 #if UNITY_6000_5_OR_NEWER
-        static int GetControlId(Component component) => component.GetEntityId().GetHashCode();
+            => component.GetEntityId().GetHashCode();
 #else
-        static int GetControlId(Component component) => component.GetInstanceID();
+            => component.GetInstanceID();
 #endif
     }
 }

--- a/Assets/VRM10_Samples/ClothSample/ClothWarp/Editor/ClothWarpRootEditor.cs
+++ b/Assets/VRM10_Samples/ClothSample/ClothWarp/Editor/ClothWarpRootEditor.cs
@@ -154,8 +154,13 @@ namespace UniVRM10.ClothWarp.Components
                 p = m_target.GetParticleFromTransform(p.Transform);
                 var t = p.Transform;
                 Handles.color = Color.green;
-                Handles.SphereHandleCap(t.GetInstanceID(), t.position, t.rotation, p.Settings.Radius * 2, EventType.Repaint);
+                Handles.SphereHandleCap(GetControlId(t), t.position, t.rotation, p.Settings.Radius * 2, EventType.Repaint);
             }
         }
+#if UNITY_6000_5_OR_NEWER
+        static int GetControlId(Component component) => EntityId.ToULong(component.GetEntityId()).GetHashCode();
+#else
+        static int GetControlId(Component component) => component.GetInstanceID();
+#endif
     }
 }

--- a/Assets/VRM10_Samples/ClothSample/ClothWarp/Editor/ClothWarpRootEditor.cs
+++ b/Assets/VRM10_Samples/ClothSample/ClothWarp/Editor/ClothWarpRootEditor.cs
@@ -158,7 +158,7 @@ namespace UniVRM10.ClothWarp.Components
             }
         }
 #if UNITY_6000_5_OR_NEWER
-        static int GetControlId(Component component) => EntityId.ToULong(component.GetEntityId()).GetHashCode();
+        static int GetControlId(Component component) => component.GetEntityId().GetHashCode();
 #else
         static int GetControlId(Component component) => component.GetInstanceID();
 #endif

--- a/Packages/UniGLTF/Editor/UniHumanoid/MuscleInspectorEditor.cs
+++ b/Packages/UniGLTF/Editor/UniHumanoid/MuscleInspectorEditor.cs
@@ -4,6 +4,11 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_5_OR_NEWER
+using TreeView = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace UniHumanoid
 {
@@ -183,7 +188,7 @@ namespace UniHumanoid
         }
 
         // inside class BoneTreeView : TreeView<int>
-        protected override void RowGUI(UnityEditor.IMGUI.Controls.TreeView.RowGUIArgs args)
+        protected override void RowGUI(RowGUIArgs args)
         {
             for (int i = 0; i < args.GetNumVisibleColumns(); ++i)
             {
@@ -191,7 +196,7 @@ namespace UniHumanoid
             }
         }
 
-        void CellGUI(Rect cellRect, int index, ref UnityEditor.IMGUI.Controls.TreeView.RowGUIArgs args)
+        void CellGUI(Rect cellRect, int index, ref RowGUIArgs args)
         {
             CenterRectUsingSingleLineHeight(ref cellRect);
 

--- a/Packages/VRM10/Editor/Components/SpringBone/SelectedGUI.cs
+++ b/Packages/VRM10/Editor/Components/SpringBone/SelectedGUI.cs
@@ -81,10 +81,24 @@ namespace UniVRM10
 
                 if (isFocused)
                 {
+                    bool refresh = false;
+#if UNITY_6000_5_OR_NEWER
+                    var id = element.objectReferenceValue.GetEntityId();
+                    if (id != VRM10SpringBoneCollider.SelectedEntityId)
+                    {
+                        VRM10SpringBoneCollider.SelectedEntityId = id;
+                        refresh = true;
+                    }
+#else
                     var id = element.objectReferenceValue.GetInstanceID();
                     if (id != VRM10SpringBoneCollider.SelectedGuid)
                     {
                         VRM10SpringBoneCollider.SelectedGuid = id;
+                        refresh = true;
+                    }
+#endif
+                    if (refresh)
+                    {
                         SceneView.RepaintAll();
                         EditorUtility.SetDirty(element.objectReferenceValue);
                     }

--- a/Packages/VRM10/Editor/Components/SpringBone/SpringBoneTreeView.cs
+++ b/Packages/VRM10/Editor/Components/SpringBone/SpringBoneTreeView.cs
@@ -1,7 +1,11 @@
 using System.Collections.Generic;
 using UnityEditor;
-using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_5_OR_NEWER
+using TreeView = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace UniVRM10
 {
@@ -254,20 +258,20 @@ namespace UniVRM10
                 {
                     case VRM10SpringBoneColliderTypes.Sphere:
                         // Handles.color = Color.magenta;
-                        Handles.SphereHandleCap(collider.GetInstanceID(), collider.Offset, Quaternion.identity, collider.Radius * 2, Event.current.type);
+                        Handles.SphereHandleCap(GetControlId(collider), collider.Offset, Quaternion.identity, collider.Radius * 2, Event.current.type);
                         break;
 
                     case VRM10SpringBoneColliderTypes.Capsule:
                         // Handles.color = Color.cyan;
-                        Handles.SphereHandleCap(collider.GetInstanceID(), collider.Offset, Quaternion.identity, collider.Radius * 2, Event.current.type);
-                        Handles.SphereHandleCap(collider.GetInstanceID(), collider.Tail, Quaternion.identity, collider.Radius * 2, Event.current.type);
+                        Handles.SphereHandleCap(GetControlId(collider), collider.Offset, Quaternion.identity, collider.Radius * 2, Event.current.type);
+                        Handles.SphereHandleCap(GetControlId(collider), collider.Tail, Quaternion.identity, collider.Radius * 2, Event.current.type);
                         Handles.DrawLine(collider.Offset, collider.Tail);
                         break;
                 }
                 Handles.matrix = Matrix4x4.identity;
             }
 
-            var isHover = HandleUtility.nearestControl == collider.GetInstanceID();
+            var isHover = HandleUtility.nearestControl == GetControlId(collider);
             return (IsLeftDown() && isHover, isHover);
         }
 
@@ -280,7 +284,7 @@ namespace UniVRM10
                 {
                     // 先頭
                     Handles.color = color;
-                    Handles.CubeHandleCap(joint.GetInstanceID(), joint.transform.position, joint.transform.rotation,
+                    Handles.CubeHandleCap(GetControlId(joint), joint.transform.position, joint.transform.rotation,
                         // head の radius
                         joint.m_jointRadius, Event.current.type);
                 }
@@ -291,14 +295,20 @@ namespace UniVRM10
                     Handles.DrawLine(joint.transform.position, head.transform.position);
                     // joint
                     Handles.color = color;
-                    Handles.SphereHandleCap(joint.GetInstanceID(), joint.transform.position, joint.transform.rotation,
+                    Handles.SphereHandleCap(GetControlId(joint), joint.transform.position, joint.transform.rotation,
                         // head の radius
                         head.m_jointRadius * 2, Event.current.type);
                 }
             }
 
-            var isHover = HandleUtility.nearestControl == joint.GetInstanceID();
+            var isHover = HandleUtility.nearestControl == GetControlId(joint);
             return (IsLeftDown() && isHover, isHover);
         }
+
+#if UNITY_6000_5_OR_NEWER
+        static int GetControlId(Component component) => EntityId.ToULong(component.GetEntityId()).GetHashCode();
+#else
+        static int GetControlId(Component component) => component.GetInstanceID();
+#endif
     }
 }

--- a/Packages/VRM10/Editor/Components/SpringBone/SpringBoneTreeView.cs
+++ b/Packages/VRM10/Editor/Components/SpringBone/SpringBoneTreeView.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 using TreeView = UnityEditor.IMGUI.Controls.TreeView<int>;
 using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
 using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#else
+using UnityEditor.IMGUI.Controls;
 #endif
 
 namespace UniVRM10

--- a/Packages/VRM10/Editor/Components/SpringBone/SpringBoneTreeView.cs
+++ b/Packages/VRM10/Editor/Components/SpringBone/SpringBoneTreeView.cs
@@ -308,7 +308,7 @@ namespace UniVRM10
         }
 
 #if UNITY_6000_5_OR_NEWER
-        static int GetControlId(Component component) => EntityId.ToULong(component.GetEntityId()).GetHashCode();
+        static int GetControlId(Component component) => component.GetEntityId().GetHashCode();
 #else
         static int GetControlId(Component component) => component.GetInstanceID();
 #endif

--- a/Packages/VRM10/Editor/Components/SpringBone/SpringBoneTreeView.cs
+++ b/Packages/VRM10/Editor/Components/SpringBone/SpringBoneTreeView.cs
@@ -260,20 +260,20 @@ namespace UniVRM10
                 {
                     case VRM10SpringBoneColliderTypes.Sphere:
                         // Handles.color = Color.magenta;
-                        Handles.SphereHandleCap(GetControlId(collider), collider.Offset, Quaternion.identity, collider.Radius * 2, Event.current.type);
+                        Handles.SphereHandleCap(collider.GetControlId(), collider.Offset, Quaternion.identity, collider.Radius * 2, Event.current.type);
                         break;
 
                     case VRM10SpringBoneColliderTypes.Capsule:
                         // Handles.color = Color.cyan;
-                        Handles.SphereHandleCap(GetControlId(collider), collider.Offset, Quaternion.identity, collider.Radius * 2, Event.current.type);
-                        Handles.SphereHandleCap(GetControlId(collider), collider.Tail, Quaternion.identity, collider.Radius * 2, Event.current.type);
+                        Handles.SphereHandleCap(collider.GetControlId(), collider.Offset, Quaternion.identity, collider.Radius * 2, Event.current.type);
+                        Handles.SphereHandleCap(collider.GetControlId(), collider.Tail, Quaternion.identity, collider.Radius * 2, Event.current.type);
                         Handles.DrawLine(collider.Offset, collider.Tail);
                         break;
                 }
                 Handles.matrix = Matrix4x4.identity;
             }
 
-            var isHover = HandleUtility.nearestControl == GetControlId(collider);
+            var isHover = HandleUtility.nearestControl == collider.GetControlId();
             return (IsLeftDown() && isHover, isHover);
         }
 
@@ -286,7 +286,7 @@ namespace UniVRM10
                 {
                     // 先頭
                     Handles.color = color;
-                    Handles.CubeHandleCap(GetControlId(joint), joint.transform.position, joint.transform.rotation,
+                    Handles.CubeHandleCap(joint.GetControlId(), joint.transform.position, joint.transform.rotation,
                         // head の radius
                         joint.m_jointRadius, Event.current.type);
                 }
@@ -297,20 +297,14 @@ namespace UniVRM10
                     Handles.DrawLine(joint.transform.position, head.transform.position);
                     // joint
                     Handles.color = color;
-                    Handles.SphereHandleCap(GetControlId(joint), joint.transform.position, joint.transform.rotation,
+                    Handles.SphereHandleCap(joint.GetControlId(), joint.transform.position, joint.transform.rotation,
                         // head の radius
                         head.m_jointRadius * 2, Event.current.type);
                 }
             }
 
-            var isHover = HandleUtility.nearestControl == GetControlId(joint);
+            var isHover = HandleUtility.nearestControl == joint.GetControlId();
             return (IsLeftDown() && isHover, isHover);
         }
-
-#if UNITY_6000_5_OR_NEWER
-        static int GetControlId(Component component) => component.GetEntityId().GetHashCode();
-#else
-        static int GetControlId(Component component) => component.GetInstanceID();
-#endif
     }
 }

--- a/Packages/VRM10/Editor/Vrm10EditorUtility.cs
+++ b/Packages/VRM10/Editor/Vrm10EditorUtility.cs
@@ -51,5 +51,18 @@ namespace UniVRM10
 
             EditorGUI.EndProperty();
         }
+
+        /// <summary>
+        /// Control ID を取得
+        /// </summary>
+        /// <param name="component">対象となるコンポーネント</param>
+        /// <returns>コンポーネントの Control ID</returns>
+        /// <remarks>Control ID とは、Handles.CubeHandleCap()の第一引数等で使用可能な、コンポーネント単位でユニークなint値のこと</remarks>
+        internal static int GetControlId(this Component component)
+#if UNITY_6000_5_OR_NEWER
+            => component.GetEntityId().GetHashCode();
+#else
+            => component.GetInstanceID();
+#endif
     }
 }

--- a/Packages/VRM10/Runtime/Components/Expression/MorphTargetBindingMerger/MorphTargetIdentifier.cs
+++ b/Packages/VRM10/Runtime/Components/Expression/MorphTargetBindingMerger/MorphTargetIdentifier.cs
@@ -23,19 +23,31 @@ namespace UniVRM10
         }
 
         public SkinnedMeshRenderer TargetRenderer { get; }
+#if UNITY_6000_5_OR_NEWER
+        public EntityId TargetRendererEntityId { get; }
+#else
         public int TargetRendererInstanceId { get; }
+#endif
         public int TargetBlendShapeIndex { get; }
 
         public MorphTargetIdentifier(SkinnedMeshRenderer targetRenderer, int targetBlendShapeIndex)
         {
             TargetRenderer = targetRenderer;
+#if UNITY_6000_5_OR_NEWER
+            TargetRendererEntityId = targetRenderer.GetEntityId();
+#else
             TargetRendererInstanceId = targetRenderer.GetInstanceID();
+#endif
             TargetBlendShapeIndex = targetBlendShapeIndex;
         }
 
         public bool Equals(MorphTargetIdentifier other)
         {
+#if UNITY_6000_5_OR_NEWER
+            return TargetRendererEntityId == other.TargetRendererEntityId && TargetBlendShapeIndex == other.TargetBlendShapeIndex;
+#else
             return TargetRendererInstanceId == other.TargetRendererInstanceId && TargetBlendShapeIndex == other.TargetBlendShapeIndex;
+#endif
         }
 
         public override bool Equals(object obj)
@@ -45,7 +57,11 @@ namespace UniVRM10
 
         public override int GetHashCode()
         {
+#if UNITY_6000_5_OR_NEWER
+            return HashCode.Combine(TargetRendererEntityId, TargetBlendShapeIndex);
+#else
             return HashCode.Combine(TargetRendererInstanceId, TargetBlendShapeIndex);
+#endif
         }
 
         #region IEqualityComparer
@@ -55,12 +71,20 @@ namespace UniVRM10
         {
             public bool Equals(MorphTargetIdentifier x, MorphTargetIdentifier y)
             {
+#if UNITY_6000_5_OR_NEWER
+                return x.TargetRendererEntityId == y.TargetRendererEntityId && x.TargetBlendShapeIndex == y.TargetBlendShapeIndex;
+#else
                 return x.TargetRendererInstanceId == y.TargetRendererInstanceId && x.TargetBlendShapeIndex == y.TargetBlendShapeIndex;
+#endif
             }
 
             public int GetHashCode(MorphTargetIdentifier obj)
             {
+#if UNITY_6000_5_OR_NEWER
+                return HashCode.Combine(obj.TargetRendererEntityId, obj.TargetBlendShapeIndex);
+#else
                 return HashCode.Combine(obj.TargetRendererInstanceId, obj.TargetBlendShapeIndex);
+#endif
             }
         }
         #endregion

--- a/Packages/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneCollider.cs
+++ b/Packages/VRM10/Runtime/Components/SpringBone/VRM10SpringBoneCollider.cs
@@ -30,9 +30,15 @@ namespace UniVRM10
 
         public Vector3 TailOrNormal => ColliderType == VRM10SpringBoneColliderTypes.Plane ? Normal : Tail;
 
+#if UNITY_6000_5_OR_NEWER
+        public static EntityId SelectedEntityId;
+
+        public bool IsSelected => GetEntityId() == SelectedEntityId;
+#else
         public static int SelectedGuid;
 
         public bool IsSelected => GetInstanceID() == SelectedGuid;
+#endif
 
         public void OnValidate()
         {


### PR DESCRIPTION
fix #2803 

- `UnityEngine.Object.GetInstanceID()` に代わり `.GetEntityId()` を使用
  - `int` を要求する API 向けには `EntityId.GetHashCode()` を使用
- `TreeView` 系は常に `TreeView<T>` を使用
  - 差分を減らすため、 using エイリアスを使用

## 確認した Unity Editor のバージョン

- [X] Unity 2022.3.62f2
- [X] Unity 6000.0.77f1
- [X] Unity 6000.3.18f1
- [X] Unity 6000.5.1f1

## 疑問点

3点あります
- (1) `UNITY_6000_5_OR_NEWER` で区切るべきか？
- (2) 関数ではなく extension が望ましい？
- (3) `InstanceId` とも `EntityId` とも異なる中立的な名前を採用することで、差分と `#if` を削減できる。　望ましい形や、名前の候補等があれば、議論が必要か？

### (1) `UNITY_6000_5_OR_NEWER` 以外のバージョン判別

- 実態として、 6000.5 より前のバージョンでも `TreeView` に対する警告などは出ていた
- 技術的に 6000.0 や 6000.3 を境目にできる。結果として以前のバージョンの警告の量は減少する（ゼロにはならない）
- また、より低いバージョンにすることで、将来 `#if` を削除できるタイミングが早まる
- プロジェクトとして警告 0 ポリシーの慣習は無いので、このPRではエラー対応以上のことはしていない

### (2) 関数 vs extension
- `Component` -> `EntityId` -> `int` 変換を行う同一の関数が２箇所にある。  また、extension ではなく単純な関数として実装されている
  - 比較的小さく、公開すべきタイプのものではないので、両者とも private かつコピーのままとなっている。　同一パッケージの複数箇所で使用する際には再検討すべき
  - [VRM10_Samples内](https://github.com/vrm-c/UniVRM/compare/master...matsutaka-pxv:UniVRM:fix/unity-6000-5?expand=1#diff-41c146031efb38169ce4480a825b12e900d849229ff41ca346111b1c88a38565R160-R164)
  - [VRM10内](https://github.com/vrm-c/UniVRM/compare/master...matsutaka-pxv:UniVRM:fix/unity-6000-5?expand=1#diff-0eaa31d66496071f7d4e7b381d64294753633b8340c47986147299b7732bb9beR309-R314)

### (3) `#if` がコード内に散らばっている問題
- [`MorphTargetIdentifier.TargetRendererEntityId`の定義](https://github.com/vrm-c/UniVRM/compare/master...matsutaka-pxv:UniVRM:fix/unity-6000-5?expand=1#diff-a8fcc1f13c6ef2339cc7df33e105e7ea61ae36f04fe5fa1f5a5bbee780eace7fR26-R30)
  - `EntityId` の使用を促すため明示的な名称にしたが、結果として `#if` が散らばっている。
  - これを、名称だけ `MorphTargetIdentifier.TargetRendererInstanceId` のままとするか、別の名前で統一して差分削減が可能
- `VRM10SpringBoneCollider.SelectedGuid` も同様

以上です。
