### PR TITLE
NativeArray変換を ゼロコピー化して最適化

### DIFF
--- a/Packages/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
+++ b/Packages/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
@@ -69,23 +69,12 @@ namespace UniGLTF
 
         public NativeArray<T> CreateNativeArray<T>(ArraySegment<T> data) where T : struct
         {
-            var array = CreateNativeArray<T>(data.Count);
-#if UNITY_2022_2_OR_NEWER
-            var toSpan = array.AsSpan();
-            var fromSpan = data.AsSpan();
-            fromSpan.CopyTo(toSpan);
-#else
-            for (int i = 0; i < data.Count; i++)
-                array[i] = data.Array[data.Offset + i];
-#endif
-            return array;
+            return CreateNativeArray((ReadOnlyMemory<T>)data);
         }
 
         public NativeArray<T> CreateNativeArray<T>(T[] data) where T : struct
         {
-            var array = CreateNativeArray<T>(data.Length);
-            array.CopyFrom(data);
-            return array;
+            return CreateNativeArray((ReadOnlyMemory<T>)data);
         }
 
         /// <summary>


### PR DESCRIPTION
`T[]`、`ArraySegment` など マネージドメモリを NativeArray に変換するコードについて、コピーするのではなく `Memory<>.Pin` を経由したゼロコピーの実装を使うようにする、という最適化です。

( #2824 のやり残し

