### PR TITLE
[EditorExport][0x] VRM-0.X の export dialog から RuntimeTextureSerializer を選択できる

### DIFF
--- a/Packages/VRM/Editor/Format/VRMEditorExporter.cs
+++ b/Packages/VRM/Editor/Format/VRMEditorExporter.cs
@@ -239,7 +239,9 @@ namespace VRM
             using (var exporter = new VRMExporter(data, gltfExportSettings,
                 animationExporter: settings.KeepAnimation ? new EditorAnimationExporter() : null,
                 materialExporter: materialExporter,
-                textureSerializer: settings.KeepTextureAssetConfiguration ? new RuntimeTextureSerializer() : new EditorTextureSerializer()))
+                textureSerializer: settings.UseRuntimeTextureSerializer 
+                    ? new RuntimeTextureSerializer() 
+                    : new EditorTextureSerializer()))
             {
                 exporter.Prepare(target);
                 exporter.Export();

--- a/Packages/VRM/Editor/Format/VRMEditorExporter.cs
+++ b/Packages/VRM/Editor/Format/VRMEditorExporter.cs
@@ -239,7 +239,7 @@ namespace VRM
             using (var exporter = new VRMExporter(data, gltfExportSettings,
                 animationExporter: settings.KeepAnimation ? new EditorAnimationExporter() : null,
                 materialExporter: materialExporter,
-                textureSerializer: new EditorTextureSerializer()))
+                textureSerializer: settings.KeepTextureAssetConfiguration ? new RuntimeTextureSerializer() : new EditorTextureSerializer()))
             {
                 exporter.Prepare(target);
                 exporter.Export();

--- a/Packages/VRM/Editor/Format/VRMExportOptions.cs
+++ b/Packages/VRM/Editor/Format/VRMExportOptions.cs
@@ -53,7 +53,11 @@ namespace VRM
         KEEP_VERTEX_COLOR,
 
         [LangMsg(Languages.ja, "glTF Animationをエクスポートする。")]
-        [LangMsg(Languages.en, "export glTF animation.")]
+        [LangMsg(Languages.en, "Export glTF animation.")]
         EXPORT_GLTF_ANIMATION,
+
+        [LangMsg(Languages.ja, "テクスチャーアセット設定を変更しない。")]
+        [LangMsg(Languages.en, "Keep texture asset configuration.")]
+        KEEP_TEXTURE_ASSET_CONFIGURATION,
     }
 }

--- a/Packages/VRM/Editor/Format/VRMExportOptions.cs
+++ b/Packages/VRM/Editor/Format/VRMExportOptions.cs
@@ -56,8 +56,8 @@ namespace VRM
         [LangMsg(Languages.en, "Export glTF animation.")]
         EXPORT_GLTF_ANIMATION,
 
-        [LangMsg(Languages.ja, "テクスチャーアセット設定を変更しない。")]
-        [LangMsg(Languages.en, "Keep texture asset configuration.")]
-        KEEP_TEXTURE_ASSET_CONFIGURATION,
+        [LangMsg(Languages.ja, "RuntimeTextureSerializerを使う。")]
+        [LangMsg(Languages.en, "Use RuntimeTextureSerializer.")]
+        USE_RUNTIME_TEXTURE_SERIALIZER,
     }
 }

--- a/Packages/VRM/Editor/Format/VRMExportSettings.cs
+++ b/Packages/VRM/Editor/Format/VRMExportSettings.cs
@@ -67,6 +67,12 @@ namespace VRM
         [Tooltip("Keep animation")]
         public bool KeepAnimation = false;
 
+        /// <summary>
+        /// Export時にTexture設定を変更しない
+        /// </summary>
+        [Tooltip("Keep texture configuration")]
+        public bool KeepTextureAssetConfiguration = false;
+
         public GltfExportSettings GltfExportSettings => new GltfExportSettings
         {
             UseSparseAccessorForMorphTarget = UseSparseAccessor,

--- a/Packages/VRM/Editor/Format/VRMExportSettings.cs
+++ b/Packages/VRM/Editor/Format/VRMExportSettings.cs
@@ -68,10 +68,10 @@ namespace VRM
         public bool KeepAnimation = false;
 
         /// <summary>
-        /// Export時にTexture設定を変更しない
+        /// Export時にRuntimeTextureSerializerを使う
         /// </summary>
-        [Tooltip("Keep texture configuration")]
-        public bool KeepTextureAssetConfiguration = false;
+        [Tooltip("Use RuntimeTextureSerializer")]
+        public bool UseRuntimeTextureSerializer = false;
 
         public GltfExportSettings GltfExportSettings => new GltfExportSettings
         {

--- a/Packages/VRM/Editor/Format/VRMExportSettingsEditor.cs
+++ b/Packages/VRM/Editor/Format/VRMExportSettingsEditor.cs
@@ -56,7 +56,7 @@ namespace VRM
             m_checkbox_list.Add(new CheckBoxProp(serializedObject.FindProperty(nameof(VRMExportSettings.DivideVertexBuffer)), VRMExportOptions.DIVIDE_VERTEX_BUFFER));
             m_checkbox_list.Add(new CheckBoxProp(serializedObject.FindProperty(nameof(VRMExportSettings.KeepVertexColor)), VRMExportOptions.KEEP_VERTEX_COLOR));
             m_checkbox_list.Add(new CheckBoxProp(serializedObject.FindProperty(nameof(VRMExportSettings.KeepAnimation)), VRMExportOptions.EXPORT_GLTF_ANIMATION));
-            m_checkbox_list.Add(new CheckBoxProp(serializedObject.FindProperty(nameof(VRMExportSettings.KeepTextureAssetConfiguration)), VRMExportOptions.KEEP_TEXTURE_ASSET_CONFIGURATION));
+            m_checkbox_list.Add(new CheckBoxProp(serializedObject.FindProperty(nameof(VRMExportSettings.UseRuntimeTextureSerializer)), VRMExportOptions.USE_RUNTIME_TEXTURE_SERIALIZER));
         }
 
 

--- a/Packages/VRM/Editor/Format/VRMExportSettingsEditor.cs
+++ b/Packages/VRM/Editor/Format/VRMExportSettingsEditor.cs
@@ -56,6 +56,7 @@ namespace VRM
             m_checkbox_list.Add(new CheckBoxProp(serializedObject.FindProperty(nameof(VRMExportSettings.DivideVertexBuffer)), VRMExportOptions.DIVIDE_VERTEX_BUFFER));
             m_checkbox_list.Add(new CheckBoxProp(serializedObject.FindProperty(nameof(VRMExportSettings.KeepVertexColor)), VRMExportOptions.KEEP_VERTEX_COLOR));
             m_checkbox_list.Add(new CheckBoxProp(serializedObject.FindProperty(nameof(VRMExportSettings.KeepAnimation)), VRMExportOptions.EXPORT_GLTF_ANIMATION));
+            m_checkbox_list.Add(new CheckBoxProp(serializedObject.FindProperty(nameof(VRMExportSettings.KeepTextureAssetConfiguration)), VRMExportOptions.KEEP_TEXTURE_ASSET_CONFIGURATION));
         }
 
 


### PR DESCRIPTION
fixed #2762

<img width="715" height="1239" alt="add_keep_texture_asset_configuration" src="https://github.com/user-attachments/assets/65aa1ee7-5d83-446d-af64-fb12efcdd4dd" />

👇 文言修正

<img width="364" height="127" alt="use_runtimetextureserializer" src="https://github.com/user-attachments/assets/5145d3c7-392c-4287-950d-74e9d373f12f" />
