### PR TITLE
Unity 6.2 以降で ShaderUtil の一部のメンバーが Obsolete 警告を出すのに対応

### DIFF
--- a/Packages/UniGLTF/Editor/UniGLTF/Validation/NameValidator.cs
+++ b/Packages/UniGLTF/Editor/UniGLTF/Validation/NameValidator.cs
@@ -34,14 +34,14 @@ namespace UniGLTF
             foreach (var material in materials)
             {
                 var shader = material.shader;
-                int propertyCount = ShaderUtil.GetPropertyCount(shader);
+                int propertyCount = shader.GetPropertyCount();
                 for (int i = 0; i < propertyCount; i++)
                 {
-                    if (ShaderUtil.GetPropertyType(shader, i) == ShaderUtil.ShaderPropertyType.TexEnv)
+                    if (shader.GetPropertyType(i) == UnityEngine.Rendering.ShaderPropertyType.Texture)
                     {
-                        if ((material.GetTexture(ShaderUtil.GetPropertyName(shader, i)) != null))
+                        if (material.GetTexture(shader.GetPropertyName(i)) != null)
                         {
-                            var textureName = material.GetTexture(ShaderUtil.GetPropertyName(shader, i)).name;
+                            var textureName = material.GetTexture(shader.GetPropertyName(i)).name;
                             if (!textureNameList.Contains(textureName))
                                 textureNameList.Add(textureName);
                         }

--- a/Packages/VRM/Editor/BlendShape/BlendShapeClipEditorHelper.cs
+++ b/Packages/VRM/Editor/BlendShape/BlendShapeClipEditorHelper.cs
@@ -93,7 +93,7 @@ namespace VRM
                             {
                                 switch (propItem.PropertyType)
                                 {
-                                    case ShaderUtil.ShaderPropertyType.Color:
+                                    case UnityEngine.Rendering.ShaderPropertyType.Color:
                                         {
                                             property.FindPropertyRelative("BaseValue").vector4Value = propItem.DefaultValues;
 
@@ -107,7 +107,7 @@ namespace VRM
                                         }
                                         break;
 
-                                    case ShaderUtil.ShaderPropertyType.TexEnv:
+                                    case UnityEngine.Rendering.ShaderPropertyType.Texture:
                                         {
                                             property.FindPropertyRelative("BaseValue").vector4Value = propItem.DefaultValues;
 

--- a/Packages/VRM/Editor/Format/VRMMaterialValidator.cs
+++ b/Packages/VRM/Editor/Format/VRMMaterialValidator.cs
@@ -24,7 +24,7 @@ namespace VRM
             if (m.shader.name == "VRM/MToon")
             {
                 // [Unity列挙]
-                // * UnityEditor.ShaderUtil により Shader の Property を列挙する。Editor専用。
+                // * Shader の Property を列挙する。Editor専用。
                 // * あらかじめEditorで実行して property 一覧をハードコーディングしてある `Assets\VRMShaders\VRM\IO\Runtime\VRM\PreExportShaders_VRM.cs` 界隈。
                 // * 今は "VRM/MToon" のみ
                 // 

--- a/Packages/VRM/Runtime/BlendShape/MeshPreviewItem.cs
+++ b/Packages/VRM/Runtime/BlendShape/MeshPreviewItem.cs
@@ -14,7 +14,7 @@ namespace VRM
     [Serializable]
     public struct PropItem
     {
-        public ShaderUtil.ShaderPropertyType PropertyType;
+        public UnityEngine.Rendering.ShaderPropertyType PropertyType;
         public Vector4 DefaultValues;
     }
 #endif
@@ -42,14 +42,14 @@ namespace VRM
 #if UNITY_EDITOR
 
             var propNames = new List<string>();
-            for (int i = 0; i < ShaderUtil.GetPropertyCount(material.shader); ++i)
+            for (int i = 0; i < material.shader.GetPropertyCount(); ++i)
             {
-                var propType = ShaderUtil.GetPropertyType(material.shader, i);
-                var name = ShaderUtil.GetPropertyName(material.shader, i);
+                var propType = material.shader.GetPropertyType(i);
+                var name = material.shader.GetPropertyName(i);
 
                 switch (propType)
                 {
-                    case ShaderUtil.ShaderPropertyType.Color:
+                    case UnityEngine.Rendering.ShaderPropertyType.Color:
                         // 色
                         item.PropMap.Add(name, new PropItem
                         {
@@ -59,7 +59,7 @@ namespace VRM
                         propNames.Add(name);
                         break;
 
-                    case ShaderUtil.ShaderPropertyType.TexEnv:
+                    case UnityEngine.Rendering.ShaderPropertyType.Texture:
                         // テクスチャ
                         {
                             name += "_ST";

--- a/Packages/VRM/Runtime/IO/MaterialIO/MToon/ShaderProps.cs
+++ b/Packages/VRM/Runtime/IO/MaterialIO/MToon/ShaderProps.cs
@@ -33,15 +33,15 @@ namespace VRM
         public ShaderProperty[] Properties;
 
 #if UNITY_EDITOR
-        static ShaderPropertyType ConvType(ShaderUtil.ShaderPropertyType src)
+        static ShaderPropertyType ConvType(UnityEngine.Rendering.ShaderPropertyType src)
         {
             switch (src)
             {
-                case ShaderUtil.ShaderPropertyType.TexEnv: return ShaderPropertyType.TexEnv;
-                case ShaderUtil.ShaderPropertyType.Color: return ShaderPropertyType.Color;
-                case ShaderUtil.ShaderPropertyType.Float: return ShaderPropertyType.Float;
-                case ShaderUtil.ShaderPropertyType.Range: return ShaderPropertyType.Range;
-                case ShaderUtil.ShaderPropertyType.Vector: return ShaderPropertyType.Vector;
+                case UnityEngine.Rendering.ShaderPropertyType.Texture: return ShaderPropertyType.TexEnv;
+                case UnityEngine.Rendering.ShaderPropertyType.Color: return ShaderPropertyType.Color;
+                case UnityEngine.Rendering.ShaderPropertyType.Float: return ShaderPropertyType.Float;
+                case UnityEngine.Rendering.ShaderPropertyType.Range: return ShaderPropertyType.Range;
+                case UnityEngine.Rendering.ShaderPropertyType.Vector: return ShaderPropertyType.Vector;
                 default: throw new NotImplementedException();
             }
         }
@@ -49,10 +49,10 @@ namespace VRM
         public static ShaderProps FromShader(Shader shader)
         {
             var properties = new List<ShaderProperty>();
-            for (int i = 0; i < ShaderUtil.GetPropertyCount(shader); ++i)
+            for (int i = 0; i < shader.GetPropertyCount(); ++i)
             {
-                var name = ShaderUtil.GetPropertyName(shader, i);
-                var propType = ShaderUtil.GetPropertyType(shader, i);
+                var name = shader.GetPropertyName(i);
+                var propType = shader.GetPropertyType(i);
                 properties.Add(new ShaderProperty(name, ConvType(propType)));
             }
 

--- a/Packages/VRM10/Runtime/Components/Expression/Preview/PreviewMaterialUtil.cs
+++ b/Packages/VRM10/Runtime/Components/Expression/Preview/PreviewMaterialUtil.cs
@@ -16,14 +16,14 @@ namespace UniVRM10
 
             var propNames = new List<string>();
             var hasError = false;
-            for (int i = 0; i < ShaderUtil.GetPropertyCount(material.shader); ++i)
+            for (int i = 0; i < material.shader.GetPropertyCount(); ++i)
             {
-                var propType = ShaderUtil.GetPropertyType(material.shader, i);
-                var name = ShaderUtil.GetPropertyName(material.shader, i);
+                var propType = material.shader.GetPropertyType(i);
+                var name = material.shader.GetPropertyName(i);
 
                 switch (propType)
                 {
-                    case ShaderUtil.ShaderPropertyType.Color:
+                    case UnityEngine.Rendering.ShaderPropertyType.Color:
                         // 色
                         {
                             if (!PreviewMaterialItem.TryGetBindType(name, out var bindType))
@@ -50,7 +50,7 @@ namespace UniVRM10
                         }
                         break;
 
-                    case ShaderUtil.ShaderPropertyType.TexEnv:
+                    case UnityEngine.Rendering.ShaderPropertyType.Texture:
                         break;
                 }
             }

--- a/Packages/VRM10/Tests/SerializationTests.cs
+++ b/Packages/VRM10/Tests/SerializationTests.cs
@@ -75,18 +75,18 @@ namespace UniVRM10
             Assert.AreEqual(lhs.name, rhs.name);
             Assert.AreEqual(lhs.shader, rhs.shader);
             var sb = new StringBuilder();
-            for (int i = 0; i < ShaderUtil.GetPropertyCount(lhs.shader); ++i)
+            for (int i = 0; i < lhs.shader.GetPropertyCount(); ++i)
             {
-                var prop = ShaderUtil.GetPropertyName(lhs.shader, i);
+                var prop = lhs.shader.GetPropertyName(i);
                 if (s_ignoreProps.Contains(prop))
                 {
                     continue;
                 }
 
-                switch (ShaderUtil.GetPropertyType(lhs.shader, i))
+                switch (lhs.shader.GetPropertyType(i))
                 {
-                    case UnityEditor.ShaderUtil.ShaderPropertyType.Color:
-                    case UnityEditor.ShaderUtil.ShaderPropertyType.Vector:
+                    case UnityEngine.Rendering.ShaderPropertyType.Color:
+                    case UnityEngine.Rendering.ShaderPropertyType.Vector:
                         {
                             var l = lhs.GetVector(prop);
                             var r = rhs.GetVector(prop);
@@ -97,8 +97,8 @@ namespace UniVRM10
                         }
                         break;
 
-                    case UnityEditor.ShaderUtil.ShaderPropertyType.Float:
-                    case UnityEditor.ShaderUtil.ShaderPropertyType.Range:
+                    case UnityEngine.Rendering.ShaderPropertyType.Float:
+                    case UnityEngine.Rendering.ShaderPropertyType.Range:
                         {
                             var l = lhs.GetFloat(prop);
                             var r = rhs.GetFloat(prop);
@@ -109,7 +109,7 @@ namespace UniVRM10
                         }
                         break;
 
-                    case UnityEditor.ShaderUtil.ShaderPropertyType.TexEnv:
+                    case UnityEngine.Rendering.ShaderPropertyType.Texture:
                         {
                             var l = lhs.GetTextureOffset(prop);
                             var r = rhs.GetTextureOffset(prop);


### PR DESCRIPTION
Unity 6.2 以降で、UniVRMが利用している ShaderUtil の次のメンバーが Obsolete となり警告が出るようになりました。

- [GetPropertyCount](https://docs.unity3d.com/6000.2/Documentation/ScriptReference/ShaderUtil.GetPropertyCount.html)
- [GetPropertyType](https://docs.unity3d.com/6000.2/Documentation/ScriptReference/ShaderUtil.GetPropertyType.html)
- [GetPropertyName](https://docs.unity3d.com/6000.2/Documentation/ScriptReference/ShaderUtil.GetPropertyName.html)
- [ShaderPropertyType](https://docs.unity3d.com/6000.2/Documentation/ScriptReference/ShaderUtil.ShaderPropertyType.html)

これらは `Shader` インスタンスのメソッドと `UnityEngine.Rendering.ShaderPropertyType` に置き換わりました。これらの置き換え先として警告メッセージで指定されている項目は全て UniVRM の最小サポートバージョンである Unity 2022.3 LTS にも存在するため、そのまま置き換えました。

発生していた警告は次のようなものでした。

```
Packages\VRM10\Runtime\Components\Expression\Preview\PreviewMaterialUtil.cs(19,33): warning CS0618: 'ShaderUtil.GetPropertyCount(Shader)' is obsolete: 'Use Shader.GetPropertyCount instead.'
Packages\VRM10\Runtime\Components\Expression\Preview\PreviewMaterialUtil.cs(21,32): warning CS0618: 'ShaderUtil.GetPropertyType(Shader, int)' is obsolete: 'Use Shader.GetPropertyType instead.'
Packages\VRM10\Runtime\Components\Expression\Preview\PreviewMaterialUtil.cs(22,28): warning CS0618: 'ShaderUtil.GetPropertyName(Shader, int)' is obsolete: 'Use Shader.GetPropertyName instead.'
```